### PR TITLE
copy crate at build time

### DIFF
--- a/rclrs_examples/CMakeLists.txt
+++ b/rclrs_examples/CMakeLists.txt
@@ -39,14 +39,12 @@ endforeach()
 
 include(ExternalProject)
 
-add_custom_target(copy_crate ALL
-    COMMENT "Copying crate from ${CMAKE_SOURCE_DIR}/src to ${CMAKE_BINARY_DIR}/src"
-)
+configure_file(${CMAKE_SOURCE_DIR}/src/rclrs_publisher.rs ${CMAKE_BINARY_DIR}/src/rclrs_publisher.rs COPYONLY)
+configure_file(${CMAKE_SOURCE_DIR}/src/rclrs_subscriber.rs ${CMAKE_BINARY_DIR}/src/rclrs_subscriber.rs COPYONLY)
 
-add_custom_command(
-    TARGET copy_crate
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_SOURCE_DIR}/src/rclrs_publisher.rs" "${CMAKE_BINARY_DIR}/src/rclrs_publisher.rs"
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_SOURCE_DIR}/src/rclrs_subscriber.rs" "${CMAKE_BINARY_DIR}/src/rclrs_subscriber.rs"
+add_custom_target(
+    copy_crate
+    DEPENDS ${CMAKE_BINARY_DIR}/src/rclrs_publisher.rs ${CMAKE_BINARY_DIR}/src/rclrs_subscriber.rs
 )
 
 file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/.cargo")
@@ -77,5 +75,4 @@ install(FILES
     PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
     DESTINATION lib/${PROJECT_NAME}
 )
-
 ament_package()

--- a/rclrs_examples/CMakeLists.txt
+++ b/rclrs_examples/CMakeLists.txt
@@ -42,11 +42,6 @@ include(ExternalProject)
 configure_file(${CMAKE_SOURCE_DIR}/src/rclrs_publisher.rs ${CMAKE_BINARY_DIR}/src/rclrs_publisher.rs COPYONLY)
 configure_file(${CMAKE_SOURCE_DIR}/src/rclrs_subscriber.rs ${CMAKE_BINARY_DIR}/src/rclrs_subscriber.rs COPYONLY)
 
-add_custom_target(
-    copy_crate
-    DEPENDS ${CMAKE_BINARY_DIR}/src/rclrs_publisher.rs ${CMAKE_BINARY_DIR}/src/rclrs_subscriber.rs
-)
-
 file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/.cargo")
 file(WRITE "${CMAKE_BINARY_DIR}/.cargo/config"
 "\
@@ -61,16 +56,22 @@ ${_native_libraries_dirs}
 file(COPY "${CMAKE_SOURCE_DIR}/Cargo.toml" DESTINATION "${CMAKE_BINARY_DIR}/")
 file(APPEND "${CMAKE_BINARY_DIR}/Cargo.toml" "${_crates_dependencies}")
 
-add_custom_target(cargo_build ALL
-    COMMENT "build crate")
-    
 add_custom_command(
     OUTPUT
         ${CMAKE_BINARY_DIR}/ament_cargo/${PROJECT_NAME}/target/release/rclrs_publisher
         ${CMAKE_BINARY_DIR}/ament_cargo/${PROJECT_NAME}/target/release/rclrs_subscriber
-    TARGET cargo_build
     COMMAND cargo build --release --manifest-path "${CMAKE_BINARY_DIR}/Cargo.toml"
-    DEPENDS copy_crate)
+    DEPENDS
+        ${CMAKE_BINARY_DIR}/src/rclrs_publisher.rs
+        ${CMAKE_BINARY_DIR}/src/rclrs_subscriber.rs
+)
+
+add_custom_target(
+    build_crate ALL
+    DEPENDS
+        ${CMAKE_BINARY_DIR}/ament_cargo/${PROJECT_NAME}/target/release/rclrs_publisher
+        ${CMAKE_BINARY_DIR}/ament_cargo/${PROJECT_NAME}/target/release/rclrs_subscriber
+)
 
 install(FILES
     ${CMAKE_BINARY_DIR}/ament_cargo/${PROJECT_NAME}/target/release/rclrs_publisher

--- a/rclrs_examples/CMakeLists.txt
+++ b/rclrs_examples/CMakeLists.txt
@@ -65,6 +65,9 @@ add_custom_target(cargo_build ALL
     COMMENT "build crate")
     
 add_custom_command(
+    OUTPUT
+        ${CMAKE_BINARY_DIR}/ament_cargo/${PROJECT_NAME}/target/release/rclrs_publisher
+        ${CMAKE_BINARY_DIR}/ament_cargo/${PROJECT_NAME}/target/release/rclrs_subscriber
     TARGET cargo_build
     COMMAND cargo build --release --manifest-path "${CMAKE_BINARY_DIR}/Cargo.toml"
     DEPENDS copy_crate)

--- a/rclrs_examples/CMakeLists.txt
+++ b/rclrs_examples/CMakeLists.txt
@@ -39,8 +39,15 @@ endforeach()
 
 include(ExternalProject)
 
-file(REMOVE_RECURSE "${CMAKE_BINARY_DIR}/src")
-file(COPY "${CMAKE_SOURCE_DIR}/src" DESTINATION "${CMAKE_BINARY_DIR}")
+add_custom_target(copy_crate ALL
+    COMMENT "Copying crate from ${CMAKE_SOURCE_DIR}/src to ${CMAKE_BINARY_DIR}/src"
+)
+
+add_custom_command(
+    TARGET copy_crate
+    COMMAND ${CMAKE_COMMAND} -E remove_directory "${CMAKE_BINARY_DIR}/src"
+    COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/src" "${CMAKE_BINARY_DIR}/src"
+)
 
 file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/.cargo")
 file(WRITE "${CMAKE_BINARY_DIR}/.cargo/config"
@@ -56,13 +63,13 @@ ${_native_libraries_dirs}
 file(COPY "${CMAKE_SOURCE_DIR}/Cargo.toml" DESTINATION "${CMAKE_BINARY_DIR}/")
 file(APPEND "${CMAKE_BINARY_DIR}/Cargo.toml" "${_crates_dependencies}")
 
-ExternalProject_Add(
-    rclrs_examples
-    DOWNLOAD_COMMAND ""
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND cargo build --release --manifest-path "${CMAKE_BINARY_DIR}/Cargo.toml"
-    INSTALL_COMMAND ""
-    LOG_BUILD ON)
+add_custom_target(cargo_build ALL
+    COMMENT "build crate")
+    
+add_custom_command(
+    TARGET cargo_build
+    COMMAND cargo build --release --manifest-path "${CMAKE_BINARY_DIR}/Cargo.toml"
+    DEPENDS copy_crate)
 
 install(FILES
     ${CMAKE_BINARY_DIR}/ament_cargo/${PROJECT_NAME}/target/release/rclrs_publisher
@@ -70,4 +77,5 @@ install(FILES
     PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
     DESTINATION lib/${PROJECT_NAME}
 )
+
 ament_package()

--- a/rclrs_examples/CMakeLists.txt
+++ b/rclrs_examples/CMakeLists.txt
@@ -45,8 +45,8 @@ add_custom_target(copy_crate ALL
 
 add_custom_command(
     TARGET copy_crate
-    COMMAND ${CMAKE_COMMAND} -E remove_directory "${CMAKE_BINARY_DIR}/src"
-    COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/src" "${CMAKE_BINARY_DIR}/src"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_SOURCE_DIR}/src/rclrs_publisher.rs" "${CMAKE_BINARY_DIR}/src/rclrs_publisher.rs"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_SOURCE_DIR}/src/rclrs_subscriber.rs" "${CMAKE_BINARY_DIR}/src/rclrs_subscriber.rs"
 )
 
 file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/.cargo")


### PR DESCRIPTION
Addressing [https://github.com/esteve/ros2_rust/pull/3#issuecomment-468972443](https://github.com/esteve/ros2_rust/pull/3#issuecomment-468972443).

rclrs_examples crate source files are now copied at build time with CMake.