### PR TITLE
Fix instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ Sounds great, how can I try this out?
 The following steps show how to build the examples:
 
 ```
-mkdir -p ros2_rust_ws/src
-cd ros2_rust_ws
-git clone https://github.com/esteve/ros2_rust.git src/ros2_rust
-vcs import src < ./src/ros2_rust/ros2_rust.repos
+mkdir -p ~/ros2_rust_ws/src
+cd ~/ros2_rust_ws
+wget https://raw.githubusercontent.com/ros2-rust/ros2-rust/ros2_rust.repos
+vcs import src < ros2_rust.repos
 source /opt/ros/crystal/setup.sh
 colcon build
 ```

--- a/ros2_rust.repos
+++ b/ros2_rust.repos
@@ -11,3 +11,7 @@ repositories:
     type: git
     url: https://github.com/ros2/rosidl_defaults.git
     version: crystal
+  ros2_rust/ros2_rust:
+    type: git
+    url: https://github.com/ros2-rust/ros2_rust.git
+    version: master


### PR DESCRIPTION
@lelongg I just realized after merging that the build instructions were slightly different than for ROS2 master, this makes it keep them in the same style.