### PR TITLE
More fixes for instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ Sounds great, how can I try this out?
 The following steps show how to build the examples:
 
 ```
-# first, install vcstools from PyPI or apt:
-# sudo apt install python3-vcstools
-# pip install vcstools
+# first, install vcstool from PyPI or apt:
+# sudo apt install python3-vcstool
+# pip install vcstool
 
 mkdir -p ~/ros2_rust_ws/src
 cd ~/ros2_rust_ws

--- a/README.md
+++ b/README.md
@@ -38,9 +38,13 @@ Sounds great, how can I try this out?
 The following steps show how to build the examples:
 
 ```
+# first, install vcstools from PyPI or apt:
+# sudo apt install python3-vcstools
+# pip install vcstools
+
 mkdir -p ~/ros2_rust_ws/src
 cd ~/ros2_rust_ws
-wget https://raw.githubusercontent.com/ros2-rust/ros2-rust/ros2_rust.repos
+wget https://raw.githubusercontent.com/ros2-rust/ros2_rust/master/ros2_rust.repos
 vcs import src < ros2_rust.repos
 source /opt/ros/crystal/setup.sh
 colcon build


### PR DESCRIPTION
- corrected link to ros2_rust.repos
- added suggestion about how to install vcstools (it is not installed by default with ROS2)