### PR TITLE
fix warnings

### DIFF
--- a/rclrs/src/node/mod.rs
+++ b/rclrs/src/node/mod.rs
@@ -38,7 +38,7 @@ impl Drop for NodeHandle {
 pub struct Node {
     handle: Rc<NodeHandle>,
     pub(crate) context: Rc<ContextHandle>,
-    pub(crate) subscriptions: Vec<Weak<SubscriptionBase>>,
+    pub(crate) subscriptions: Vec<Weak<dyn SubscriptionBase>>,
 }
 
 impl Node {
@@ -99,7 +99,7 @@ impl Node {
     {
         let subscription = Rc::new(Subscription::<T>::new(self, topic, qos, callback)?);
         self.subscriptions
-            .push(Rc::downgrade(&subscription) as Weak<SubscriptionBase>);
+            .push(Rc::downgrade(&subscription) as Weak<dyn SubscriptionBase>);
         Ok(subscription)
     }
 }

--- a/rclrs/src/node/subscription.rs
+++ b/rclrs/src/node/subscription.rs
@@ -44,10 +44,10 @@ impl Drop for SubscriptionHandle {
 
 pub trait SubscriptionBase {
     fn handle(&self) -> &SubscriptionHandle;
-    fn create_message(&self) -> Box<rclrs_common::traits::Message>;
-    fn callback_fn(&self, message: Box<rclrs_common::traits::Message>) -> ();
+    fn create_message(&self) -> Box<dyn rclrs_common::traits::Message>;
+    fn callback_fn(&self, message: Box<dyn rclrs_common::traits::Message>) -> ();
 
-    fn take(&self, message: &mut rclrs_common::traits::Message) -> RclResult<bool> {
+    fn take(&self, message: &mut dyn rclrs_common::traits::Message) -> RclResult<bool> {
         let handle = &*self.handle().get();
         let message_handle = message.get_native_message();
 
@@ -136,7 +136,7 @@ where
         ret.ok()
     }
 
-    fn callback_ext(&self, message: Box<rclrs_common::traits::Message>) {
+    fn callback_ext(&self, message: Box<dyn rclrs_common::traits::Message>) {
         let msg = message.downcast_ref::<T>().unwrap();
         (self.callback)(msg);
     }
@@ -150,11 +150,11 @@ where
         self.handle.borrow()
     }
 
-    fn create_message(&self) -> Box<rclrs_common::traits::Message> {
+    fn create_message(&self) -> Box<dyn rclrs_common::traits::Message> {
         Box::new(T::default())
     }
 
-    fn callback_fn(&self, message: Box<rclrs_common::traits::Message>) {
+    fn callback_fn(&self, message: Box<dyn rclrs_common::traits::Message>) {
         self.callback_ext(message);
     }
 }

--- a/rclrs_common/src/lib.rs
+++ b/rclrs_common/src/lib.rs
@@ -125,7 +125,7 @@ pub mod traits {
         fn read_handle(&mut self, message_handle: uintptr_t) -> ();
     }
 
-    downcast!(Message);
+    downcast!(dyn Message);
 
     pub trait MessageDefinition<T>: Message {
         fn get_type_support() -> uintptr_t;

--- a/rosidl_generator_rs/resource/msg.c.em
+++ b/rosidl_generator_rs/resource/msg.c.em
@@ -1,3 +1,4 @@
+#include "rosidl_generator_c/string_functions.h"
 #include "rosidl_generator_c/message_type_support_struct.h"
 
 @[for subfolder, msg_spec in msg_specs]@

--- a/rosidl_generator_rs/resource/msg.rs.em
+++ b/rosidl_generator_rs/resource/msg.rs.em
@@ -1,4 +1,3 @@
-use std;
 use libc::c_char;
 use libc::uintptr_t;
 use rclrs_common;
@@ -92,7 +91,8 @@ impl @(type_name) {
     }
   }
 
-  fn read_handle(&mut self, message_handle: uintptr_t) -> () {
+  #[allow(unused_unsafe)]
+  fn read_handle(&mut self, _message_handle: uintptr_t) -> () {
     unsafe {
       {
 @[for field in msg_spec.fields]@
@@ -100,10 +100,10 @@ impl @(type_name) {
 @[    else]@
 @[        if field.type.is_primitive_type()]@
 @[            if field.type.type == 'string']@
-      let ptr = @(package_name)_@(subfolder)_@(convert_camel_case_to_lower_case_underscore(type_name))_@(field.name)_read_handle(message_handle);
+      let ptr = @(package_name)_@(subfolder)_@(convert_camel_case_to_lower_case_underscore(type_name))_@(field.name)_read_handle(_message_handle);
       self.@(field.name) = CStr::from_ptr(ptr).to_string_lossy().into_owned();
 @[            else]@
-      self.@(field.name) = @(package_name)_@(subfolder)_@(convert_camel_case_to_lower_case_underscore(type_name))_@(field.name)_read_handle(message_handle);
+      self.@(field.name) = @(package_name)_@(subfolder)_@(convert_camel_case_to_lower_case_underscore(type_name))_@(field.name)_read_handle(_message_handle);
 @[            end if]@
 @[        else]@
 @[        end if]@

--- a/rosidl_generator_rs/rosidl_generator_rs/__init__.py
+++ b/rosidl_generator_rs/rosidl_generator_rs/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import defaultdict
 import os
 
 from rosidl_cmake import convert_camel_case_to_lower_case_underscore
@@ -206,7 +205,7 @@ def get_builtin_rs_type(type_):
         return 'u8'
 
     if type_ == 'char':
-        return 'char'
+        return 'u8'
 
     if type_ == 'float32':
         return 'f32'


### PR DESCRIPTION
Hey 👋 

I fixed the warnings and the install steps in the README.

I am using Ubuntu 18.04 and the colcon build was failing because can't find `stdbool.h` and another thing, until I installed both `clang` _and_ `libclang`.