### PR TITLE
Fix array type generation and field names that are keywords

### DIFF
--- a/rosidl_generator_rs/resource/msg.rs.em
+++ b/rosidl_generator_rs/resource/msg.rs.em
@@ -20,7 +20,7 @@ type_name = msg_spec.structure.namespaced_type.name
 #[derive(Default)]
 pub struct @(type_name) {
 @[for member in msg_spec.structure.members]@
-    pub @(member.name): @(get_rs_type(member.type).replace(package_name, 'crate')),
+    pub @(get_rs_name(member.name)): @(get_rs_type(member.type).replace(package_name, 'crate')),
 @[end for]@
 }
 
@@ -31,9 +31,9 @@ extern "C" {
     fn @(package_name)_@(subfolder)_@(convert_camel_case_to_lower_case_underscore(type_name))_get_native_message(
 @[for member in msg_spec.structure.members]@
 @[    if isinstance(member.type, AbstractGenericString)]@
-    @(member.name): *const c_char,
+    @(get_rs_name(member.name)): *const c_char,
 @[    elif isinstance(member.type, BasicType)]@
-    @(member.name): @(get_rs_type(member.type)),
+    @(get_rs_name(member.name)): @(get_rs_type(member.type)),
 @[    end if]@
 @[end for]@
     ) -> uintptr_t;
@@ -56,9 +56,9 @@ impl @(type_name) {
 @[for member in msg_spec.structure.members]@
 @[    if isinstance(member.type, Array)]@
 @[    elif isinstance(member.type, AbstractGenericString)]@
-    CString::new(self.@(member.name).clone()).unwrap().as_ptr(),
+    CString::new(self.@(get_rs_name(member.name)).clone()).unwrap().as_ptr(),
 @[    elif isinstance(member.type, BasicType)]@
-    self.@(member.name),
+    self.@(get_rs_name(member.name)),
 @[    end if]@
 @[end for]@
     ) };
@@ -78,9 +78,9 @@ impl @(type_name) {
 @[    if isinstance(member.type, Array)]@
 @[    elif isinstance(member.type, AbstractGenericString)]@
       let ptr = @(package_name)_@(subfolder)_@(convert_camel_case_to_lower_case_underscore(type_name))_@(member.name)_read_handle(_message_handle);
-      self.@(member.name) = CStr::from_ptr(ptr).to_string_lossy().into_owned();
+      self.@(get_rs_name(member.name)) = CStr::from_ptr(ptr).to_string_lossy().into_owned();
 @[    elif isinstance(member.type, BasicType)]@
-      self.@(member.name) = @(package_name)_@(subfolder)_@(convert_camel_case_to_lower_case_underscore(type_name))_@(member.name)_read_handle(_message_handle);
+      self.@(get_rs_name(member.name)) = @(package_name)_@(subfolder)_@(convert_camel_case_to_lower_case_underscore(type_name))_@(member.name)_read_handle(_message_handle);
 @[    elif isinstance(member.type, AbstractSequence)]@
 @[    end if]@
 @[end for]@

--- a/rosidl_generator_rs/rosidl_generator_rs/__init__.py
+++ b/rosidl_generator_rs/rosidl_generator_rs/__init__.py
@@ -90,6 +90,7 @@ def generate_rs(generator_arguments_file, typesupport_impls):
     data = {
         'get_c_type': get_c_type,
         'get_rs_type': get_rs_type,
+        'get_rs_name': get_rs_name,
         'constant_value_to_rs': constant_value_to_rs,
         'value_to_rs': value_to_rs,
         'convert_camel_case_to_lower_case_underscore':
@@ -141,6 +142,20 @@ def generate_rs(generator_arguments_file, typesupport_impls):
 
     return 0
 
+def get_rs_name(name):
+    keywords = [
+        # strict keywords
+        'as', 'break', 'const', 'continue', 'crate', 'else', 'enum', 'extern', 'false', 'fn', 'for', 'if', 'for',
+        'impl', 'in', 'let', 'loop', 'match', 'mod', 'move', 'mut', 'pub', 'ref', 'return', 'self', 'Self', 'static',
+        'struct', 'super', 'trait', 'true', 'type', 'unsafe', 'use', 'where', 'while',
+        # Edition 2018+
+        'async', 'await', 'dyn',
+        # Reserved
+        'abstract', 'become', 'box', 'do', 'final', 'macro', 'override', 'priv', 'typeof', 'unsized', 'virtual',
+        'yield', 'try'
+    ]
+    # If the field name is a reserved keyword in rust append an underscore
+    return name if not name in keywords else name + '_'
 
 def escape_string(s):
     s = s.replace('\\', '\\\\')
@@ -254,7 +269,7 @@ def get_builtin_rs_type(type_, package_name=None):
     elif isinstance(type_, AbstractGenericString):
         return 'std::string::String'
     elif isinstance(type_, Array):
-        return '[{}, {}]'.format(get_rs_type(type_.value_type), 32 if type_.size <= 32 else 32)
+        return '[{}; {}]'.format(get_rs_type(type_.value_type), 32 if type_.size <= 32 else 32)
     elif isinstance(type_, AbstractSequence):
         return 'Vec<{}>'.format(get_rs_type(type_.value_type))
 


### PR DESCRIPTION
Fixes a bug in array type generation. Also append an underscore to field names that are rust keywords.

https://github.com/ros2-rust/ros2_rust/issues/26
