### PR TITLE
Add test_interface-files dependency to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Or do so manually as summarized in the steps below:
 
 ```
 # first, install vcstool from PyPI or apt:
-# sudo apt install ros-foxy-desktop python3-vcstool libclang-dev clang
+# sudo apt install ros-foxy-desktop ros-foxy-test-interface-files python3-vcstool libclang-dev clang
 # pip install vcstool
 
 mkdir -p ~/ros2_rust_ws/src/ros2-rust


### PR DESCRIPTION
colcon build fails as cmake cannot find "test_interface_files", so I added it to the Readme