### PR TITLE
Implement WaitSet

### DIFF
--- a/rclrs/src/error.rs
+++ b/rclrs/src/error.rs
@@ -14,10 +14,5 @@ pub(crate) trait ToResult {
 impl ToResult for rcl_ret_t {
     fn ok(&self) -> Result<(), RclError> {
         to_rcl_result(*self as i32)
-    //     if *self as u32 == RCL_RET_OK {
-    //         Ok(())
-    //     } else {
-    //         Err(RclError::from(*self))
-    //     }
     }
 }

--- a/rclrs/src/error.rs
+++ b/rclrs/src/error.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 
 use crate::rcl_bindings::*;
-pub use rclrs_common::error::RclError;
+pub use rclrs_common::error::{RclError, to_rcl_result};
 
 pub(crate) trait ToResult {
     fn ok(&self) -> Result<(), RclError>;
@@ -13,10 +13,11 @@ pub(crate) trait ToResult {
 
 impl ToResult for rcl_ret_t {
     fn ok(&self) -> Result<(), RclError> {
-        if *self as u32 == RCL_RET_OK {
-            Ok(())
-        } else {
-            Err(RclError::from(*self))
-        }
+        to_rcl_result(*self as i32)
+    //     if *self as u32 == RCL_RET_OK {
+    //         Ok(())
+    //     } else {
+    //         Err(RclError::from(*self))
+    //     }
     }
 }

--- a/rclrs/src/lib.rs
+++ b/rclrs/src/lib.rs
@@ -97,8 +97,6 @@ pub fn spin_once(node: &Node, timeout: i64) -> Result<(), WaitSetError> {
         number_of_events,
         context)?;
 
-    wait_set.clear()?;
-
     for subscription in &node.subscriptions {
         match wait_set.add_subscription(subscription) {
             Ok(()) => (),

--- a/rclrs/src/lib.rs
+++ b/rclrs/src/lib.rs
@@ -92,19 +92,6 @@ pub fn spin_once(node: &Node, timeout: i64) -> Result<(), WaitSetError> {
 
     let context = &mut *node.context.get_mut();
 
-    // unsafe {
-    //     rcl_wait_set_init(
-    //         &mut wait_set_handle as *mut _,
-    //         number_of_subscriptions,
-    //         number_of_guard_conditions,
-    //         number_of_timers,
-    //         number_of_clients,
-    //         number_of_services,
-    //         number_of_events,
-    //         context,
-    //         rcutils_get_default_allocator(),
-    //     ).ok()?;
-    // }
     wait_set.init(
         number_of_subscriptions,
         number_of_guard_conditions,
@@ -114,49 +101,9 @@ pub fn spin_once(node: &Node, timeout: i64) -> Result<(), WaitSetError> {
         number_of_events,
         context)?;
 
-    
-        
-    // unsafe {
-    //     match rcl_wait_set_clear(&mut wait_set_handle as *mut _).ok() {
-    //         Ok(()) => (),
-    //         Err(rcl_err) => {
-    //             eprintln!("Unable to clear WaitSet! Error code: {:?}", rcl_err);
-    //             match rcl_wait_set_fini(&mut wait_set_handle as *mut _).ok() {
-    //                 Ok(()) => return Err(rcl_err),
-    //                 Err(rcl_err2) => {
-    //                     eprintln!("Trying to clear the WaitSet caused a second error!! Error code: {:?}", rcl_err2);
-    //                     return Err(rcl_err2);
-    //                 }
-    //             }
-    //         }
-    //     };
-    // }
     wait_set.clear()?;
 
     for subscription in &node.subscriptions {
-        // if let Some(subscription) = subscription.upgrade() {
-        //     let subscription_handle = &*subscription.handle().get();
-        //     unsafe {
-        //         match rcl_wait_set_add_subscription(
-        //             &mut wait_set_handle as *mut _,
-        //             subscription_handle as *const _,
-        //             std::ptr::null_mut(),
-        //         )
-        //         .ok() {
-        //             Ok(()) => (),
-        //             Err(rcl_err) => {
-        //                 eprintln!("Unable to add subscription to WaitSet! Error code: {:?}", rcl_err);
-        //                 match rcl_wait_set_fini(&mut wait_set_handle as *mut _).ok() {
-        //                     Ok(()) => return Err(rcl_err),
-        //                     Err(rcl_err2) => {
-        //                         eprintln!("Trying to clear the WaitSet caused a second error!! Error code: {:?}", rcl_err2);
-        //                         return Err(rcl_err2);
-        //                     }
-        //                 }
-        //             }
-        //         };
-        //     }
-        // }
         match wait_set.add_subscription(subscription) {
             Ok(()) => (),
             Err(WaitSetError::DroppedSubscription) => (),
@@ -165,24 +112,6 @@ pub fn spin_once(node: &Node, timeout: i64) -> Result<(), WaitSetError> {
     }
 
     wait_set.wait(timeout)?;
-    // unsafe {
-    //     match rcl_wait(&mut wait_set_handle as *mut _, timeout).ok() {
-    //         Ok(()) => (),
-    //         Err(rcl_err) => {
-    //             match rcl_wait_set_fini(&mut wait_set_handle as *mut _).ok() {
-    //                 Ok(()) => return Err(rcl_err),
-    //                 Err(RclError::Timeout) => return Err(RclError::Timeout),
-    //                 Err(rcl_err2) => {
-    //                     eprintln!("Error waiting on WaitSet! Error code: {:?}", rcl_err);
-    //                     eprintln!("Trying to clear the WaitSet caused a second error!! Error code: {:?}", rcl_err2);
-    //                     return Err(rcl_err2);
-    //                 }
-    //             }
-    //         }
-
-    //     };
-    // }
-
     for subscription in &node.subscriptions {
         if let Some(subscription) = subscription.upgrade() {
             let mut message = subscription.create_message();
@@ -192,15 +121,6 @@ pub fn spin_once(node: &Node, timeout: i64) -> Result<(), WaitSetError> {
             }
         }
     }
-    // unsafe {
-    //     match rcl_wait_set_fini(&mut wait_set_handle as *mut _).ok() {
-    //         Ok(()) => (),
-    //         Err(rcl_err) => {
-    //             eprintln!("Error cleaning up WaitSet! Error code: {:?}", rcl_err);
-    //             return Err(rcl_err);
-    //         }
-    //     };
-    // }
 
     Ok(())
 }

--- a/rclrs/src/lib.rs
+++ b/rclrs/src/lib.rs
@@ -2,6 +2,7 @@ pub mod context;
 pub mod error;
 pub mod node;
 pub mod qos;
+pub mod wait;
 
 mod rcl_bindings;
 

--- a/rclrs/src/lib.rs
+++ b/rclrs/src/lib.rs
@@ -79,10 +79,6 @@ pub fn spin(node: &Node) -> Result<(), RclError> {
 ///
 ///
 pub fn spin_once(node: &Node, timeout: i64) -> Result<(), WaitSetError> {
-    // get an rcl_wait_set_t - All NULLs
-    // let mut wait_set_handle = unsafe { rcl_get_zero_initialized_wait_set() };
-    let mut wait_set = WaitSet::new();
-
     let number_of_subscriptions = node.subscriptions.len();
     let number_of_guard_conditions = 0;
     let number_of_timers = 0;
@@ -92,7 +88,7 @@ pub fn spin_once(node: &Node, timeout: i64) -> Result<(), WaitSetError> {
 
     let context = &mut *node.context.get_mut();
 
-    wait_set.init(
+    let mut wait_set = WaitSet::new(
         number_of_subscriptions,
         number_of_guard_conditions,
         number_of_timers,

--- a/rclrs/src/lib.rs
+++ b/rclrs/src/lib.rs
@@ -14,6 +14,8 @@ pub use self::qos::*;
 use self::rcl_bindings::*;
 use std::ops::{Deref, DerefMut};
 use anyhow::Result;
+use rclrs_common::error::WaitSetError;
+use wait::WaitSet;
 
 pub trait Handle<T> {
     type DerefT: Deref<Target = T>;
@@ -28,8 +30,9 @@ pub fn spin(node: &Node) -> Result<(), RclError> {
     while unsafe { rcl_context_is_valid(&mut *node.context.get_mut() as *mut _) } {
         if let Some(error) = spin_once(node, 500).err() {
             match error {
-                RclError::Timeout => continue,
-                _ => return Err(error),
+                WaitSetError::DroppedSubscription => continue,
+                WaitSetError::RclError(RclError::Timeout) => continue,
+                WaitSetError::RclError(rclerr) => return Err(rclerr),
             }
         }
     }
@@ -75,9 +78,10 @@ pub fn spin(node: &Node) -> Result<(), RclError> {
 ///         +--------------------+
 ///
 ///
-pub fn spin_once(node: &Node, timeout: i64) -> Result<(), RclError> {
+pub fn spin_once(node: &Node, timeout: i64) -> Result<(), WaitSetError> {
     // get an rcl_wait_set_t - All NULLs
-    let mut wait_set_handle = unsafe { rcl_get_zero_initialized_wait_set() };
+    // let mut wait_set_handle = unsafe { rcl_get_zero_initialized_wait_set() };
+    let mut wait_set = WaitSet::new();
 
     let number_of_subscriptions = node.subscriptions.len();
     let number_of_guard_conditions = 0;
@@ -88,79 +92,96 @@ pub fn spin_once(node: &Node, timeout: i64) -> Result<(), RclError> {
 
     let context = &mut *node.context.get_mut();
 
-    unsafe {
-        rcl_wait_set_init(
-            &mut wait_set_handle as *mut _,
-            number_of_subscriptions,
-            number_of_guard_conditions,
-            number_of_timers,
-            number_of_clients,
-            number_of_services,
-            number_of_events,
-            context,
-            rcutils_get_default_allocator(),
-        ).ok()?;
-    }
+    // unsafe {
+    //     rcl_wait_set_init(
+    //         &mut wait_set_handle as *mut _,
+    //         number_of_subscriptions,
+    //         number_of_guard_conditions,
+    //         number_of_timers,
+    //         number_of_clients,
+    //         number_of_services,
+    //         number_of_events,
+    //         context,
+    //         rcutils_get_default_allocator(),
+    //     ).ok()?;
+    // }
+    wait_set.init(
+        number_of_subscriptions,
+        number_of_guard_conditions,
+        number_of_timers,
+        number_of_clients,
+        number_of_services,
+        number_of_events,
+        context)?;
 
-    unsafe {
-        match rcl_wait_set_clear(&mut wait_set_handle as *mut _).ok() {
-            Ok(()) => (),
-            Err(rcl_err) => {
-                eprintln!("Unable to clear WaitSet! Error code: {:?}", rcl_err);
-                match rcl_wait_set_fini(&mut wait_set_handle as *mut _).ok() {
-                    Ok(()) => return Err(rcl_err),
-                    Err(rcl_err2) => {
-                        eprintln!("Trying to clear the WaitSet caused a second error!! Error code: {:?}", rcl_err2);
-                        return Err(rcl_err2);
-                    }
-                }
-            }
-        };
-    }
+    
+        
+    // unsafe {
+    //     match rcl_wait_set_clear(&mut wait_set_handle as *mut _).ok() {
+    //         Ok(()) => (),
+    //         Err(rcl_err) => {
+    //             eprintln!("Unable to clear WaitSet! Error code: {:?}", rcl_err);
+    //             match rcl_wait_set_fini(&mut wait_set_handle as *mut _).ok() {
+    //                 Ok(()) => return Err(rcl_err),
+    //                 Err(rcl_err2) => {
+    //                     eprintln!("Trying to clear the WaitSet caused a second error!! Error code: {:?}", rcl_err2);
+    //                     return Err(rcl_err2);
+    //                 }
+    //             }
+    //         }
+    //     };
+    // }
+    wait_set.clear()?;
 
     for subscription in &node.subscriptions {
-        if let Some(subscription) = subscription.upgrade() {
-            let subscription_handle = &*subscription.handle().get();
-            unsafe {
-                match rcl_wait_set_add_subscription(
-                    &mut wait_set_handle as *mut _,
-                    subscription_handle as *const _,
-                    std::ptr::null_mut(),
-                )
-                .ok() {
-                    Ok(()) => (),
-                    Err(rcl_err) => {
-                        eprintln!("Unable to add subscription to WaitSet! Error code: {:?}", rcl_err);
-                        match rcl_wait_set_fini(&mut wait_set_handle as *mut _).ok() {
-                            Ok(()) => return Err(rcl_err),
-                            Err(rcl_err2) => {
-                                eprintln!("Trying to clear the WaitSet caused a second error!! Error code: {:?}", rcl_err2);
-                                return Err(rcl_err2);
-                            }
-                        }
-                    }
-                };
-            }
-        }
-    }
-
-    unsafe {
-        match rcl_wait(&mut wait_set_handle as *mut _, timeout).ok() {
+        // if let Some(subscription) = subscription.upgrade() {
+        //     let subscription_handle = &*subscription.handle().get();
+        //     unsafe {
+        //         match rcl_wait_set_add_subscription(
+        //             &mut wait_set_handle as *mut _,
+        //             subscription_handle as *const _,
+        //             std::ptr::null_mut(),
+        //         )
+        //         .ok() {
+        //             Ok(()) => (),
+        //             Err(rcl_err) => {
+        //                 eprintln!("Unable to add subscription to WaitSet! Error code: {:?}", rcl_err);
+        //                 match rcl_wait_set_fini(&mut wait_set_handle as *mut _).ok() {
+        //                     Ok(()) => return Err(rcl_err),
+        //                     Err(rcl_err2) => {
+        //                         eprintln!("Trying to clear the WaitSet caused a second error!! Error code: {:?}", rcl_err2);
+        //                         return Err(rcl_err2);
+        //                     }
+        //                 }
+        //             }
+        //         };
+        //     }
+        // }
+        match wait_set.add_subscription(subscription) {
             Ok(()) => (),
-            Err(rcl_err) => {
-                match rcl_wait_set_fini(&mut wait_set_handle as *mut _).ok() {
-                    Ok(()) => return Err(rcl_err),
-                    Err(RclError::Timeout) => return Err(RclError::Timeout),
-                    Err(rcl_err2) => {
-                        eprintln!("Error waiting on WaitSet! Error code: {:?}", rcl_err);
-                        eprintln!("Trying to clear the WaitSet caused a second error!! Error code: {:?}", rcl_err2);
-                        return Err(rcl_err2);
-                    }
-                }
-            }
-
+            Err(WaitSetError::DroppedSubscription) => (),
+            err => return err,
         };
     }
+
+    wait_set.wait(timeout)?;
+    // unsafe {
+    //     match rcl_wait(&mut wait_set_handle as *mut _, timeout).ok() {
+    //         Ok(()) => (),
+    //         Err(rcl_err) => {
+    //             match rcl_wait_set_fini(&mut wait_set_handle as *mut _).ok() {
+    //                 Ok(()) => return Err(rcl_err),
+    //                 Err(RclError::Timeout) => return Err(RclError::Timeout),
+    //                 Err(rcl_err2) => {
+    //                     eprintln!("Error waiting on WaitSet! Error code: {:?}", rcl_err);
+    //                     eprintln!("Trying to clear the WaitSet caused a second error!! Error code: {:?}", rcl_err2);
+    //                     return Err(rcl_err2);
+    //                 }
+    //             }
+    //         }
+
+    //     };
+    // }
 
     for subscription in &node.subscriptions {
         if let Some(subscription) = subscription.upgrade() {
@@ -171,15 +192,15 @@ pub fn spin_once(node: &Node, timeout: i64) -> Result<(), RclError> {
             }
         }
     }
-    unsafe {
-        match rcl_wait_set_fini(&mut wait_set_handle as *mut _).ok() {
-            Ok(()) => (),
-            Err(rcl_err) => {
-                eprintln!("Error cleaning up WaitSet! Error code: {:?}", rcl_err);
-                return Err(rcl_err);
-            }
-        };
-    }
+    // unsafe {
+    //     match rcl_wait_set_fini(&mut wait_set_handle as *mut _).ok() {
+    //         Ok(()) => (),
+    //         Err(rcl_err) => {
+    //             eprintln!("Error cleaning up WaitSet! Error code: {:?}", rcl_err);
+    //             return Err(rcl_err);
+    //         }
+    //     };
+    // }
 
     Ok(())
 }

--- a/rclrs/src/node/subscription.rs
+++ b/rclrs/src/node/subscription.rs
@@ -8,6 +8,7 @@ use std::ffi::CString;
 use std::marker::PhantomData;
 use std::rc::Rc;
 use anyhow::Result;
+use rclrs_common::error::to_rcl_result;
 
 pub struct SubscriptionHandle {
     handle: RefCell<rcl_subscription_t>,
@@ -78,13 +79,13 @@ pub trait SubscriptionBase {
             )
         };
 
-        let result = match result.into() {
-            RclError::Ok => {
+        let result = match to_rcl_result(result) {
+            Ok(()) => {
                 message.read_handle(message_handle);
                 Ok(true)
             }
-            RclError::SubscriptionTakeFailed => Ok(false),
-            error => Err(error),
+            Err(RclError::SubscriptionTakeFailed) => Ok(false),
+            Err(error) => Err(error),
         };
 
         message.destroy_native_message(message_handle);

--- a/rclrs/src/wait.rs
+++ b/rclrs/src/wait.rs
@@ -16,15 +16,14 @@
 // OPSEC #4584.
 
 use std::borrow::BorrowMut;
-use std::cell::{Ref, RefCell, RefMut};
-use std::rc::{Rc, Weak};
+use std::rc::Weak;
 
 use crate::{SubscriptionBase, error::*};
 use crate::Handle;
 
 use crate::rcl_bindings::*;
 
-use anyhow::{Context, Error, Result};
+use anyhow::Result;
 use rclrs_common::error::WaitSetError;
 
 pub struct WaitSet {
@@ -44,7 +43,7 @@ impl WaitSet {
         number_of_clients: usize,
         number_of_services: usize,
         number_of_events: usize,
-        context: &mut rcl_context_s,
+        context: &mut rcl_context_t,
     ) -> Result<Self, WaitSetError> {
         let mut waitset = Self {
             wait_set: unsafe { rcl_get_zero_initialized_wait_set() },

--- a/rclrs/src/wait.rs
+++ b/rclrs/src/wait.rs
@@ -17,14 +17,15 @@
 
 use std::borrow::BorrowMut;
 use std::cell::{Ref, RefCell, RefMut};
-use std::rc::Rc;
+use std::rc::{Rc, Weak};
 
+use crate::{SubscriptionBase, error::*};
 use crate::Handle;
-use crate::error::*;
 
 use crate::rcl_bindings::*;
 
-use anyhow::{Context, Error};
+use anyhow::{Context, Error, Result};
+use rclrs_common::error::WaitSetError;
 
 pub struct WaitSet {
     pub wait_set: rcl_wait_set_t,
@@ -36,7 +37,7 @@ impl WaitSet {
     ///
     /// Under the hood, this calls `rcl_get_zero_initialized_wait_set()`, and stores it
     /// within the WaitSet struct, while also noting that the returned value is uninitialized.
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             wait_set: unsafe { rcl_get_zero_initialized_wait_set() },
             initialized: false,
@@ -48,51 +49,90 @@ impl WaitSet {
     /// This function allocates space for the subscriptions and other wait-able
     /// entities that can be stored in the wait set, using a default allocator grabbed from
     /// `rcutils_get_default_allocator()`
-    ///
-    /// Safety: The unsafe  cases of the underlying `rcl_wait_set_init`
-    fn init(
+    pub fn init(
         &mut self,
-        num_subs: usize,
-        num_gcs: usize,
-        num_timers: usize,
-        num_clients: usize,
-        num_services: usize,
-        num_events: usize,
-        context: &mut rcl_context_s) -> Result<(), RclError> {
-            if self.initialized {
-                return Err(RclError::WaitSetInvalid);
-                // return Err(RclError::WaitSetInvalid).context(|| "WaitSet.init called with already-initialized wait_set!");
-            }
-            unsafe {
-                match rcl_wait_set_init(
-                    self.wait_set.borrow_mut() as *mut _,
-                    num_subs,
-                    num_gcs,
-                    num_timers,
-                    num_clients,
-                    num_services,
-                    num_events,
-                    context,
-                    rcutils_get_default_allocator()
-                ).ok() {
-                    Ok(()) => {
-                        self.initialized = true;
-                        Ok(())
-                    },
-                    Err(err) => {
-                        self.initialized = false;
-                        Err(err)
-                    }
+        number_of_subscriptions: usize,
+        number_of_guard_conditions: usize,
+        number_of_timers: usize,
+        number_of_clients: usize,
+        number_of_services: usize,
+        number_of_events: usize,
+        context: &mut rcl_context_s,
+    ) -> Result<(), WaitSetError> {
+        if self.initialized {
+            return Err(WaitSetError::RclError(RclError::WaitSetInvalid));
+        }
+        unsafe {
+            match to_rcl_result(rcl_wait_set_init(
+                self.wait_set.borrow_mut() as *mut _,
+                number_of_subscriptions,
+                number_of_guard_conditions,
+                number_of_timers,
+                number_of_clients,
+                number_of_services,
+                number_of_events,
+                context,
+                rcutils_get_default_allocator(),
+            )) {
+                Ok(()) => {
+                    self.initialized = true;
+                    Ok(())
                 }
+                Err(err) => {
+                    self.initialized = false;
+                    Err(WaitSetError::RclError(err))
+                }
+            }
+        }
+    }
+
+    /// Removes (sets to NULL) all entities in the WaitSet
+    ///
+    /// # Errors
+    /// - `RclError::InvalidArgument` if any arguments are invalid.
+    /// - `RclError::WaitSetInvalid` if the WaitSet is already zero-initialized.
+    /// - `RclError::Error` for an unspecified error
+    pub fn clear(&mut self) -> Result<(), WaitSetError> {
+        if !self.initialized {
+            return Err(WaitSetError::RclError(RclError::WaitSetInvalid));
+        }
+        unsafe {
+            // Whether or not we successfully clear, this WaitSet will count as uninitialized
+            self.initialized = false;
+            to_rcl_result(rcl_wait_set_clear(self.wait_set.borrow_mut() as *mut _)).map_err(WaitSetError::RclError)
+        }
+    }
+
+    pub fn add_subscription(&mut self, subscription: &Weak<dyn SubscriptionBase>) -> Result<(), WaitSetError> {
+        if let Some(subscription) = subscription.upgrade() {
+            let subscription_handle = &*subscription.handle().get();
+            unsafe {
+                return to_rcl_result(rcl_wait_set_add_subscription(
+                    self.wait_set.borrow_mut() as *mut _,
+                subscription_handle as *const _,
+            std::ptr::null_mut())).map_err(WaitSetError::RclError);
+            }
+        } else {
+            Err(WaitSetError::DroppedSubscription)
+        }
+    }
+
+    pub fn wait(&mut self, timeout: i64) -> Result<(), WaitSetError> {
+        unsafe {
+            to_rcl_result(rcl_wait(self.wait_set.borrow_mut() as *mut _, timeout)).map_err(WaitSetError::RclError)
         }
     }
 }
 
 impl Drop for WaitSet {
+    /// Drops the WaitSet, and clears the memory
+    ///
+    /// # Panics
+    /// A panic is raised if `rcl` is unable to release the waitset for any reason.
     fn drop(&mut self) {
         let handle = &mut *self.wait_set.borrow_mut();
         unsafe {
-            match rcl_wait_set_fini(handle as *mut _).ok() {
+            match to_rcl_result(rcl_wait_set_fini(handle as *mut _)) {
                 Ok(()) => (),
                 Err(err) => {
                     panic!("Unable to release WaitSet!! {:?}", err)

--- a/rclrs/src/wait.rs
+++ b/rclrs/src/wait.rs
@@ -1,0 +1,103 @@
+// Copyright 2020 DCS Corporation, All Rights Reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// DISTRIBUTION A. Approved for public release; distribution unlimited.
+// OPSEC #4584.
+
+use std::borrow::BorrowMut;
+use std::cell::{Ref, RefCell, RefMut};
+use std::rc::Rc;
+
+use crate::Handle;
+use crate::error::*;
+
+use crate::rcl_bindings::*;
+
+use anyhow::{Context, Error};
+
+pub struct WaitSet {
+    pub wait_set: rcl_wait_set_t,
+    initialized: bool,
+}
+
+impl WaitSet {
+    /// Creates a new WaitSet object.
+    ///
+    /// Under the hood, this calls `rcl_get_zero_initialized_wait_set()`, and stores it
+    /// within the WaitSet struct, while also noting that the returned value is uninitialized.
+    fn new() -> Self {
+        Self {
+            wait_set: unsafe { rcl_get_zero_initialized_wait_set() },
+            initialized: false,
+        }
+    }
+
+    /// Initializes an rcl wait set with space for items to be waited on
+    ///
+    /// This function allocates space for the subscriptions and other wait-able
+    /// entities that can be stored in the wait set, using a default allocator grabbed from
+    /// `rcutils_get_default_allocator()`
+    ///
+    /// Safety: The unsafe  cases of the underlying `rcl_wait_set_init`
+    fn init(
+        &mut self,
+        num_subs: usize,
+        num_gcs: usize,
+        num_timers: usize,
+        num_clients: usize,
+        num_services: usize,
+        num_events: usize,
+        context: &mut rcl_context_s) -> Result<(), RclError> {
+            if self.initialized {
+                return Err(RclError::WaitSetInvalid);
+                // return Err(RclError::WaitSetInvalid).context(|| "WaitSet.init called with already-initialized wait_set!");
+            }
+            unsafe {
+                match rcl_wait_set_init(
+                    self.wait_set.borrow_mut() as *mut _,
+                    num_subs,
+                    num_gcs,
+                    num_timers,
+                    num_clients,
+                    num_services,
+                    num_events,
+                    context,
+                    rcutils_get_default_allocator()
+                ).ok() {
+                    Ok(()) => {
+                        self.initialized = true;
+                        Ok(())
+                    },
+                    Err(err) => {
+                        self.initialized = false;
+                        Err(err)
+                    }
+                }
+        }
+    }
+}
+
+impl Drop for WaitSet {
+    fn drop(&mut self) {
+        let handle = &mut *self.wait_set.borrow_mut();
+        unsafe {
+            match rcl_wait_set_fini(handle as *mut _).ok() {
+                Ok(()) => (),
+                Err(err) => {
+                    panic!("Unable to release WaitSet!! {:?}", err)
+                }
+            }
+        }
+    }
+}

--- a/rclrs_common/src/lib.rs
+++ b/rclrs_common/src/lib.rs
@@ -3,8 +3,8 @@ pub mod error {
 
     #[derive(Debug, Error)]
     pub enum RclError {
-        #[error("Success")]
-        Ok,
+        // #[error("Success")]
+        // Ok,
         #[error("Unspecified Error")]
         Error,
         #[error("Timeout occurred")]
@@ -65,46 +65,93 @@ pub mod error {
         InvalidParamRule,
         #[error("Argument is not a valid log level")]
         InvalidLogLevelRule,
+        #[error("Unknown RCL return code: {0}")]
+        UnknownError(i32)
     }
 
-    impl From<i32> for RclError {
-        fn from(error: i32) -> Self {
-            match error {
-                0 => RclError::Ok,
-                1 => RclError::Error,
-                2 => RclError::Timeout,
-                10 => RclError::BadAlloc,
-                11 => RclError::InvalidArgument,
-                100 => RclError::AlreadyInit,
-                101 => RclError::NotInit,
-                102 => RclError::MismatchedRmwId,
-                103 => RclError::TopicNameInvalid,
-                104 => RclError::ServiceNameInvalid,
-                105 => RclError::UnknownSubstitution,
-                106 => RclError::AlreadyShutdown,
-                200 => RclError::NodeInvalid,
-                201 => RclError::NodeInvalidName,
-                202 => RclError::NodeInvalidNamespace,
-                300 => RclError::PublisherInvalid,
-                400 => RclError::SubscriptionInvalid,
-                401 => RclError::SubscriptionTakeFailed,
-                500 => RclError::ClientInvalid,
-                501 => RclError::ClientTakeFailed,
-                600 => RclError::ServiceInvalid,
-                601 => RclError::ServiceTakeFailed,
-                800 => RclError::TimerInvalid,
-                801 => RclError::TimerCanceled,
-                900 => RclError::WaitSetInvalid,
-                901 => RclError::WaitSetEmpty,
-                902 => RclError::WaitSetFull,
-                1001 => RclError::InvalidRemapRule,
-                1002 => RclError::WrongLexeme,
-                1010 => RclError::InvalidParamRule,
-                1020 => RclError::InvalidLogLevelRule,
-                _ => unimplemented!(),
-            }
+    pub fn to_rcl_result(error_id: i32) -> Result<(), RclError> {
+        match error_id {
+            0 => Ok(()),
+            1 => Err(RclError::Error),
+            2 => Err(RclError::Timeout),
+            10 => Err(RclError::BadAlloc),
+            11 => Err(RclError::InvalidArgument),
+            100 => Err(RclError::AlreadyInit),
+            101 => Err(RclError::NotInit),
+            102 => Err(RclError::MismatchedRmwId),
+            103 => Err(RclError::TopicNameInvalid),
+            104 => Err(RclError::ServiceNameInvalid),
+            105 => Err(RclError::UnknownSubstitution),
+            106 => Err(RclError::AlreadyShutdown),
+            200 => Err(RclError::NodeInvalid),
+            201 => Err(RclError::NodeInvalidName),
+            202 => Err(RclError::NodeInvalidNamespace),
+            300 => Err(RclError::PublisherInvalid),
+            400 => Err(RclError::SubscriptionInvalid),
+            401 => Err(RclError::SubscriptionTakeFailed),
+            500 => Err(RclError::ClientInvalid),
+            501 => Err(RclError::ClientTakeFailed),
+            600 => Err(RclError::ServiceInvalid),
+            601 => Err(RclError::ServiceTakeFailed),
+            800 => Err(RclError::TimerInvalid),
+            801 => Err(RclError::TimerCanceled),
+            900 => Err(RclError::WaitSetInvalid),
+            901 => Err(RclError::WaitSetEmpty),
+            902 => Err(RclError::WaitSetFull),
+            1001 => Err(RclError::InvalidRemapRule),
+            1002 => Err(RclError::WrongLexeme),
+            1010 => Err(RclError::InvalidParamRule),
+            1020 => Err(RclError::InvalidLogLevelRule),
+            unrecognized => Err(RclError::UnknownError(unrecognized))
         }
     }
+
+    #[derive(Debug, Error)]
+    pub enum WaitSetError {
+        #[error("Passed subscription was dropped")]
+        DroppedSubscription,
+        #[error("Rcl error occurred")]
+        RclError (#[from] RclError)
+    }
+
+    // impl From<i32> for RclError {
+    //     fn from(error: i32) -> Self {
+    //         match error {
+    //             // 0 => RclError::Ok,
+    //             1 => RclError::Error,
+    //             2 => RclError::Timeout,
+    //             10 => RclError::BadAlloc,
+    //             11 => RclError::InvalidArgument,
+    //             100 => RclError::AlreadyInit,
+    //             101 => RclError::NotInit,
+    //             102 => RclError::MismatchedRmwId,
+    //             103 => RclError::TopicNameInvalid,
+    //             104 => RclError::ServiceNameInvalid,
+    //             105 => RclError::UnknownSubstitution,
+    //             106 => RclError::AlreadyShutdown,
+    //             200 => RclError::NodeInvalid,
+    //             201 => RclError::NodeInvalidName,
+    //             202 => RclError::NodeInvalidNamespace,
+    //             300 => RclError::PublisherInvalid,
+    //             400 => RclError::SubscriptionInvalid,
+    //             401 => RclError::SubscriptionTakeFailed,
+    //             500 => RclError::ClientInvalid,
+    //             501 => RclError::ClientTakeFailed,
+    //             600 => RclError::ServiceInvalid,
+    //             601 => RclError::ServiceTakeFailed,
+    //             800 => RclError::TimerInvalid,
+    //             801 => RclError::TimerCanceled,
+    //             900 => RclError::WaitSetInvalid,
+    //             901 => RclError::WaitSetEmpty,
+    //             902 => RclError::WaitSetFull,
+    //             1001 => RclError::InvalidRemapRule,
+    //             1002 => RclError::WrongLexeme,
+    //             1010 => RclError::InvalidParamRule,
+    //             1020 => RclError::InvalidLogLevelRule,
+    //             _ => unimplemented!(),
+    //         }
+    //     }
+    // }
 }
 
 pub mod traits {

--- a/rclrs_common/src/lib.rs
+++ b/rclrs_common/src/lib.rs
@@ -113,45 +113,6 @@ pub mod error {
         #[error("Rcl error occurred")]
         RclError (#[from] RclError)
     }
-
-    // impl From<i32> for RclError {
-    //     fn from(error: i32) -> Self {
-    //         match error {
-    //             // 0 => RclError::Ok,
-    //             1 => RclError::Error,
-    //             2 => RclError::Timeout,
-    //             10 => RclError::BadAlloc,
-    //             11 => RclError::InvalidArgument,
-    //             100 => RclError::AlreadyInit,
-    //             101 => RclError::NotInit,
-    //             102 => RclError::MismatchedRmwId,
-    //             103 => RclError::TopicNameInvalid,
-    //             104 => RclError::ServiceNameInvalid,
-    //             105 => RclError::UnknownSubstitution,
-    //             106 => RclError::AlreadyShutdown,
-    //             200 => RclError::NodeInvalid,
-    //             201 => RclError::NodeInvalidName,
-    //             202 => RclError::NodeInvalidNamespace,
-    //             300 => RclError::PublisherInvalid,
-    //             400 => RclError::SubscriptionInvalid,
-    //             401 => RclError::SubscriptionTakeFailed,
-    //             500 => RclError::ClientInvalid,
-    //             501 => RclError::ClientTakeFailed,
-    //             600 => RclError::ServiceInvalid,
-    //             601 => RclError::ServiceTakeFailed,
-    //             800 => RclError::TimerInvalid,
-    //             801 => RclError::TimerCanceled,
-    //             900 => RclError::WaitSetInvalid,
-    //             901 => RclError::WaitSetEmpty,
-    //             902 => RclError::WaitSetFull,
-    //             1001 => RclError::InvalidRemapRule,
-    //             1002 => RclError::WrongLexeme,
-    //             1010 => RclError::InvalidParamRule,
-    //             1020 => RclError::InvalidLogLevelRule,
-    //             _ => unimplemented!(),
-    //         }
-    //     }
-    // }
 }
 
 pub mod traits {


### PR DESCRIPTION
Closes #47 

Also includes a rework of the error system around the `spin` functionality, to accept the new ways that the `WaitSet` can fail.