### PR TITLE
Add Arc and Mutex

### DIFF
--- a/rclrs/Cargo.toml
+++ b/rclrs/Cargo.toml
@@ -5,9 +5,10 @@ authors = ["Esteve Fernandez <esteve@apache.org>"]
 edition = "2018"
 
 [dependencies]
-libc = "0.2.43"
-thiserror = "1"
 anyhow = {version = "1", features = ["backtrace"]}
+libc = "0.2.43"
+parking_lot = "0.11"
+thiserror = "1"
 
 [build-dependencies]
 bindgen = "0.59.1"

--- a/rclrs/build.rs
+++ b/rclrs/build.rs
@@ -8,7 +8,9 @@ fn main() {
         .header("src/rcl_wrapper.h")
         .derive_copy(false)
         .size_t_is_usize(true)
-        .default_enum_style(bindgen::EnumVariation::Rust{non_exhaustive: false});
+        .default_enum_style(bindgen::EnumVariation::Rust {
+            non_exhaustive: false,
+        });
 
     let ament_prefix_var_name = "AMENT_PREFIX_PATH";
     let ament_prefix_var = env::var(ament_prefix_var_name);

--- a/rclrs/src/context.rs
+++ b/rclrs/src/context.rs
@@ -1,49 +1,55 @@
-use crate::error::{RclError, ToResult};
-use crate::{Handle, Node};
+use crate::error::ToResult;
 use crate::rcl_bindings::*;
-use std::cell::{Ref, RefCell, RefMut};
+use crate::Node;
+use rclrs_common::error::RclError;
 use std::env;
 use std::ffi::CString;
 use std::os::raw::c_char;
-use std::rc::Rc;
-use anyhow::Result;
+use std::sync::Arc;
+use parking_lot::{Mutex, MutexGuard};
 
-pub struct ContextHandle(RefCell<rcl_context_t>);
+pub struct ContextHandle(Mutex<rcl_context_t>);
 
-impl<'a> Handle<rcl_context_t> for &'a ContextHandle {
-    type DerefT = Ref<'a, rcl_context_t>;
-    type DerefMutT = RefMut<'a, rcl_context_t>;
-
-    fn get(self) -> Self::DerefT {
-        self.0.borrow()
+impl ContextHandle {
+    pub fn get_mut(&mut self) -> &mut rcl_context_t {
+        self
+        .0
+        .get_mut()
     }
 
-    fn get_mut(self) -> Self::DerefMutT {
-        self.0.borrow_mut()
+    pub fn lock(&self) -> MutexGuard<rcl_context_t> {
+        self
+        .0
+        .lock()
+    }
+
+    pub fn try_lock(&self) -> Option<MutexGuard<rcl_context_t>> {
+        self
+        .0
+        .try_lock()
     }
 }
 
 impl Drop for ContextHandle {
     fn drop(&mut self) {
-        let handle = &mut *self.get_mut();
         unsafe {
-            rcl_shutdown(handle as *mut _);
+            rcl_shutdown(&mut *self.get_mut() as *mut _);
         }
     }
 }
 
 pub struct Context {
-    pub handle: Rc<ContextHandle>,
+    pub handle: Arc<ContextHandle>,
 }
 
 impl Context {
-    fn init(&mut self) -> Result<(), RclError> {
+    fn init(&self) -> Result<(), RclError> {
         let args: Vec<CString> = env::args()
             .filter_map(|arg| CString::new(arg).ok())
             .collect();
 
         let c_args: Vec<*const c_char> = args.iter().map(|arg| arg.as_ptr()).collect();
-        let handle = &mut *self.handle.get_mut();
+        let handle = &mut *self.handle.lock();
 
         unsafe {
             let allocator = rcutils_get_default_allocator();
@@ -62,9 +68,9 @@ impl Context {
         Ok(())
     }
 
-    pub fn ok(&self) -> bool {
-        let handle = &mut *self.handle.get_mut();
-        unsafe { rcl_context_is_valid(handle as *mut _) }
+    pub fn ok(&self) -> Result<bool, RclError> {
+        let handle = &mut *self.handle.lock();
+        unsafe { Ok(rcl_context_is_valid(handle as *mut _)) }
     }
 
     pub fn create_node(&self, node_name: &str) -> Result<Node, RclError> {
@@ -74,8 +80,8 @@ impl Context {
 
 impl Default for Context {
     fn default() -> Self {
-        let mut context = Self {
-            handle: Rc::new(ContextHandle(RefCell::new(unsafe {
+        let context = Self {
+            handle: Arc::new(ContextHandle(Mutex::new(unsafe {
                 rcl_get_zero_initialized_context()
             }))),
         };

--- a/rclrs/src/context.rs
+++ b/rclrs/src/context.rs
@@ -1,32 +1,26 @@
 use crate::error::ToResult;
 use crate::rcl_bindings::*;
 use crate::Node;
+use parking_lot::{Mutex, MutexGuard};
 use rclrs_common::error::RclError;
 use std::env;
 use std::ffi::CString;
 use std::os::raw::c_char;
 use std::sync::Arc;
-use parking_lot::{Mutex, MutexGuard};
 
 pub struct ContextHandle(Mutex<rcl_context_t>);
 
 impl ContextHandle {
     pub fn get_mut(&mut self) -> &mut rcl_context_t {
-        self
-        .0
-        .get_mut()
+        self.0.get_mut()
     }
 
     pub fn lock(&self) -> MutexGuard<rcl_context_t> {
-        self
-        .0
-        .lock()
+        self.0.lock()
     }
 
     pub fn try_lock(&self) -> Option<MutexGuard<rcl_context_t>> {
-        self
-        .0
-        .try_lock()
+        self.0.try_lock()
     }
 }
 

--- a/rclrs/src/error.rs
+++ b/rclrs/src/error.rs
@@ -1,7 +1,5 @@
-use anyhow::Result;
-
 use crate::rcl_bindings::*;
-pub use rclrs_common::error::{RclError, to_rcl_result};
+pub use rclrs_common::error::{to_rcl_result, RclError};
 
 pub(crate) trait ToResult {
     fn ok(&self) -> Result<(), RclError>;

--- a/rclrs/src/lib.rs
+++ b/rclrs/src/lib.rs
@@ -12,9 +12,8 @@ pub use self::node::*;
 pub use self::qos::*;
 
 use self::rcl_bindings::*;
-use std::ops::{Deref, DerefMut};
-use anyhow::Result;
 use rclrs_common::error::WaitSetError;
+use std::ops::{Deref, DerefMut};
 use wait::WaitSet;
 
 pub trait Handle<T> {
@@ -26,20 +25,19 @@ pub trait Handle<T> {
 }
 
 /// Wrapper around [`spin_once`]
-pub fn spin(node: &Node) -> Result<(), RclError> {
-    while unsafe { rcl_context_is_valid(&mut *node.context.get_mut() as *mut _) } {
+pub fn spin<'node>(node: &'node node::Node) -> Result<(), WaitSetError> {
+    while unsafe { rcl_context_is_valid(&mut *node.context.lock() as *mut _) } {
         if let Some(error) = spin_once(node, 500).err() {
             match error {
-                WaitSetError::DroppedSubscription => continue,
-                WaitSetError::RclError(RclError::Timeout) => continue,
-                WaitSetError::RclError(rclerr) => return Err(rclerr),
-            }
+                WaitSetError::DroppedSubscription |
+                    WaitSetError::RclError(RclError::Timeout) => continue,
+                error => return Err(error),
+            };
         }
     }
 
     Ok(())
 }
-
 
 /// Main function for waiting.
 ///
@@ -78,7 +76,7 @@ pub fn spin(node: &Node) -> Result<(), RclError> {
 ///         +--------------------+
 ///
 ///
-pub fn spin_once(node: &Node, timeout: i64) -> Result<(), WaitSetError> {
+pub fn spin_once<'node>(node: &'node Node, timeout: i64) -> Result<(), WaitSetError> {
     let number_of_subscriptions = node.subscriptions.len();
     let number_of_guard_conditions = 0;
     let number_of_timers = 0;
@@ -86,7 +84,7 @@ pub fn spin_once(node: &Node, timeout: i64) -> Result<(), WaitSetError> {
     let number_of_services = 0;
     let number_of_events = 0;
 
-    let context = &mut *node.context.get_mut();
+    let context = &mut *node.context.lock();
 
     let mut wait_set = WaitSet::new(
         number_of_subscriptions,
@@ -95,13 +93,14 @@ pub fn spin_once(node: &Node, timeout: i64) -> Result<(), WaitSetError> {
         number_of_clients,
         number_of_services,
         number_of_events,
-        context)?;
+        context,
+    )?;
 
     for subscription in &node.subscriptions {
         match wait_set.add_subscription(subscription) {
             Ok(()) => (),
             Err(WaitSetError::DroppedSubscription) => (),
-            err => return err,
+            Err(err) => return Err(err),
         };
     }
 

--- a/rclrs/src/lib.rs
+++ b/rclrs/src/lib.rs
@@ -29,8 +29,9 @@ pub fn spin<'node>(node: &'node node::Node) -> Result<(), WaitSetError> {
     while unsafe { rcl_context_is_valid(&mut *node.context.lock() as *mut _) } {
         if let Some(error) = spin_once(node, 500).err() {
             match error {
-                WaitSetError::DroppedSubscription |
-                    WaitSetError::RclError(RclError::Timeout) => continue,
+                WaitSetError::DroppedSubscription | WaitSetError::RclError(RclError::Timeout) => {
+                    continue
+                }
                 error => return Err(error),
             };
         }

--- a/rclrs/src/node/mod.rs
+++ b/rclrs/src/node/mod.rs
@@ -1,7 +1,7 @@
 use crate::qos::QoSProfile;
 use crate::rcl_bindings::*;
-use crate::{Context, ContextHandle};
 use crate::ToResult;
+use crate::{Context, ContextHandle};
 use rclrs_common::error::RclError;
 use std::ffi::CString;
 use std::sync::{Arc, Weak};
@@ -21,15 +21,11 @@ impl NodeHandle {
     }
 
     pub fn lock(&self) -> MutexGuard<rcl_node_t> {
-        self
-        .0
-        .lock()
+        self.0.lock()
     }
 
     pub fn try_lock(&self) -> Option<MutexGuard<rcl_node_t>> {
-        self
-        .0
-        .try_lock()
+        self.0.try_lock()
     }
 }
 

--- a/rclrs/src/node/mod.rs
+++ b/rclrs/src/node/mod.rs
@@ -1,54 +1,58 @@
-use crate::{RclError, ToResult};
 use crate::qos::QoSProfile;
 use crate::rcl_bindings::*;
-use crate::{Context, ContextHandle, Handle};
-use std::cell::{Ref, RefCell, RefMut};
+use crate::{Context, ContextHandle};
+use crate::ToResult;
+use rclrs_common::error::RclError;
 use std::ffi::CString;
-use std::rc::{Rc, Weak};
-use anyhow::Result;
+use std::sync::{Arc, Weak};
+
+use parking_lot::{Mutex, MutexGuard};
 
 pub mod publisher;
 pub use self::publisher::*;
 pub mod subscription;
 pub use self::subscription::*;
 
-pub struct NodeHandle(RefCell<rcl_node_t>);
+pub struct NodeHandle(Mutex<rcl_node_t>);
 
-impl<'a> Handle<rcl_node_t> for &'a NodeHandle {
-    type DerefT = Ref<'a, rcl_node_t>;
-    type DerefMutT = RefMut<'a, rcl_node_t>;
-
-    fn get(self) -> Self::DerefT {
-        self.0.borrow()
+impl NodeHandle {
+    pub fn get_mut(&mut self) -> &mut rcl_node_t {
+        self.0.get_mut()
     }
 
-    fn get_mut(self) -> Self::DerefMutT {
-        self.0.borrow_mut()
+    pub fn lock(&self) -> MutexGuard<rcl_node_t> {
+        self
+        .0
+        .lock()
+    }
+
+    pub fn try_lock(&self) -> Option<MutexGuard<rcl_node_t>> {
+        self
+        .0
+        .try_lock()
     }
 }
 
 impl Drop for NodeHandle {
     fn drop(&mut self) {
         let handle = &mut *self.get_mut();
-        unsafe {
-            rcl_node_fini(handle as *mut _).unwrap();
-        }
+        unsafe { rcl_node_fini(handle as *mut _).unwrap() };
     }
 }
 
 pub struct Node {
-    handle: Rc<NodeHandle>,
-    pub(crate) context: Rc<ContextHandle>,
+    handle: Arc<NodeHandle>,
+    pub(crate) context: Arc<ContextHandle>,
     pub(crate) subscriptions: Vec<Weak<dyn SubscriptionBase>>,
 }
 
 impl Node {
     #[allow(clippy::new_ret_no_self)]
-    pub fn new(node_name: &str, context: &Context) -> Result<Node, RclError> {
+    pub fn new<'ctxt>(node_name: &str, context: &Context) -> Result<Node, RclError> {
         Self::new_with_namespace(node_name, "", context)
     }
 
-    pub fn new_with_namespace(
+    pub fn new_with_namespace<'ctxt>(
         node_name: &str,
         node_ns: &str,
         context: &Context,
@@ -57,7 +61,7 @@ impl Node {
         let raw_node_ns = CString::new(node_ns).unwrap();
 
         let mut node_handle = unsafe { rcl_get_zero_initialized_node() };
-        let context_handle = &mut *context.handle.get_mut();
+        let context_handle = &mut *context.handle.lock();
 
         unsafe {
             let node_options = rcl_node_get_default_options();
@@ -71,7 +75,7 @@ impl Node {
             .ok()?;
         }
 
-        let handle = Rc::new(NodeHandle(RefCell::new(node_handle)));
+        let handle = Arc::new(NodeHandle(Mutex::new(node_handle)));
 
         Ok(Node {
             handle,
@@ -81,7 +85,11 @@ impl Node {
     }
 
     // TODO: make publisher's lifetime depend on node's lifetime
-    pub fn create_publisher<T>(&self, topic: &str, qos: QoSProfile) -> Result<Publisher<T>, RclError>
+    pub fn create_publisher<T>(
+        &self,
+        topic: &str,
+        qos: QoSProfile,
+    ) -> Result<Publisher<T>, RclError>
     where
         T: rclrs_common::traits::MessageDefinition<T>,
     {
@@ -94,14 +102,14 @@ impl Node {
         topic: &str,
         qos: QoSProfile,
         callback: F,
-    ) -> Result<Rc<Subscription<T>>, RclError>
+    ) -> Result<Arc<Subscription<T>>, RclError>
     where
         T: rclrs_common::traits::MessageDefinition<T> + Default,
         F: FnMut(&T) + Sized + 'static,
     {
-        let subscription = Rc::new(Subscription::<T>::new(self, topic, qos, callback)?);
+        let subscription = Arc::new(Subscription::<T>::new(self, topic, qos, callback)?);
         self.subscriptions
-            .push(Rc::downgrade(&subscription) as Weak<dyn SubscriptionBase>);
+            .push(Arc::downgrade(&subscription) as Weak<dyn SubscriptionBase>);
         Ok(subscription)
     }
 }

--- a/rclrs/src/node/publisher.rs
+++ b/rclrs/src/node/publisher.rs
@@ -21,21 +21,15 @@ impl PublisherHandle {
     }
 
     fn get_mut(&mut self) -> &mut rcl_publisher_t {
-        self
-        .handle
-        .get_mut()
+        self.handle.get_mut()
     }
 
     fn lock(&self) -> MutexGuard<rcl_publisher_t> {
-        self
-        .handle
-        .lock()
+        self.handle.lock()
     }
 
     fn try_lock(&self) -> Option<MutexGuard<rcl_publisher_t>> {
-        self
-        .handle
-        .try_lock()
+        self.handle.try_lock()
     }
 }
 

--- a/rclrs/src/node/publisher.rs
+++ b/rclrs/src/node/publisher.rs
@@ -1,42 +1,48 @@
-use crate::error::{RclError, ToResult};
+use crate::error::ToResult;
 use crate::qos::QoSProfile;
-use crate::{Handle, Node, NodeHandle};
 use crate::rcl_bindings::*;
+use crate::{Node, NodeHandle};
+use rclrs_common::error::RclError;
 use std::borrow::Borrow;
-use std::cell::{Ref, RefCell, RefMut};
 use std::ffi::CString;
 use std::marker::PhantomData;
-use std::rc::Rc;
-use anyhow::Result;
+use std::sync::Arc;
+
+use parking_lot::{Mutex, MutexGuard};
 
 pub struct PublisherHandle {
-    handle: RefCell<rcl_publisher_t>,
-    node_handle: Rc<NodeHandle>,
+    handle: Mutex<rcl_publisher_t>,
+    node_handle: Arc<NodeHandle>,
 }
 
 impl PublisherHandle {
     fn node_handle(&self) -> &NodeHandle {
         self.node_handle.borrow()
     }
-}
 
-impl<'a> Handle<rcl_publisher_t> for &'a PublisherHandle {
-    type DerefT = Ref<'a, rcl_publisher_t>;
-    type DerefMutT = RefMut<'a, rcl_publisher_t>;
-
-    fn get(self) -> Self::DerefT {
-        self.handle.borrow()
+    fn get_mut(&mut self) -> &mut rcl_publisher_t {
+        self
+        .handle
+        .get_mut()
     }
 
-    fn get_mut(self) -> Self::DerefMutT {
-        self.handle.borrow_mut()
+    fn lock(&self) -> MutexGuard<rcl_publisher_t> {
+        self
+        .handle
+        .lock()
+    }
+
+    fn try_lock(&self) -> Option<MutexGuard<rcl_publisher_t>> {
+        self
+        .handle
+        .try_lock()
     }
 }
 
 impl Drop for PublisherHandle {
     fn drop(&mut self) {
-        let handle = &mut *self.get_mut();
-        let node_handle = &mut *self.node_handle().get_mut();
+        let handle = self.handle.get_mut();
+        let node_handle = &mut *self.node_handle.lock();
         unsafe {
             rcl_publisher_fini(handle as *mut _, node_handle as *mut _);
         }
@@ -48,7 +54,7 @@ pub struct Publisher<T>
 where
     T: rclrs_common::traits::MessageDefinition<T>,
 {
-    pub handle: Rc<PublisherHandle>,
+    pub handle: Arc<PublisherHandle>,
     message: PhantomData<T>,
 }
 
@@ -63,7 +69,7 @@ where
         let mut publisher_handle = unsafe { rcl_get_zero_initialized_publisher() };
         let type_support = T::get_type_support() as *const rosidl_message_type_support_t;
         let topic_c_string = CString::new(topic).unwrap();
-        let node_handle = &mut *node.handle.get_mut();
+        let node_handle = &mut *node.handle.lock();
 
         unsafe {
             let mut publisher_options = rcl_publisher_get_default_options();
@@ -79,8 +85,8 @@ where
             .ok()?;
         }
 
-        let handle = Rc::new(PublisherHandle {
-            handle: RefCell::new(publisher_handle),
+        let handle = Arc::new(PublisherHandle {
+            handle: Mutex::new(publisher_handle),
             node_handle: node.handle.clone(),
         });
 
@@ -92,8 +98,14 @@ where
 
     pub fn publish(&self, message: &T) -> Result<(), RclError> {
         let native_message_ptr = message.get_native_message();
-        let handle = &mut *self.handle.get_mut();
-        let ret = unsafe { rcl_publish(handle as *mut _, native_message_ptr as *mut _, std::ptr::null_mut()) };
+        let handle = &mut *self.handle.lock();
+        let ret = unsafe {
+            rcl_publish(
+                handle as *mut _,
+                native_message_ptr as *mut _,
+                std::ptr::null_mut(),
+            )
+        };
         message.destroy_native_message(native_message_ptr);
         ret.ok()
     }

--- a/rclrs/src/node/subscription.rs
+++ b/rclrs/src/node/subscription.rs
@@ -1,43 +1,48 @@
 use crate::error::{RclError, ToResult};
 use crate::qos::QoSProfile;
-use crate::{Handle, Node, NodeHandle};
 use crate::rcl_bindings::*;
+use crate::{Node, NodeHandle};
+use rclrs_common::error::to_rcl_result;
 use std::borrow::Borrow;
-use std::cell::{Ref, RefCell, RefMut};
 use std::ffi::CString;
 use std::marker::PhantomData;
-use std::rc::Rc;
-use anyhow::Result;
-use rclrs_common::error::to_rcl_result;
+use std::sync::Arc;
+
+use parking_lot::{Mutex, MutexGuard};
 
 pub struct SubscriptionHandle {
-    handle: RefCell<rcl_subscription_t>,
-    node_handle: Rc<NodeHandle>,
+    handle: Mutex<rcl_subscription_t>,
+    node_handle: Arc<NodeHandle>,
 }
 
 impl SubscriptionHandle {
     fn node_handle(&self) -> &NodeHandle {
         self.node_handle.borrow()
     }
-}
 
-impl<'a> Handle<rcl_subscription_t> for &'a SubscriptionHandle {
-    type DerefT = Ref<'a, rcl_subscription_t>;
-    type DerefMutT = RefMut<'a, rcl_subscription_t>;
-
-    fn get(self) -> Self::DerefT {
-        self.handle.borrow()
+    pub fn get_mut(&mut self) -> &mut rcl_subscription_t {
+        self
+        .handle
+        .get_mut()
     }
 
-    fn get_mut(self) -> Self::DerefMutT {
-        self.handle.borrow_mut()
+    pub fn lock(&self) -> MutexGuard<rcl_subscription_t> {
+        self
+        .handle
+        .lock()
+    }
+
+    pub fn try_lock(&self) -> Option<MutexGuard<rcl_subscription_t>> {
+        self
+        .handle
+        .try_lock()
     }
 }
 
 impl Drop for SubscriptionHandle {
     fn drop(&mut self) {
-        let handle = &mut *self.get_mut();
-        let node_handle = &mut *self.node_handle().get_mut();
+        let handle = self.handle.get_mut();
+        let node_handle = &mut *self.node_handle.lock();
         unsafe {
             rcl_subscription_fini(handle as *mut _, node_handle as *mut _);
         }
@@ -67,7 +72,7 @@ pub trait SubscriptionBase {
     /// |  rmw_take   |
     /// +-------------+
     fn take(&self, message: &mut dyn rclrs_common::traits::Message) -> Result<bool, RclError> {
-        let handle = &*self.handle().get();
+        let handle = &mut *self.handle().lock();
         let message_handle = message.get_native_message();
 
         let result = unsafe {
@@ -75,7 +80,7 @@ pub trait SubscriptionBase {
                 handle as *const _,
                 message_handle as *mut _,
                 std::ptr::null_mut(),
-                std::ptr::null_mut()
+                std::ptr::null_mut(),
             )
         };
 
@@ -85,7 +90,7 @@ pub trait SubscriptionBase {
                 Ok(true)
             }
             Err(RclError::SubscriptionTakeFailed) => Ok(false),
-            Err(error) => Err(error),
+            Err(error) => Err(error.into()),
         };
 
         message.destroy_native_message(message_handle);
@@ -99,9 +104,9 @@ pub struct Subscription<T>
 where
     T: rclrs_common::traits::Message,
 {
-    pub handle: Rc<SubscriptionHandle>,
+    pub handle: Arc<SubscriptionHandle>,
     // The callback's lifetime should last as long as we need it to
-    pub callback: RefCell<Box<dyn FnMut(&T) + 'static>>,
+    pub callback: Mutex<Box<dyn FnMut(&T) + 'static>>,
     message: PhantomData<T>,
 }
 
@@ -117,7 +122,7 @@ where
         let mut subscription_handle = unsafe { rcl_get_zero_initialized_subscription() };
         let type_support = T::get_type_support() as *const rosidl_message_type_support_t;
         let topic_c_string = CString::new(topic).unwrap();
-        let node_handle = &mut *node.handle.get_mut();
+        let node_handle = &mut *node.handle.lock();
 
         unsafe {
             let mut subscription_options = rcl_subscription_get_default_options();
@@ -132,37 +137,38 @@ where
             .ok()?;
         }
 
-        let handle = Rc::new(SubscriptionHandle {
-            handle: RefCell::new(subscription_handle),
+        let handle = Arc::new(SubscriptionHandle {
+            handle: Mutex::new(subscription_handle),
             node_handle: node.handle.clone(),
         });
 
         Ok(Self {
             handle,
-            callback: RefCell::new(Box::new(callback)),
+            callback: Mutex::new(Box::new(callback)),
             message: PhantomData,
         })
     }
 
     pub fn take(&self, message: &mut T) -> Result<(), RclError> {
-        let handle = &*self.handle.get();
+        let handle = &mut *self.handle.lock();
         let message_handle = message.get_native_message();
         let ret = unsafe {
             rcl_take(
                 handle as *const _,
                 message_handle as *mut _,
                 std::ptr::null_mut(),
-                std::ptr::null_mut()
+                std::ptr::null_mut(),
             )
         };
         message.read_handle(message_handle);
         message.destroy_native_message(message_handle);
-        ret.ok()
+        ret.ok().map_err(|err| err.into())
     }
 
-    fn callback_ext(&self, message: Box<dyn rclrs_common::traits::Message>) {
+    fn callback_ext(&self, message: Box<dyn rclrs_common::traits::Message>) ->Result<(), RclError> {
         let msg = message.downcast_ref::<T>().unwrap();
-        (&mut *self.callback.borrow_mut())(msg);
+        (&mut *self.callback.lock())(msg);
+        Ok(())
     }
 }
 

--- a/rclrs/src/node/subscription.rs
+++ b/rclrs/src/node/subscription.rs
@@ -21,21 +21,15 @@ impl SubscriptionHandle {
     }
 
     pub fn get_mut(&mut self) -> &mut rcl_subscription_t {
-        self
-        .handle
-        .get_mut()
+        self.handle.get_mut()
     }
 
     pub fn lock(&self) -> MutexGuard<rcl_subscription_t> {
-        self
-        .handle
-        .lock()
+        self.handle.lock()
     }
 
     pub fn try_lock(&self) -> Option<MutexGuard<rcl_subscription_t>> {
-        self
-        .handle
-        .try_lock()
+        self.handle.try_lock()
     }
 }
 
@@ -165,7 +159,10 @@ where
         ret.ok().map_err(|err| err.into())
     }
 
-    fn callback_ext(&self, message: Box<dyn rclrs_common::traits::Message>) ->Result<(), RclError> {
+    fn callback_ext(
+        &self,
+        message: Box<dyn rclrs_common::traits::Message>,
+    ) -> Result<(), RclError> {
         let msg = message.downcast_ref::<T>().unwrap();
         (&mut *self.callback.lock())(msg);
         Ok(())

--- a/rclrs/src/qos.rs
+++ b/rclrs/src/qos.rs
@@ -86,7 +86,7 @@ impl From<QoSProfile> for rmw_qos_profile_t {
             avoid_ros_namespace_conventions: qos.avoid_ros_namespace_conventions,
             deadline: rmw_time_t { sec: 0, nsec: 0 },
             lifespan: rmw_time_t { sec: 0, nsec: 0 },
-            liveliness_lease_duration: rmw_time_t { sec: 0, nsec: 0},
+            liveliness_lease_duration: rmw_time_t { sec: 0, nsec: 0 },
             liveliness: rmw_qos_liveliness_policy_t::RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT,
         }
     }

--- a/rclrs/src/wait.rs
+++ b/rclrs/src/wait.rs
@@ -16,14 +16,12 @@
 // OPSEC #4584.
 
 use std::borrow::BorrowMut;
-use std::rc::Weak;
+use std::sync::Weak;
 
-use crate::Handle;
 use crate::{error::*, SubscriptionBase};
 
 use crate::rcl_bindings::*;
 
-use anyhow::Result;
 use rclrs_common::error::WaitSetError;
 
 pub struct WaitSet {
@@ -101,7 +99,7 @@ impl WaitSet {
         subscription: &Weak<dyn SubscriptionBase>,
     ) -> Result<(), WaitSetError> {
         if let Some(subscription) = subscription.upgrade() {
-            let subscription_handle = &*subscription.handle().get();
+            let subscription_handle = &mut *subscription.handle().lock();
             unsafe {
                 return to_rcl_result(rcl_wait_set_add_subscription(
                     self.wait_set.borrow_mut() as *mut _,

--- a/rclrs_common/src/lib.rs
+++ b/rclrs_common/src/lib.rs
@@ -3,8 +3,6 @@ pub mod error {
 
     #[derive(Debug, Error)]
     pub enum RclError {
-        // #[error("Success")]
-        // Ok,
         #[error("Unspecified Error")]
         Error,
         #[error("Timeout occurred")]

--- a/rclrs_common/src/lib.rs
+++ b/rclrs_common/src/lib.rs
@@ -64,7 +64,7 @@ pub mod error {
         #[error("Argument is not a valid log level")]
         InvalidLogLevelRule,
         #[error("Unknown RCL return code: {0}")]
-        UnknownError(i32)
+        UnknownError(i32),
     }
 
     pub fn to_rcl_result(error_id: i32) -> Result<(), RclError> {
@@ -100,7 +100,7 @@ pub mod error {
             1002 => Err(RclError::WrongLexeme),
             1010 => Err(RclError::InvalidParamRule),
             1020 => Err(RclError::InvalidLogLevelRule),
-            unrecognized => Err(RclError::UnknownError(unrecognized))
+            unrecognized => Err(RclError::UnknownError(unrecognized)),
         }
     }
 
@@ -109,7 +109,7 @@ pub mod error {
         #[error("Passed subscription was dropped")]
         DroppedSubscription,
         #[error("Rcl error occurred")]
-        RclError (#[from] RclError)
+        RclError(#[from] RclError),
     }
 }
 

--- a/rclrs_examples/src/rclrs_publisher.rs
+++ b/rclrs_examples/src/rclrs_publisher.rs
@@ -14,7 +14,7 @@ fn main() -> Result<(), Error>{
 
     let mut publish_count: u32 = 1;
 
-    while context.ok() {
+    while context.ok()? {
         message.data = format!("Hello, world! {}", publish_count);
         println!("Publishing: [{}]", message.data);
         publisher.publish(&message)?;

--- a/rclrs_examples/src/rclrs_publisher.rs
+++ b/rclrs_examples/src/rclrs_publisher.rs
@@ -1,8 +1,8 @@
-use anyhow::{Result, Error};
+use anyhow::{Error, Result};
 use rclrs;
 use std_msgs;
 
-fn main() -> Result<(), Error>{
+fn main() -> Result<(), Error> {
     let context = rclrs::Context::default();
 
     let node = context.create_node("minimal_publisher")?;
@@ -24,4 +24,3 @@ fn main() -> Result<(), Error>{
 
     Ok(())
 }
-

--- a/rclrs_examples/src/rclrs_subscriber.rs
+++ b/rclrs_examples/src/rclrs_subscriber.rs
@@ -19,8 +19,5 @@ fn main() -> Result<(), Error> {
         },
     )?;
 
-    match rclrs::spin(&node) {
-        Ok(()) => Ok(()),
-        Err(RclError) => Err(anyhow::Error::from(RclError)),
-    }
+    rclrs::spin(&node).map_err(|err| err.into())
 }


### PR DESCRIPTION
Closes #50

This PR replaces the `Rc` and `RefCell` usages with `Arc` and `parking_lot::Mutex`, respectively.

This PR does **NOT** implement a multithreaded spinner - this is just work to make such a spinner easier to implement in future.