### PR TITLE
Fix missing Dockerfile ARG, Update Rust to 1.49.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN apt-get update && apt-get install -q -y \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.47.0
+    RUST_VERSION=1.49.0
 RUN set -eux; \
     wget -O rustup-init "https://sh.rustup.rs"; \
     chmod +x rustup-init; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ FROM $FROM_IMAGE AS cacher
 
 # clone overlay source
 ARG OVERLAY_WS
+ARG REPOS_FILE
 WORKDIR $OVERLAY_WS/src
 COPY ./${REPOS_FILE} ../
 RUN vcs import ./ < ../${REPOS_FILE} && \


### PR DESCRIPTION
Docker ARG REPOS_FILE was not redeclared in the "cacher" build stage,
and so was not inheriting the default value specified at the top of the
file. This redeclares the arg in the "cacher" build stage, so that the
default value may be used.

On the specified version of Rust in the Dockerfile (1.47.0), a build error was encountered in rclrs_examples
```
   error[E0658]: use of unstable library feature 'renamed_spin_loop'
      --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/spin-0.9.2/src/relax.rs:26:9
       |
    26 |         core::hint::spin_loop();
       |         ^^^^^^^^^^^^^^^^^^^^^
       |
       = note: see issue #55002 <https://github.com/rust-lang/rust/issues/55002> for more information
    
       Compiling bitvec v0.19.5
    error: aborting due to previous error
```
As seen at the given link, updating Rust resolves the issue. 1.48.0 also had build failures, but 1.49.0 passed.