### PR TITLE
Update rust to 1.57.0 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN apt-get update && apt-get install -q -y \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.57.0
+    RUST_VERSION=1.58.0
 RUN set -eux; \
     wget -O rustup-init "https://sh.rustup.rs"; \
     chmod +x rustup-init; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN apt-get update && apt-get install -q -y \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.49.0
+    RUST_VERSION=1.57.0
 RUN set -eux; \
     wget -O rustup-init "https://sh.rustup.rs"; \
     chmod +x rustup-init; \


### PR DESCRIPTION
Fixes #69 and building rclrs with rclrs_examples.

Currently, in master instructions to build and run things from Dockerfile will not work.