### PR TITLE
Disable layout tests generated by bindgen

### DIFF
--- a/rclrs/build.rs
+++ b/rclrs/build.rs
@@ -22,6 +22,7 @@ fn main() {
         .allowlist_var("rcl_.*")
         .allowlist_var("rmw_.*")
         .allowlist_var("rcutils_.*")
+        .layout_tests(false)
         .size_t_is_usize(true)
         .default_enum_style(bindgen::EnumVariation::Rust {
             non_exhaustive: false,


### PR DESCRIPTION
These tests have undefined behavior, which makes `cargo tests` produce lots of warnings. For example:

```
warning: dereferencing a null pointer
    --> /home/nikolai.morin/ros2_rust/rclrs/target/debug/build/rclrs-ed1bf17021230abe/out/rcl_bindings_generated.rs:6261:19
     |
6261 |         unsafe { &(*(::core::ptr::null::<rcl_wait_set_t>())).size_of_events as *const _ as usize },
     |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this code causes undefined behavior when executed
```