### PR TITLE
Give subscription callback the owned message

### DIFF
--- a/rclrs/src/node/mod.rs
+++ b/rclrs/src/node/mod.rs
@@ -102,8 +102,8 @@ impl Node {
         callback: F,
     ) -> Result<Arc<Subscription<T>>, RclReturnCode>
     where
-        T: Message + 'static,
-        F: FnMut(&T) + Sized + 'static,
+        T: Message,
+        F: FnMut(T) + Sized + 'static,
     {
         let subscription = Arc::new(Subscription::<T>::new(self, topic, qos, callback)?);
         self.subscriptions

--- a/rclrs/src/node/subscription.rs
+++ b/rclrs/src/node/subscription.rs
@@ -50,7 +50,7 @@ where
 {
     pub handle: Arc<SubscriptionHandle>,
     // The callback's lifetime should last as long as we need it to
-    pub callback: Mutex<Box<dyn FnMut(&T) + 'static>>,
+    pub callback: Mutex<Box<dyn FnMut(T) + 'static>>,
     message: PhantomData<T>,
 }
 
@@ -66,7 +66,7 @@ where
     ) -> Result<Self, RclReturnCode>
     where
         T: Message,
-        F: FnMut(&T) + Sized + 'static,
+        F: FnMut(T) + Sized + 'static,
     {
         let mut subscription_handle = unsafe { rcl_get_zero_initialized_subscription() };
         let type_support =
@@ -148,7 +148,7 @@ where
             }
             Err(e) => return Err(e),
         };
-        (*self.callback.lock())(&msg);
+        (*self.callback.lock())(msg);
         Ok(())
     }
 }

--- a/rclrs_examples/src/message_demo.rs
+++ b/rclrs_examples/src/message_demo.rs
@@ -128,13 +128,13 @@ fn demonstrate_pubsub() -> Result<(), Error> {
         .create_subscription::<rclrs_example_msgs::msg::VariousTypes, _>(
             "topic",
             rclrs::QOS_PROFILE_DEFAULT,
-            move |_msg: &rclrs_example_msgs::msg::VariousTypes| println!("Got idiomatic message!"),
+            move |_msg: rclrs_example_msgs::msg::VariousTypes| println!("Got idiomatic message!"),
         )?;
     let _direct_subscription = node
         .create_subscription::<rclrs_example_msgs::msg::rmw::VariousTypes, _>(
             "topic",
             rclrs::QOS_PROFILE_DEFAULT,
-            move |_msg: &rclrs_example_msgs::msg::rmw::VariousTypes| {
+            move |_msg: rclrs_example_msgs::msg::rmw::VariousTypes| {
                 println!("Got RMW-compatible message!")
             },
         )?;

--- a/rclrs_examples/src/minimal_subscriber.rs
+++ b/rclrs_examples/src/minimal_subscriber.rs
@@ -12,7 +12,7 @@ fn main() -> Result<(), Error> {
     let _subscription = node.create_subscription::<std_msgs::msg::String, _>(
         "topic",
         rclrs::QOS_PROFILE_DEFAULT,
-        move |msg: &std_msgs::msg::String| {
+        move |msg: std_msgs::msg::String| {
             num_messages += 1;
             println!("I heard: '{}'", msg.data);
             println!("(Got {} messages so far)", num_messages);

--- a/rosidl_runtime_rs/Cargo.toml
+++ b/rosidl_runtime_rs/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 path = "src/lib.rs"
 
 [dependencies]
-downcast-rs = "1.2.0"
 libc = "0.2"
 
 [dev-dependencies]


### PR DESCRIPTION
This enables efficiency and ergonomics improvements: for instance, think of a node that takes incoming messages and mutates them, then re-publishes them. Or alternatively, a node could move (part of) the message into a new message to be published. When the received message is owned, this can be done with fewer copies. There is no drawback to this, since the message is already not used anymore after the callback. 

Also remove unused dependency from rosidl_runtime_rs