### PR TITLE
Bump every package to version 0.2

### DIFF
--- a/rclrs/Cargo.toml
+++ b/rclrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rclrs"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Esteve Fernandez <esteve@apache.org>"]
 edition = "2021"
 

--- a/rclrs/package.xml
+++ b/rclrs/package.xml
@@ -4,7 +4,7 @@
    schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rclrs</name>
-  <version>0.0.3</version>
+  <version>0.2.0</version>
   <description>Package containing the Rust client.</description>
   <maintainer email="esteve@apache.org">Esteve Fernandez</maintainer>
   <license>Apache License 2.0</license>

--- a/rclrs_example_msgs/package.xml
+++ b/rclrs_example_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rclrs_example_msgs</name>
-  <version>2.0.5</version>
+  <version>0.2.0</version>
   <description>A package containing some example message definitions.</description>
   <maintainer email="nnmmgit@gmail.com">Nikolai Morin</maintainer>
   <license>Apache License 2.0</license>

--- a/rclrs_examples/Cargo.toml
+++ b/rclrs_examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rclrs_examples"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Esteve Fernandez <esteve@apache.org>"]
 edition = "2021"
 

--- a/rclrs_examples/package.xml
+++ b/rclrs_examples/package.xml
@@ -4,7 +4,7 @@
    schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rclrs_examples</name>
-  <version>0.0.0</version>
+  <version>0.2.0</version>
   <description>Package containing examples of how to use the rclrs API.</description>
   <maintainer email="esteve@apache.org">Esteve Fernandez</maintainer>
   <license>Apache License 2.0</license>

--- a/rosidl_generator_rs/package.xml
+++ b/rosidl_generator_rs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosidl_generator_rs</name>
-  <version>0.0.4</version>
+  <version>0.2.0</version>
   <description>Generate the ROS interfaces in Rust.</description>
   <maintainer email="esteve@apache.org">Esteve Fernandez</maintainer>
   <license>Apache License 2.0</license>

--- a/rosidl_generator_rs/resource/Cargo.toml.in
+++ b/rosidl_generator_rs/resource/Cargo.toml.in
@@ -1,6 +1,6 @@
 [package]
 name = "@PROJECT_NAME@"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/rosidl_runtime_rs/Cargo.toml
+++ b/rosidl_runtime_rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rosidl_runtime_rs"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Jacob Hassold <jhassold@dcscorp.com>", "Nikolai Morin <nnmmgit@gmail.com>"]
 edition = "2021"
 

--- a/rosidl_runtime_rs/package.xml
+++ b/rosidl_runtime_rs/package.xml
@@ -4,7 +4,7 @@
    schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosidl_runtime_rs</name>
-  <version>0.0.1</version>
+  <version>0.2.0</version>
   <description>Message generation code shared by Rust projects in ROS 2</description>
   <maintainer email="jhassold@dcscorp.com">Jacob Hassold</maintainer>
   <maintainer email="nnmmgit@gmail.com">Nikolai Morin</maintainer>


### PR DESCRIPTION
The reason for the "bump" is to have a consistent version numbering across packages, not because it's needed for a release.