### PR TITLE
Remove NodeHandle struct

### DIFF
--- a/rclrs/src/node/publisher.rs
+++ b/rclrs/src/node/publisher.rs
@@ -1,7 +1,7 @@
 use crate::error::{RclReturnCode, ToResult};
 use crate::qos::QoSProfile;
 use crate::rcl_bindings::*;
-use crate::{Node, NodeHandle};
+use crate::Node;
 use alloc::sync::Arc;
 use core::marker::PhantomData;
 use cstr_core::CString;
@@ -16,7 +16,7 @@ use parking_lot::{Mutex, MutexGuard};
 
 pub(crate) struct PublisherHandle {
     handle: Mutex<rcl_publisher_t>,
-    node_handle: Arc<NodeHandle>,
+    node_handle: Arc<Mutex<rcl_node_t>>,
 }
 
 impl PublisherHandle {

--- a/rclrs/src/node/subscription.rs
+++ b/rclrs/src/node/subscription.rs
@@ -1,7 +1,7 @@
 use crate::error::{SubscriberErrorCode, ToResult};
 use crate::qos::QoSProfile;
+use crate::Node;
 use crate::{rcl_bindings::*, RclReturnCode};
-use crate::{Node, NodeHandle};
 use alloc::boxed::Box;
 use alloc::sync::Arc;
 use core::borrow::Borrow;
@@ -17,7 +17,7 @@ use parking_lot::{Mutex, MutexGuard};
 
 pub struct SubscriptionHandle {
     handle: Mutex<rcl_subscription_t>,
-    node_handle: Arc<NodeHandle>,
+    node_handle: Arc<Mutex<rcl_node_t>>,
 }
 
 impl SubscriptionHandle {


### PR DESCRIPTION
This is a small simplification that makes it (imo) easier to see what's going on, besides making the code a little smaller.