### PR TITLE
Fix timeout_ns set value when None is passed to timeout param

### DIFF
--- a/rclrs/src/wait.rs
+++ b/rclrs/src/wait.rs
@@ -150,7 +150,7 @@ impl WaitSet {
     /// [1]: std::time::Duration::ZERO
     pub fn wait(&mut self, timeout: Option<Duration>) -> Result<ReadyEntities, RclReturnCode> {
         let timeout_ns = match timeout.map(|d| d.as_nanos()) {
-            None => 0,
+            None => -1,
             Some(ns) if ns <= i64::MAX as u128 => ns as i64,
             _ => {
                 return Err(RclReturnCode::InvalidArgument);


### PR DESCRIPTION
Fix #104 

`rcl_wait` requires negative value if procedure wants to
block thread indefinitely until some messages are passed.
However, in current implementation, `timeout_ns` is set to zero,
even if `timeout` param is `None`, and this results in
making `rcl_wait` non-blocking function ( returns immediately ).

To make it correctly, I fixed to set `timeout_ns` to `-1` if `timeout` param is `None`.