### PR TITLE
Removed support for no_std

### DIFF
--- a/rclrs/Cargo.toml
+++ b/rclrs/Cargo.toml
@@ -13,8 +13,7 @@ lock_api = "0.4.5"
 cstr_core = "0.2"
 cty = "0.2"
 core-error = "0.0.0"
-parking_lot = {version = "0.11.2", optional = true}
-spin = "0.9.2"
+parking_lot = "0.11.2"
 downcast = "0.10.0"
 
 [dependencies.rosidl_runtime_rs]
@@ -22,7 +21,3 @@ version = "*"
 
 [build-dependencies]
 bindgen = "0.59.1"
-
-[features]
-default = ["std"]
-std = ["parking_lot"]

--- a/rclrs/Cargo.toml
+++ b/rclrs/Cargo.toml
@@ -10,7 +10,6 @@ path = "src/lib.rs"
 [dependencies]
 libc = "0.2.43"
 parking_lot = "0.11.2"
-downcast = "0.10.0"
 
 [dependencies.rosidl_runtime_rs]
 version = "*"

--- a/rclrs/Cargo.toml
+++ b/rclrs/Cargo.toml
@@ -9,10 +9,6 @@ path = "src/lib.rs"
 
 [dependencies]
 libc = "0.2.43"
-lock_api = "0.4.5"
-cstr_core = "0.2"
-cty = "0.2"
-core-error = "0.0.0"
 parking_lot = "0.11.2"
 downcast = "0.10.0"
 

--- a/rclrs/build.rs
+++ b/rclrs/build.rs
@@ -9,8 +9,6 @@ const AMENT_PREFIX_PATH: &str = "AMENT_PREFIX_PATH";
 fn main() {
     let mut builder = bindgen::Builder::default()
         .header("src/rcl_wrapper.h")
-        .use_core()
-        .ctypes_prefix("cty")
         .derive_copy(false)
         .allowlist_recursively(true)
         .allowlist_type("rcl_.*")

--- a/rclrs/src/context.rs
+++ b/rclrs/src/context.rs
@@ -1,12 +1,13 @@
 use crate::rcl_bindings::*;
 use crate::{Node, RclReturnCode, ToResult};
-use alloc::sync::Arc;
-use alloc::vec::Vec;
-use std::string::String;
 
-use cty::c_char;
-use parking_lot::Mutex;
 use std::ffi::CString;
+use std::os::raw::c_char;
+use std::string::String;
+use std::sync::Arc;
+use std::vec::Vec;
+
+use parking_lot::Mutex;
 
 impl Drop for rcl_context_t {
     fn drop(&mut self) {

--- a/rclrs/src/context.rs
+++ b/rclrs/src/context.rs
@@ -4,16 +4,8 @@ use alloc::sync::Arc;
 use alloc::vec::Vec;
 use std::string::String;
 
-#[cfg(not(feature = "std"))]
-use cstr_core::{c_char, CString};
-#[cfg(not(feature = "std"))]
-use spin::Mutex;
-
-#[cfg(feature = "std")]
 use cty::c_char;
-#[cfg(feature = "std")]
 use parking_lot::Mutex;
-#[cfg(feature = "std")]
 use std::ffi::CString;
 
 impl Drop for rcl_context_t {

--- a/rclrs/src/error.rs
+++ b/rclrs/src/error.rs
@@ -613,7 +613,7 @@ impl ToResult for rcl_ret_t {
 
 #[cfg(test)]
 mod tests {
-    use core::convert::TryFrom;
+    use std::convert::TryFrom;
 
     use crate::error::{
         ClientErrorCode, EventErrorCode, LifecycleErrorCode, NodeErrorCode, ParsingErrorCode,

--- a/rclrs/src/error.rs
+++ b/rclrs/src/error.rs
@@ -1,9 +1,7 @@
 use crate::rcl_bindings::*;
-use core::{
-    convert::TryFrom,
-    fmt::{self, Display},
-};
-use core_error::{self, Error};
+use std::convert::TryFrom;
+use std::error::Error;
+use std::fmt::{self, Display};
 
 /// RCL specific error codes.
 ///

--- a/rclrs/src/error.rs
+++ b/rclrs/src/error.rs
@@ -1,5 +1,4 @@
 use crate::rcl_bindings::*;
-use std::convert::TryFrom;
 use std::error::Error;
 use std::fmt::{self, Display};
 
@@ -613,8 +612,6 @@ impl ToResult for rcl_ret_t {
 
 #[cfg(test)]
 mod tests {
-    use std::convert::TryFrom;
-
     use crate::error::{
         ClientErrorCode, EventErrorCode, LifecycleErrorCode, NodeErrorCode, ParsingErrorCode,
         RclErrorCode, RclReturnCode, ServiceErrorCode, SubscriberErrorCode, TimerErrorCode,

--- a/rclrs/src/lib.rs
+++ b/rclrs/src/lib.rs
@@ -1,4 +1,3 @@
-#![no_std]
 #![warn(missing_docs)]
 //! Rust client library for ROS2.
 //!
@@ -9,23 +8,17 @@
 extern crate alloc;
 extern crate core_error;
 extern crate downcast;
+extern crate parking_lot;
 extern crate rosidl_runtime_rs;
-
-#[cfg(feature = "std")]
 extern crate std;
 
-#[cfg(feature = "std")]
-extern crate parking_lot;
+pub mod context;
+pub mod error;
+pub mod node;
+pub mod qos;
+pub mod wait;
 
-#[cfg(not(feature = "std"))]
-extern crate spin;
-
-mod context;
-mod error;
-mod node;
-mod qos;
 mod rcl_bindings;
-mod wait;
 
 pub use context::*;
 pub use error::*;

--- a/rclrs/src/lib.rs
+++ b/rclrs/src/lib.rs
@@ -6,7 +6,6 @@
 //! [1]: https://github.com/ros2-rust/ros2_rust/blob/master/README.md
 
 extern crate alloc;
-extern crate core_error;
 extern crate downcast;
 extern crate parking_lot;
 extern crate rosidl_runtime_rs;

--- a/rclrs/src/lib.rs
+++ b/rclrs/src/lib.rs
@@ -5,8 +5,6 @@
 //!
 //! [1]: https://github.com/ros2-rust/ros2_rust/blob/master/README.md
 
-extern crate alloc;
-extern crate downcast;
 extern crate parking_lot;
 extern crate rosidl_runtime_rs;
 extern crate std;

--- a/rclrs/src/lib.rs
+++ b/rclrs/src/lib.rs
@@ -9,11 +9,11 @@ extern crate parking_lot;
 extern crate rosidl_runtime_rs;
 extern crate std;
 
-pub mod context;
-pub mod error;
-pub mod node;
-pub mod qos;
-pub mod wait;
+mod context;
+mod error;
+mod node;
+mod qos;
+mod wait;
 
 mod rcl_bindings;
 

--- a/rclrs/src/node/mod.rs
+++ b/rclrs/src/node/mod.rs
@@ -17,11 +17,7 @@ mod subscription;
 pub use self::publisher::*;
 pub use self::subscription::*;
 
-#[cfg(not(feature = "std"))]
-use spin::Mutex;
-
-#[cfg(feature = "std")]
-use parking_lot::Mutex;
+use parking_lot::{Mutex, MutexGuard};
 
 impl Drop for rcl_node_t {
     fn drop(&mut self) {

--- a/rclrs/src/node/mod.rs
+++ b/rclrs/src/node/mod.rs
@@ -1,23 +1,20 @@
-use alloc::{
-    sync::{Arc, Weak},
-    vec::Vec,
-};
-
 use crate::error::{RclReturnCode, ToResult};
 use crate::qos::QoSProfile;
 use crate::rcl_bindings::*;
 use crate::Context;
 
-use rosidl_runtime_rs::Message;
-
-use cstr_core::CString;
-
-mod publisher;
+pub mod publisher;
 mod subscription;
 pub use self::publisher::*;
 pub use self::subscription::*;
 
-use parking_lot::{Mutex, MutexGuard};
+use std::ffi::CString;
+use std::sync::{Arc, Weak};
+use std::vec::Vec;
+
+use parking_lot::Mutex;
+
+use rosidl_runtime_rs::Message;
 
 impl Drop for rcl_node_t {
     fn drop(&mut self) {

--- a/rclrs/src/node/mod.rs
+++ b/rclrs/src/node/mod.rs
@@ -84,7 +84,7 @@ impl Node {
         Ok(Node {
             handle,
             context: context.handle.clone(),
-            subscriptions: alloc::vec![],
+            subscriptions: std::vec![],
         })
     }
 

--- a/rclrs/src/node/mod.rs
+++ b/rclrs/src/node/mod.rs
@@ -3,7 +3,7 @@ use crate::qos::QoSProfile;
 use crate::rcl_bindings::*;
 use crate::Context;
 
-pub mod publisher;
+mod publisher;
 mod subscription;
 pub use self::publisher::*;
 pub use self::subscription::*;

--- a/rclrs/src/node/publisher.rs
+++ b/rclrs/src/node/publisher.rs
@@ -127,7 +127,7 @@ where
             rcl_publish(
                 handle as *mut _,
                 rmw_message.as_ref() as *const <T as Message>::RmwMsg as *mut _,
-                core::ptr::null_mut(),
+                std::ptr::null_mut(),
             )
         };
         ret.ok()

--- a/rclrs/src/node/publisher.rs
+++ b/rclrs/src/node/publisher.rs
@@ -2,13 +2,15 @@ use crate::error::{RclReturnCode, ToResult};
 use crate::qos::QoSProfile;
 use crate::rcl_bindings::*;
 use crate::Node;
-use alloc::sync::Arc;
-use core::marker::PhantomData;
-use cstr_core::CString;
-use rosidl_runtime_rs::{Message, RmwMessage};
+
 use std::borrow::Cow;
+use std::ffi::CString;
+use std::marker::PhantomData;
+use std::sync::Arc;
 
 use parking_lot::{Mutex, MutexGuard};
+
+use rosidl_runtime_rs::{Message, RmwMessage};
 
 pub(crate) struct PublisherHandle {
     handle: Mutex<rcl_publisher_t>,

--- a/rclrs/src/node/publisher.rs
+++ b/rclrs/src/node/publisher.rs
@@ -8,10 +8,6 @@ use cstr_core::CString;
 use rosidl_runtime_rs::{Message, RmwMessage};
 use std::borrow::Cow;
 
-#[cfg(not(feature = "std"))]
-use spin::{Mutex, MutexGuard};
-
-#[cfg(feature = "std")]
 use parking_lot::{Mutex, MutexGuard};
 
 pub(crate) struct PublisherHandle {

--- a/rclrs/src/node/subscription.rs
+++ b/rclrs/src/node/subscription.rs
@@ -2,11 +2,13 @@ use crate::error::{SubscriberErrorCode, ToResult};
 use crate::qos::QoSProfile;
 use crate::Node;
 use crate::{rcl_bindings::*, RclReturnCode};
-use alloc::boxed::Box;
-use alloc::sync::Arc;
-use core::borrow::Borrow;
-use core::marker::PhantomData;
-use cstr_core::CString;
+
+use std::borrow::Borrow;
+use std::boxed::Box;
+use std::ffi::CString;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
 use rosidl_runtime_rs::{Message, RmwMessage};
 
 use parking_lot::{Mutex, MutexGuard};

--- a/rclrs/src/node/subscription.rs
+++ b/rclrs/src/node/subscription.rs
@@ -9,10 +9,6 @@ use core::marker::PhantomData;
 use cstr_core::CString;
 use rosidl_runtime_rs::{Message, RmwMessage};
 
-#[cfg(not(feature = "std"))]
-use spin::{Mutex, MutexGuard};
-
-#[cfg(feature = "std")]
 use parking_lot::{Mutex, MutexGuard};
 
 /// Internal struct used by subscriptions.

--- a/rclrs/src/node/subscription.rs
+++ b/rclrs/src/node/subscription.rs
@@ -154,8 +154,8 @@ where
             rcl_take(
                 handle as *const _,
                 &mut rmw_message as *mut <T as Message>::RmwMsg as *mut _,
-                core::ptr::null_mut(),
-                core::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
             )
         };
         ret.ok()?;

--- a/rclrs/src/wait.rs
+++ b/rclrs/src/wait.rs
@@ -118,7 +118,7 @@ impl WaitSet {
             rcl_wait_set_add_subscription(
                 &mut self.handle as *mut _,
                 &*subscription.handle().lock() as *const _,
-                core::ptr::null_mut(),
+                std::ptr::null_mut(),
             )
         }
         .ok()?;

--- a/rosidl_runtime_rs/src/string.rs
+++ b/rosidl_runtime_rs/src/string.rs
@@ -1,5 +1,4 @@
 use std::cmp::Ordering;
-use std::convert::TryFrom;
 use std::ffi::CStr;
 use std::fmt::{self, Debug, Display};
 use std::hash::{Hash, Hasher};
@@ -62,7 +61,6 @@ pub struct WString {
 ///
 /// ```
 /// # use rosidl_runtime_rs::BoundedString;
-/// # use std::convert::TryFrom;
 /// let mut maybe_str = BoundedString::<3>::try_from("noo!");
 /// assert!(maybe_str.is_err());
 /// maybe_str = BoundedString::<3>::try_from("ok!");
@@ -85,7 +83,6 @@ pub struct BoundedString<const N: usize> {
 ///
 /// ```
 /// # use rosidl_runtime_rs::BoundedWString;
-/// # use std::convert::TryFrom;
 /// let mut maybe_wstr = BoundedWString::<3>::try_from("noo!");
 /// assert!(maybe_wstr.is_err());
 /// maybe_wstr = BoundedWString::<3>::try_from("ok!");


### PR DESCRIPTION
This PR removes support for `no_std`, by removing the dependency for the `spin` crate and the corresponding `cfg()` blocks.

I recall @nnmm saying that `no_std` is broken (https://github.com/ros2-rust/ros2_rust/pull/88#discussion_r835641156) and I thought we might as well just remove support for it and revisit this in the future if we want to.