### PR TITLE
Add test_interface_files to the repos files

### DIFF
--- a/ros2_rust_foxy.repos
+++ b/ros2_rust_foxy.repos
@@ -7,6 +7,10 @@ repositories:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
     version: foxy
+  ros2/test_interface_files:
+    type: git
+    url: https://github.com/ros2/test_interface_files.git
+    version: foxy
   ros2/rosidl_defaults:
     type: git
     url: https://github.com/ros2/rosidl_defaults.git

--- a/ros2_rust_galactic.repos
+++ b/ros2_rust_galactic.repos
@@ -7,6 +7,10 @@ repositories:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
     version: galactic
+  ros2/test_interface_files:
+    type: git
+    url: https://github.com/ros2/test_interface_files.git
+    version: galactic
   ros2/rosidl_defaults:
     type: git
     url: https://github.com/ros2/rosidl_defaults.git

--- a/ros2_rust_rolling.repos
+++ b/ros2_rust_rolling.repos
@@ -7,6 +7,10 @@ repositories:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
     version: master
+  ros2/test_interface_files:
+    type: git
+    url: https://github.com/ros2/test_interface_files.git
+    version: master
   ros2/rosidl_defaults:
     type: git
     url: https://github.com/ros2/rosidl_defaults.git


### PR DESCRIPTION
It is currently not possible to simply run `colcon build`: The `test_msgs` contained in `rcl_interfaces` have a dependency on `test_interface_files`, so the build fails.