### PR TITLE
Remove unnecessary "extern crate" declarations

### DIFF
--- a/rclrs/build.rs
+++ b/rclrs/build.rs
@@ -1,5 +1,3 @@
-extern crate bindgen;
-
 use std::env;
 use std::fs::read_dir;
 use std::path::{Path, PathBuf};

--- a/rclrs/src/lib.rs
+++ b/rclrs/src/lib.rs
@@ -1,13 +1,9 @@
 #![warn(missing_docs)]
-//! Rust client library for ROS2.
+//! Rust client library for ROS 2.
 //!
 //! For getting started, see the [README][1].
 //!
 //! [1]: https://github.com/ros2-rust/ros2_rust/blob/master/README.md
-
-extern crate parking_lot;
-extern crate rosidl_runtime_rs;
-extern crate std;
 
 mod context;
 mod error;


### PR DESCRIPTION
This was only needed in Rust 2015.