### PR TITLE
Add Nikolai and Jacob to authors in Cargo.toml and maintainers in package.xml

### DIFF
--- a/examples/minimal_pub_sub/Cargo.toml
+++ b/examples/minimal_pub_sub/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "examples_rclrs_minimal_pub_sub"
 version = "0.2.0"
-authors = ["Esteve Fernandez <esteve@apache.org>", "Nikolai Morin <nnmmgit@gmail.com>"]
+# This project is not military-sponsored, Jacob's employment contract just requires him to use this email address
+authors = ["Esteve Fernandez <esteve@apache.org>", "Nikolai Morin <nnmmgit@gmail.com>", "Jacob Hassold <jacob.a.hassold.civ@army.mil>"]
 edition = "2021"
 
 [[bin]]

--- a/examples/minimal_pub_sub/Cargo.toml
+++ b/examples/minimal_pub_sub/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "examples_rclrs_minimal_pub_sub"
 version = "0.2.0"
-authors = ["Esteve Fernandez <esteve@apache.org>"]
+authors = ["Esteve Fernandez <esteve@apache.org>", "Nikolai Morin <nnmmgit@gmail.com>"]
 edition = "2021"
 
 [[bin]]

--- a/examples/minimal_pub_sub/package.xml
+++ b/examples/minimal_pub_sub/package.xml
@@ -7,6 +7,9 @@
   <version>0.2.0</version>
   <description>Package containing an example of the publish-subscribe mechanism in rclrs.</description>
   <maintainer email="esteve@apache.org">Esteve Fernandez</maintainer>
+  <maintainer email="nnmmgit@gmail.com">Nikolai Morin</maintainer>
+  <!-- This project is not military-sponsored, Jacob's employment contract just requires him to use this email address -->
+  <maintainer email="jacob.a.hassold.civ@army.mil">Jacob Hassold</maintainer>
   <license>Apache License 2.0</license>
 
   <build_depend>rclrs</build_depend>

--- a/rclrs/Cargo.toml
+++ b/rclrs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rclrs"
 version = "0.2.0"
-authors = ["Esteve Fernandez <esteve@apache.org>"]
+authors = ["Esteve Fernandez <esteve@apache.org>", "Nikolai Morin <nnmmgit@gmail.com>"]
 edition = "2021"
 
 [lib]

--- a/rclrs/Cargo.toml
+++ b/rclrs/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "rclrs"
 version = "0.2.0"
-authors = ["Esteve Fernandez <esteve@apache.org>", "Nikolai Morin <nnmmgit@gmail.com>"]
+# This project is not military-sponsored, Jacob's employment contract just requires him to use this email address
+authors = ["Esteve Fernandez <esteve@apache.org>", "Nikolai Morin <nnmmgit@gmail.com>", "Jacob Hassold <jacob.a.hassold.civ@army.mil>"]
 edition = "2021"
 
 [lib]

--- a/rclrs/package.xml
+++ b/rclrs/package.xml
@@ -5,8 +5,11 @@
 <package format="3">
   <name>rclrs</name>
   <version>0.2.0</version>
-  <description>Package containing the Rust client.</description>
+  <description>Package containing the Rust client library.</description>
   <maintainer email="esteve@apache.org">Esteve Fernandez</maintainer>
+  <maintainer email="nnmmgit@gmail.com">Nikolai Morin</maintainer>
+  <!-- This project is not military-sponsored, Jacob's employment contract just requires him to use this email address -->
+  <maintainer email="jacob.a.hassold.civ@army.mil">Jacob Hassold</maintainer>
   <license>Apache License 2.0</license>
   <author email="esteve@apache.org">Esteve Fernandez</author>
 

--- a/rosidl_runtime_rs/Cargo.toml
+++ b/rosidl_runtime_rs/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "rosidl_runtime_rs"
 version = "0.2.0"
-authors = ["Jacob Hassold <jhassold@dcscorp.com>", "Nikolai Morin <nnmmgit@gmail.com>"]
+# This project is not military-sponsored, Jacob's employment contract just requires him to use this email address
+authors = ["Jacob Hassold <jacob.a.hassold.civ@army.mil>", "Nikolai Morin <nnmmgit@gmail.com>"]
 edition = "2021"
 
 [lib]

--- a/rosidl_runtime_rs/package.xml
+++ b/rosidl_runtime_rs/package.xml
@@ -6,10 +6,11 @@
   <name>rosidl_runtime_rs</name>
   <version>0.2.0</version>
   <description>Message generation code shared by Rust projects in ROS 2</description>
-  <maintainer email="jhassold@dcscorp.com">Jacob Hassold</maintainer>
+  <!-- This project is not military-sponsored, Jacob's employment contract just requires him to use this email address -->
+  <maintainer email="jacob.a.hassold.civ@army.mil">Jacob Hassold</maintainer>
   <maintainer email="nnmmgit@gmail.com">Nikolai Morin</maintainer>
   <license>Apache License 2.0</license>
-  <author email="jhassold@dcscorp.com">Jacob Hassold</author>
+  <author email="jacob.a.hassold.civ@army.mil">Jacob Hassold</author>
   <author email="nnmmgit@gmail.com">Nikolai Morin</author>
 
   <depend>rosidl_runtime_c</depend>


### PR DESCRIPTION
I'm happy to add other people like (@jhdcs) too, I just didn't want to speak for them on the question of whether they want to be listed there.

As far as I understand, the semantics of the `authors` field in Cargo.toml is different from the one in `package.xml` in that it doesn't necessarily only list the original author(s).