### PR TITLE
Add build.rs to messages to automatically find the message libraries

### DIFF
--- a/rosidl_generator_rs/cmake/rosidl_generator_rs_generate_interfaces.cmake
+++ b/rosidl_generator_rs/cmake/rosidl_generator_rs_generate_interfaces.cmake
@@ -67,6 +67,7 @@ endforeach()
 
 list(APPEND _generated_common_rs_files
   "${_output_path}/rust/src/lib.rs"
+  "${_output_path}/rust/build.rs"
   "${_output_path}/rust/Cargo.toml"
 )
 

--- a/rosidl_generator_rs/resource/build.rs.em
+++ b/rosidl_generator_rs/resource/build.rs.em
@@ -1,0 +1,10 @@
+use std::path::Path;
+
+fn main() {
+	let lib_dir = Path::new("../../../lib")
+		.canonicalize()
+		.expect("Could not find '../../../lib'");
+	// This allows building Rust packages that depend on message crates without
+	// sourcing the install directory first.
+	println!("cargo:rustc-link-search={}", lib_dir.display());
+}

--- a/rosidl_generator_rs/rosidl_generator_rs/__init__.py
+++ b/rosidl_generator_rs/rosidl_generator_rs/__init__.py
@@ -164,6 +164,12 @@ def generate_rs(generator_arguments_file, typesupport_impls):
         os.path.join(args['output_dir'], 'rust/Cargo.toml'),
         minimum_timestamp=latest_target_timestamp)
 
+    expand_template(
+        os.path.join(template_dir, 'build.rs.em'),
+        {},
+        os.path.join(args['output_dir'], 'rust/build.rs'),
+        minimum_timestamp=latest_target_timestamp)
+
     return 0
 
 def get_rs_name(name):


### PR DESCRIPTION
I think the relative path will be always correct, but even if not, this is only an _additional_ search dir.

The impact is that you can build packages depending on message packages much more easily with `cargo`.