### PR TITLE
Removes cd to /src from instructions in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ mkdir src
 git clone https://github.com/ros2-rust/ros2_rust.git src/ros2_rust
 vcs import src < src/ros2_rust/ros2_rust_foxy.repos
 . /opt/ros/foxy/setup.sh
-cd /src
 colcon build --packages-up-to rclrs_examples
 ```
 


### PR DESCRIPTION
Hi!

I recently started trying out ros2-rust and was following the instructions in the README to get started. 

I noticed this line that seemingly tried to cd to /src, which I don't think is the intended instruction...

Thanks!

James