### PR TITLE
Reset error state when converting to RclReturnCode

### DIFF
--- a/rclrs/src/error.rs
+++ b/rclrs/src/error.rs
@@ -596,7 +596,7 @@ pub(crate) fn to_rcl_result(code: i32) -> Result<(), RclReturnCode> {
             // SAFETY: No preconditions for this function.
             unsafe { rcutils_reset_error() };
             Err(anything_else)
-        },
+        }
     }
 }
 

--- a/rclrs/src/error.rs
+++ b/rclrs/src/error.rs
@@ -592,7 +592,11 @@ impl Error for RclReturnCode {}
 pub(crate) fn to_rcl_result(code: i32) -> Result<(), RclReturnCode> {
     match RclReturnCode::from(code) {
         RclReturnCode::Ok => Ok(()),
-        anything_else => Err(anything_else),
+        anything_else => {
+            // SAFETY: No preconditions for this function.
+            unsafe { rcutils_reset_error() };
+            Err(anything_else)
+        },
     }
 }
 


### PR DESCRIPTION
This can be tested by making two failing calls to rcl after another, e.g. 

```
Context::new(["--ros-args", "-p", "foo&=3"].map(String::from));
Context::new(["--ros-args", "-p", "foo&=3"].map(String::from));
```

Before this change, an error message would be logged about overwriting the error state.