### PR TITLE
Get error string from rcl layer

### DIFF
--- a/rclrs/src/context.rs
+++ b/rclrs/src/context.rs
@@ -1,5 +1,5 @@
 use crate::rcl_bindings::*;
-use crate::{Node, RclReturnCode, ToResult};
+use crate::{Node, RclrsError, ToResult};
 
 use std::ffi::CString;
 use std::os::raw::c_char;
@@ -58,7 +58,7 @@ impl Context {
     ///
     /// # Panics
     /// When there is an interior null byte in any of the args.
-    pub fn new(args: impl IntoIterator<Item = String>) -> Result<Self, RclReturnCode> {
+    pub fn new(args: impl IntoIterator<Item = String>) -> Result<Self, RclrsError> {
         // SAFETY: Getting a zero-initialized value is always safe
         let mut rcl_context = unsafe { rcl_get_zero_initialized_context() };
         let cstring_args: Vec<CString> = args
@@ -114,7 +114,7 @@ impl Context {
     /// assert!(node.is_ok());
     /// # Ok::<(), RclReturnCode>(())
     /// ```
-    pub fn create_node(&self, node_name: &str) -> Result<Node, RclReturnCode> {
+    pub fn create_node(&self, node_name: &str) -> Result<Node, RclrsError> {
         Node::new(node_name, self)
     }
 
@@ -137,7 +137,7 @@ impl Context {
         &self,
         node_namespace: &str,
         node_name: &str,
-    ) -> Result<Node, RclReturnCode> {
+    ) -> Result<Node, RclrsError> {
         Node::new_with_namespace(node_namespace, node_name, self)
     }
 

--- a/rclrs/src/lib.rs
+++ b/rclrs/src/lib.rs
@@ -31,7 +31,7 @@ use std::time::Duration;
 /// This can usually be ignored.
 ///
 /// [1]: crate::SubscriberErrorCode
-pub fn spin_once(node: &Node, timeout: Option<Duration>) -> Result<(), RclReturnCode> {
+pub fn spin_once(node: &Node, timeout: Option<Duration>) -> Result<(), RclrsError> {
     let live_subscriptions = node.live_subscriptions();
     let ctx = Context {
         handle: node.context.clone(),
@@ -53,7 +53,7 @@ pub fn spin_once(node: &Node, timeout: Option<Duration>) -> Result<(), RclReturn
 /// Convenience function for calling [`spin_once`] in a loop.
 ///
 /// This function additionally checks that the context is still valid.
-pub fn spin(node: &Node) -> Result<(), RclReturnCode> {
+pub fn spin(node: &Node) -> Result<(), RclrsError> {
     // The context_is_valid functions exists only to abstract away ROS distro differences
     #[cfg(ros_distro = "foxy")]
     // SAFETY: No preconditions for this function.
@@ -64,9 +64,9 @@ pub fn spin(node: &Node) -> Result<(), RclReturnCode> {
 
     while context_is_valid() {
         if let Some(error) = spin_once(node, None).err() {
-            match error {
+            match error.code {
                 RclReturnCode::Timeout => continue,
-                error => return Err(error),
+                _ => return Err(error),
             };
         }
     }

--- a/rclrs/src/node/mod.rs
+++ b/rclrs/src/node/mod.rs
@@ -4,7 +4,7 @@ pub use self::publisher::*;
 pub use self::subscription::*;
 
 use crate::rcl_bindings::*;
-use crate::{Context, QoSProfile, RclReturnCode, ToResult};
+use crate::{Context, QoSProfile, RclrsError, ToResult};
 use std::ffi::{CStr, CString};
 
 use std::cmp::PartialEq;
@@ -20,7 +20,7 @@ use rosidl_runtime_rs::Message;
 impl Drop for rcl_node_t {
     fn drop(&mut self) {
         // SAFETY: No preconditions for this function
-        unsafe { rcl_node_fini(self).unwrap() };
+        unsafe { rcl_node_fini(self).ok().unwrap() };
     }
 }
 
@@ -61,7 +61,7 @@ impl Node {
     ///
     /// See [`Node::new_with_namespace`] for documentation.
     #[allow(clippy::new_ret_no_self)]
-    pub fn new(node_name: &str, context: &Context) -> Result<Node, RclReturnCode> {
+    pub fn new(node_name: &str, context: &Context) -> Result<Node, RclrsError> {
         Self::new_with_namespace("", node_name, context)
     }
 
@@ -120,7 +120,7 @@ impl Node {
         node_ns: &str,
         node_name: &str,
         context: &Context,
-    ) -> Result<Node, RclReturnCode> {
+    ) -> Result<Node, RclrsError> {
         let raw_node_name = CString::new(node_name).unwrap();
         let raw_node_ns = CString::new(node_ns).unwrap();
 
@@ -161,7 +161,7 @@ impl Node {
     ///
     /// # Example
     /// ```
-    /// # use rclrs::{Context, RclReturnCode};
+    /// # use rclrs::{Context, RclrsError};
     /// // Without remapping
     /// let context = Context::new([])?;
     /// let node = context.create_node("my_node")?;
@@ -171,7 +171,7 @@ impl Node {
     /// let context_r = Context::new(remapping)?;
     /// let node_r = context_r.create_node("my_node")?;
     /// assert_eq!(node_r.name(), "your_node");
-    /// # Ok::<(), RclReturnCode>(())
+    /// # Ok::<(), RclrsError>(())
     /// ```
     pub fn name(&self) -> String {
         self.get_string(rcl_node_get_name)
@@ -184,7 +184,7 @@ impl Node {
     ///
     /// # Example
     /// ```
-    /// # use rclrs::{Context, RclReturnCode};
+    /// # use rclrs::{Context, RclrsError};
     /// // Without remapping
     /// let context = Context::new([])?;
     /// let node = context.create_node_with_namespace("/my/namespace", "my_node")?;
@@ -194,7 +194,7 @@ impl Node {
     /// let context_r = Context::new(remapping)?;
     /// let node_r = context_r.create_node("my_node")?;
     /// assert_eq!(node_r.namespace(), "/your_namespace");
-    /// # Ok::<(), RclReturnCode>(())
+    /// # Ok::<(), RclrsError>(())
     /// ```
     pub fn namespace(&self) -> String {
         self.get_string(rcl_node_get_namespace)
@@ -207,11 +207,11 @@ impl Node {
     ///
     /// # Example
     /// ```
-    /// # use rclrs::{Context, RclReturnCode};
+    /// # use rclrs::{Context, RclrsError};
     /// let context = Context::new([])?;
     /// let node = context.create_node_with_namespace("/my/namespace", "my_node")?;
     /// assert_eq!(node.fully_qualified_name(), "/my/namespace/my_node");
-    /// # Ok::<(), RclReturnCode>(())
+    /// # Ok::<(), RclrsError>(())
     /// ```
     pub fn fully_qualified_name(&self) -> String {
         self.get_string(rcl_node_get_fully_qualified_name)
@@ -244,7 +244,7 @@ impl Node {
         &self,
         topic: &str,
         qos: QoSProfile,
-    ) -> Result<Publisher<T>, RclReturnCode>
+    ) -> Result<Publisher<T>, RclrsError>
     where
         T: Message,
     {
@@ -260,7 +260,7 @@ impl Node {
         topic: &str,
         qos: QoSProfile,
         callback: F,
-    ) -> Result<Arc<Subscription<T>>, RclReturnCode>
+    ) -> Result<Arc<Subscription<T>>, RclrsError>
     where
         T: Message,
         F: FnMut(T) + Sized + 'static,

--- a/rclrs/src/node/publisher.rs
+++ b/rclrs/src/node/publisher.rs
@@ -1,4 +1,4 @@
-use crate::error::{RclReturnCode, ToResult};
+use crate::error::{RclrsError, ToResult};
 use crate::qos::QoSProfile;
 use crate::rcl_bindings::*;
 use crate::Node;
@@ -62,7 +62,7 @@ where
     ///
     /// # Panics
     /// When the topic contains interior null bytes.
-    pub fn new(node: &Node, topic: &str, qos: QoSProfile) -> Result<Self, RclReturnCode>
+    pub fn new(node: &Node, topic: &str, qos: QoSProfile) -> Result<Self, RclrsError>
     where
         T: Message,
     {
@@ -119,7 +119,7 @@ where
     /// Calling `publish()` is a potentially blocking call, see [this issue][1] for details.
     ///
     /// [1]: https://github.com/ros2/ros2/issues/255
-    pub fn publish<'a, M: MessageCow<'a, T>>(&self, message: M) -> Result<(), RclReturnCode> {
+    pub fn publish<'a, M: MessageCow<'a, T>>(&self, message: M) -> Result<(), RclrsError> {
         let rmw_message = T::into_rmw_message(message.into_cow());
         let handle = &mut *self.handle.lock();
         let ret = unsafe {

--- a/rclrs/src/node/subscription.rs
+++ b/rclrs/src/node/subscription.rs
@@ -1,7 +1,7 @@
-use crate::error::{SubscriberErrorCode, ToResult};
+use crate::error::{RclReturnCode, SubscriberErrorCode, ToResult};
 use crate::qos::QoSProfile;
 use crate::Node;
-use crate::{rcl_bindings::*, RclReturnCode};
+use crate::{rcl_bindings::*, RclrsError};
 
 use std::borrow::Borrow;
 use std::boxed::Box;
@@ -41,7 +41,7 @@ pub trait SubscriptionBase {
     /// Internal function to get a reference to the `rcl` handle.
     fn handle(&self) -> &SubscriptionHandle;
     /// Tries to take a new message and run the callback with it.
-    fn execute(&self) -> Result<(), RclReturnCode>;
+    fn execute(&self) -> Result<(), RclrsError>;
 }
 
 /// Struct for receiving messages of type `T`.
@@ -78,7 +78,7 @@ where
         topic: &str,
         qos: QoSProfile,
         callback: F,
-    ) -> Result<Self, RclReturnCode>
+    ) -> Result<Self, RclrsError>
     where
         T: Message,
         F: FnMut(T) + Sized + 'static,
@@ -124,10 +124,10 @@ where
     /// Fetches a new message.
     ///
     /// When there is no new message, this will return a
-    /// [`SubscriptionTakeFailed`][1] wrapped in an [`RclReturnCode`][2].
+    /// [`SubscriptionTakeFailed`][1] wrapped in an [`RclrsError`][2].
     ///
     /// [1]: crate::SubscriberErrorCode
-    /// [2]: crate::RclReturnCode
+    /// [2]: crate::RclrsError
     //
     // ```text
     // +-------------+
@@ -144,7 +144,7 @@ where
     // |  rmw_take   |
     // +-------------+
     // ```
-    pub fn take(&self) -> Result<T, RclReturnCode> {
+    pub fn take(&self) -> Result<T, RclrsError> {
         let mut rmw_message = <T as Message>::RmwMsg::default();
         let handle = &mut *self.handle.lock();
         let ret = unsafe {
@@ -171,10 +171,13 @@ where
         self.handle.borrow()
     }
 
-    fn execute(&self) -> Result<(), RclReturnCode> {
+    fn execute(&self) -> Result<(), RclrsError> {
         let msg = match self.take() {
             Ok(msg) => msg,
-            Err(RclReturnCode::SubscriberError(SubscriberErrorCode::SubscriptionTakeFailed)) => {
+            Err(RclrsError {
+                code: RclReturnCode::SubscriberError(SubscriberErrorCode::SubscriptionTakeFailed),
+                ..
+            }) => {
                 // Spurious wakeup – this may happen even when a waitset indicated that this
                 // subscription was ready, so it shouldn't be an error.
                 return Ok(());


### PR DESCRIPTION
Storing the error string requires a new struct, which I've named `RclrsError`.

This also makes `Display` impls use a period instead of an exclamation mark.

Closes https://github.com/ros2-rust/ros2_rust/issues/111