### PR TITLE
Add humble to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
         ros_distribution:
           - foxy
           - galactic
-          # - humble
+          - humble
           - rolling
         include:
           # Foxy Fitzroy (June 2020 - May 2023)
@@ -28,9 +28,9 @@ jobs:
             ros_distribution: galactic
             ros_version: 2
           # Humble Hawksbill (May 2022 - May 2027)
-          # - docker_image: rostooling/setup-ros-docker:ubuntu-jammy-ros-humble-ros-base-latest
-          #   ros_distribution: humble
-          #   ros_version: 2
+          - docker_image: rostooling/setup-ros-docker:ubuntu-jammy-ros-humble-ros-base-latest
+            ros_distribution: humble
+            ros_version: 2
           # Rolling Ridley  (June 2020 - Present)
           - docker_image: rostooling/setup-ros-docker:ubuntu-jammy-ros-rolling-ros-base-latest
             ros_distribution: rolling


### PR DESCRIPTION
The setup-ros humble docker image is available now so we can add humble to the CI