### PR TITLE
fix: add clang dependency

### DIFF
--- a/rclrs/package.xml
+++ b/rclrs/package.xml
@@ -13,7 +13,7 @@
   <license>Apache License 2.0</license>
   <author email="esteve@apache.org">Esteve Fernandez</author>
 
-  <build_depend>clang<build_depend>
+  <build_depend>libclang-dev<build_depend>
   <build_depend>rosidl_runtime_rs</build_depend>
   <build_depend>rcl</build_depend>
 

--- a/rclrs/package.xml
+++ b/rclrs/package.xml
@@ -13,7 +13,7 @@
   <license>Apache License 2.0</license>
   <author email="esteve@apache.org">Esteve Fernandez</author>
 
-  <build_depend>libclang-dev<build_depend>
+  <build_depend>libclang-dev</build_depend>
   <build_depend>rosidl_runtime_rs</build_depend>
   <build_depend>rcl</build_depend>
 

--- a/rclrs/package.xml
+++ b/rclrs/package.xml
@@ -13,6 +13,7 @@
   <license>Apache License 2.0</license>
   <author email="esteve@apache.org">Esteve Fernandez</author>
 
+  <build_depend>clang<build_depend>
   <build_depend>rosidl_runtime_rs</build_depend>
   <build_depend>rcl</build_depend>
 


### PR DESCRIPTION
Missing clang causes the following error.
```
  --- stderr
  /opt/ros/humble/include/rcutils/rcutils/allocator.h:25:10: fatal error: 'stdbool.h' file not found
  /opt/ros/humble/include/rcutils/rcutils/allocator.h:25:10: fatal error: 'stdbool.h' file not found, err: true
  thread 'main' panicked at 'Unable to generate bindings: ()', build.rs:99:39
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
related issue #75