### PR TITLE
Rename variables of rcl types

### DIFF
--- a/rclrs/src/lib.rs
+++ b/rclrs/src/lib.rs
@@ -34,7 +34,7 @@ use std::time::Duration;
 pub fn spin_once(node: &Node, timeout: Option<Duration>) -> Result<(), RclrsError> {
     let live_subscriptions = node.live_subscriptions();
     let ctx = Context {
-        handle: node.context.clone(),
+        rcl_context_mtx: node.rcl_context_mtx.clone(),
     };
     let mut wait_set = WaitSet::new(live_subscriptions.len(), &ctx)?;
 
@@ -57,10 +57,10 @@ pub fn spin(node: &Node) -> Result<(), RclrsError> {
     // The context_is_valid functions exists only to abstract away ROS distro differences
     #[cfg(ros_distro = "foxy")]
     // SAFETY: No preconditions for this function.
-    let context_is_valid = || unsafe { rcl_context_is_valid(&mut *node.context.lock()) };
+    let context_is_valid = || unsafe { rcl_context_is_valid(&mut *node.rcl_context_mtx.lock()) };
     #[cfg(not(ros_distro = "foxy"))]
     // SAFETY: No preconditions for this function.
-    let context_is_valid = || unsafe { rcl_context_is_valid(&*node.context.lock()) };
+    let context_is_valid = || unsafe { rcl_context_is_valid(&*node.rcl_context_mtx.lock()) };
 
     while context_is_valid() {
         match spin_once(node, None) {

--- a/rclrs/src/node/subscription.rs
+++ b/rclrs/src/node/subscription.rs
@@ -3,7 +3,6 @@ use crate::qos::QoSProfile;
 use crate::Node;
 use crate::{rcl_bindings::*, RclrsError};
 
-use std::borrow::Borrow;
 use std::boxed::Box;
 use std::ffi::CString;
 use std::marker::PhantomData;
@@ -19,23 +18,23 @@ unsafe impl Send for rcl_subscription_t {}
 
 /// Internal struct used by subscriptions.
 pub struct SubscriptionHandle {
-    handle: Mutex<rcl_subscription_t>,
-    node_handle: Arc<Mutex<rcl_node_t>>,
+    rcl_subscription_mtx: Mutex<rcl_subscription_t>,
+    rcl_node_mtx: Arc<Mutex<rcl_node_t>>,
 }
 
 impl SubscriptionHandle {
     pub(crate) fn lock(&self) -> MutexGuard<rcl_subscription_t> {
-        self.handle.lock()
+        self.rcl_subscription_mtx.lock()
     }
 }
 
 impl Drop for SubscriptionHandle {
     fn drop(&mut self) {
-        let handle = self.handle.get_mut();
-        let node_handle = &mut *self.node_handle.lock();
+        let rcl_subscription = self.rcl_subscription_mtx.get_mut();
+        let rcl_node = &mut *self.rcl_node_mtx.lock();
         // SAFETY: No preconditions for this function (besides the arguments being valid).
         unsafe {
-            rcl_subscription_fini(handle, node_handle);
+            rcl_subscription_fini(rcl_subscription, rcl_node);
         }
     }
 }
@@ -85,27 +84,27 @@ where
         F: FnMut(T) + 'static + Send,
     {
         // SAFETY: Getting a zero-initialized value is always safe.
-        let mut subscription_handle = unsafe { rcl_get_zero_initialized_subscription() };
+        let mut rcl_subscription = unsafe { rcl_get_zero_initialized_subscription() };
         let type_support =
             <T as Message>::RmwMsg::get_type_support() as *const rosidl_message_type_support_t;
         let topic_c_string = CString::new(topic).map_err(|err| RclrsError::StringContainsNul {
             err,
             s: topic.into(),
         })?;
-        let node_handle = &mut *node.handle.lock();
+        let rcl_node = &mut *node.rcl_node_mtx.lock();
 
         // SAFETY: No preconditions for this function.
         let mut subscription_options = unsafe { rcl_subscription_get_default_options() };
         subscription_options.qos = qos.into();
         unsafe {
-            // SAFETY: The subscription handle is zero-initialized as expected by this function.
-            // The node handle is kept alive because it is co-owned by the subscription.
+            // SAFETY: The rcl_subscription is zero-initialized as expected by this function.
+            // The rcl_node is kept alive because it is co-owned by the subscription.
             // The topic name and the options are copied by this function, so they can be dropped
             // afterwards.
             // TODO: type support?
             rcl_subscription_init(
-                &mut subscription_handle,
-                node_handle,
+                &mut rcl_subscription,
+                rcl_node,
                 type_support,
                 topic_c_string.as_ptr(),
                 &subscription_options,
@@ -114,8 +113,8 @@ where
         }
 
         let handle = Arc::new(SubscriptionHandle {
-            handle: Mutex::new(subscription_handle),
-            node_handle: node.handle.clone(),
+            rcl_subscription_mtx: Mutex::new(rcl_subscription),
+            rcl_node_mtx: node.rcl_node_mtx.clone(),
         });
 
         Ok(Self {
@@ -149,13 +148,13 @@ where
     // ```
     pub fn take(&self) -> Result<T, RclrsError> {
         let mut rmw_message = <T as Message>::RmwMsg::default();
-        let handle = &mut *self.handle.lock();
+        let rcl_subscription = &mut *self.handle.lock();
         let ret = unsafe {
             // SAFETY: The first two pointers are valid/initialized, and do not need to be valid
             // beyond the function call.
             // The latter two pointers are explicitly allowed to be NULL.
             rcl_take(
-                handle,
+                rcl_subscription,
                 &mut rmw_message as *mut <T as Message>::RmwMsg as *mut _,
                 std::ptr::null_mut(),
                 std::ptr::null_mut(),
@@ -171,7 +170,7 @@ where
     T: Message,
 {
     fn handle(&self) -> &SubscriptionHandle {
-        self.handle.borrow()
+        &self.handle
     }
 
     fn execute(&self) -> Result<(), RclrsError> {


### PR DESCRIPTION
I find it confusing and not very descriptive that "handle" is used to refer to both any rcl binding struct, and the `PublisherHandle` etc. types.

This PR changes the variable names of rcl binding types to be more descriptive, e.g. use `rcl_node` as the variable name for an `rcl_node_t`. Afterwards, "handle" refers exclusively to the `PublisherHandle` etc. types.

What's maybe worth discussing: Is `rcl_node` also fine for a `&mut rcl_node_t`?