### PR TITLE
Refactor to remove SubscriptionHandle/ClientHandle/ServiceHandle

### DIFF
--- a/rclrs/src/lib.rs
+++ b/rclrs/src/lib.rs
@@ -54,21 +54,15 @@ pub fn spin_once(node: &Node, timeout: Option<Duration>) -> Result<(), RclrsErro
     )?;
 
     for live_subscription in live_subscriptions {
-        // SAFETY: The implementation of this trait function guarantees that the subscription
-        // is not part of any other wait set. (TODO: issue #207)
-        unsafe { live_subscription.add_to_wait_set(&mut wait_set)? };
+        wait_set.add_subscription(live_subscription)?;
     }
 
     for live_client in live_clients {
-        // SAFETY: The implementation of this trait function guarantees that the client
-        // is not part of any other wait set. (TODO: issue #207)
-        unsafe { live_client.add_to_wait_set(&mut wait_set)? };
+        wait_set.add_client(live_client)?;
     }
 
     for live_service in live_services {
-        // SAFETY: The implementation of this trait function guarantees that the client
-        // is not part of any other wait set. (TODO: issue #207)
-        unsafe { live_service.add_to_wait_set(&mut wait_set)? };
+        wait_set.add_service(live_service)?;
     }
 
     let ready_entities = wait_set.wait(timeout)?;

--- a/rclrs/src/lib.rs
+++ b/rclrs/src/lib.rs
@@ -53,16 +53,22 @@ pub fn spin_once(node: &Node, timeout: Option<Duration>) -> Result<(), RclrsErro
         &ctx,
     )?;
 
-    for live_subscription in &live_subscriptions {
-        wait_set.add_subscription(live_subscription.clone())?;
+    for live_subscription in live_subscriptions {
+        // SAFETY: The implementation of this trait function guarantees that the subscription
+        // is not part of any other wait set. (TODO: issue #207)
+        unsafe { live_subscription.add_to_wait_set(&mut wait_set)? };
     }
 
-    for live_client in &live_clients {
-        wait_set.add_client(live_client.clone())?;
+    for live_client in live_clients {
+        // SAFETY: The implementation of this trait function guarantees that the client
+        // is not part of any other wait set. (TODO: issue #207)
+        unsafe { live_client.add_to_wait_set(&mut wait_set)? };
     }
 
-    for live_service in &live_services {
-        wait_set.add_service(live_service.clone())?;
+    for live_service in live_services {
+        // SAFETY: The implementation of this trait function guarantees that the client
+        // is not part of any other wait set. (TODO: issue #207)
+        unsafe { live_service.add_to_wait_set(&mut wait_set)? };
     }
 
     let ready_entities = wait_set.wait(timeout)?;

--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -10,7 +10,7 @@ pub use self::service::*;
 pub use self::subscription::*;
 
 use crate::rcl_bindings::*;
-use crate::{Context, ParameterOverrideMap, QoSProfile, RclrsError, ToResult, Waitable};
+use crate::{Context, ParameterOverrideMap, QoSProfile, RclrsError, ToResult};
 
 use std::cmp::PartialEq;
 use std::ffi::CStr;
@@ -72,9 +72,9 @@ unsafe impl Send for rcl_node_t {}
 pub struct Node {
     rcl_node_mtx: Arc<Mutex<rcl_node_t>>,
     pub(crate) rcl_context_mtx: Arc<Mutex<rcl_context_t>>,
-    pub(crate) clients: Vec<Weak<dyn Waitable>>,
-    pub(crate) services: Vec<Weak<dyn Waitable>>,
-    pub(crate) subscriptions: Vec<Weak<dyn Waitable>>,
+    pub(crate) clients: Vec<Weak<dyn ClientWaitable>>,
+    pub(crate) services: Vec<Weak<dyn ServiceWaitable>>,
+    pub(crate) subscriptions: Vec<Weak<dyn SubscriptionWaitable>>,
     _parameter_map: ParameterOverrideMap,
 }
 
@@ -193,7 +193,7 @@ impl Node {
     {
         let client = Arc::new(crate::node::client::Client::<T>::new(self, topic)?);
         self.clients
-            .push(Arc::downgrade(&client) as Weak<dyn Waitable>);
+            .push(Arc::downgrade(&client) as Weak<dyn ClientWaitable>);
         Ok(client)
     }
 
@@ -229,7 +229,7 @@ impl Node {
             self, topic, callback,
         )?);
         self.services
-            .push(Arc::downgrade(&service) as Weak<dyn Waitable>);
+            .push(Arc::downgrade(&service) as Weak<dyn ServiceWaitable>);
         Ok(service)
     }
 
@@ -249,23 +249,23 @@ impl Node {
     {
         let subscription = Arc::new(Subscription::<T>::new(self, topic, qos, callback)?);
         self.subscriptions
-            .push(Arc::downgrade(&subscription) as Weak<dyn Waitable>);
+            .push(Arc::downgrade(&subscription) as Weak<dyn SubscriptionWaitable>);
         Ok(subscription)
     }
 
     /// Returns the subscriptions that have not been dropped yet.
-    pub(crate) fn live_subscriptions(&self) -> Vec<Arc<dyn Waitable>> {
+    pub(crate) fn live_subscriptions(&self) -> Vec<Arc<dyn SubscriptionWaitable>> {
         self.subscriptions
             .iter()
             .filter_map(Weak::upgrade)
             .collect()
     }
 
-    pub(crate) fn live_clients(&self) -> Vec<Arc<dyn Waitable>> {
+    pub(crate) fn live_clients(&self) -> Vec<Arc<dyn ClientWaitable>> {
         self.clients.iter().filter_map(Weak::upgrade).collect()
     }
 
-    pub(crate) fn live_services(&self) -> Vec<Arc<dyn Waitable>> {
+    pub(crate) fn live_services(&self) -> Vec<Arc<dyn ServiceWaitable>> {
         self.services.iter().filter_map(Weak::upgrade).collect()
     }
 

--- a/rclrs/src/node/client.rs
+++ b/rclrs/src/node/client.rs
@@ -86,7 +86,7 @@ where
 }
 
 /// A marker trait to distinguish `Client` waitables from other [`Waitable`]s.
-pub(crate) trait ClientWaitable: Waitable {}
+pub trait ClientWaitable: Waitable {}
 
 impl<T> ClientWaitable for Client<T> where T: rosidl_runtime_rs::Service {}
 

--- a/rclrs/src/node/client.rs
+++ b/rclrs/src/node/client.rs
@@ -85,6 +85,11 @@ where
     }
 }
 
+/// A marker trait to distinguish `Client` waitables from other [`Waitable`]s.
+pub(crate) trait ClientWaitable: Waitable {}
+
+impl<T> ClientWaitable for Client<T> where T: rosidl_runtime_rs::Service {}
+
 impl<T> Client<T>
 where
     T: rosidl_runtime_rs::Service,

--- a/rclrs/src/node/service.rs
+++ b/rclrs/src/node/service.rs
@@ -57,7 +57,7 @@ where
             std::ptr::null_mut(),
         )
         .ok()?;
-        wait_set.clients.push(self);
+        wait_set.services.push(self);
         Ok(())
     }
 
@@ -90,7 +90,7 @@ where
 }
 
 /// A marker trait to distinguish `Service` waitables from other [`Waitable`]s.
-pub(crate) trait ServiceWaitable: Waitable {}
+pub trait ServiceWaitable: Waitable {}
 
 impl<T> ServiceWaitable for Service<T> where T: rosidl_runtime_rs::Service {}
 

--- a/rclrs/src/node/service.rs
+++ b/rclrs/src/node/service.rs
@@ -89,6 +89,11 @@ where
     }
 }
 
+/// A marker trait to distinguish `Service` waitables from other [`Waitable`]s.
+pub(crate) trait ServiceWaitable: Waitable {}
+
+impl<T> ServiceWaitable for Service<T> where T: rosidl_runtime_rs::Service {}
+
 impl<T> Service<T>
 where
     T: rosidl_runtime_rs::Service,

--- a/rclrs/src/node/subscription.rs
+++ b/rclrs/src/node/subscription.rs
@@ -85,6 +85,11 @@ where
     }
 }
 
+/// A marker trait to distinguish `Subscription` waitables from other [`Waitable`]s.
+pub(crate) trait SubscriptionWaitable: Waitable {}
+
+impl<T> SubscriptionWaitable for Subscription<T> where T: Message {}
+
 impl<T> Subscription<T>
 where
     T: Message,

--- a/rclrs/src/node/subscription.rs
+++ b/rclrs/src/node/subscription.rs
@@ -86,7 +86,7 @@ where
 }
 
 /// A marker trait to distinguish `Subscription` waitables from other [`Waitable`]s.
-pub(crate) trait SubscriptionWaitable: Waitable {}
+pub trait SubscriptionWaitable: Waitable {}
 
 impl<T> SubscriptionWaitable for Subscription<T> where T: Message {}
 

--- a/rclrs/src/wait.rs
+++ b/rclrs/src/wait.rs
@@ -17,7 +17,7 @@
 
 use crate::error::{to_rclrs_result, RclReturnCode, RclrsError, ToResult};
 use crate::rcl_bindings::*;
-use crate::Context;
+use crate::{Client, Context, Service, Subscription};
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -124,6 +124,60 @@ impl WaitSet {
             clients: Vec::new(),
             services: Vec::new(),
         })
+    }
+
+    /// Adds a client to the wait set.
+    ///
+    /// It is possible, but not useful, to add the same client twice.
+    ///
+    /// This will return an error if the number of clients in the wait set is larger than the
+    /// capacity set in [`WaitSet::new`].
+    ///
+    /// The same client must not be added to multiple wait sets, because that would make it
+    /// unsafe to simultaneously wait on those wait sets.
+    pub fn add_client<T: rosidl_runtime_rs::Service>(
+        &mut self,
+        client: Arc<Client<T>>,
+    ) -> Result<(), RclrsError> {
+        // SAFETY: The implementation of this trait for clients checks that the client
+        // has not already been added to a different wait set.
+        unsafe { client.add_to_wait_set(self) }
+    }
+
+    /// Adds a service to the wait set.
+    ///
+    /// It is possible, but not useful, to add the same service twice.
+    ///
+    /// This will return an error if the number of services in the wait set is larger than the
+    /// capacity set in [`WaitSet::new`].
+    ///
+    /// The same service must not be added to multiple wait sets, because that would make it
+    /// unsafe to simultaneously wait on those wait sets.
+    pub fn add_service<T: rosidl_runtime_rs::Service>(
+        &mut self,
+        service: Arc<Service<T>>,
+    ) -> Result<(), RclrsError> {
+        // SAFETY: The implementation of this trait for services checks that the service
+        // has not already been added to a different wait set.
+        unsafe { service.add_to_wait_set(self) }
+    }
+
+    /// Adds a subscription to the wait set.
+    ///
+    /// It is possible, but not useful, to add the same subscription twice.
+    ///
+    /// This will return an error if the number of subscriptions in the wait set is larger than the
+    /// capacity set in [`WaitSet::new`].
+    ///
+    /// The same subscription must not be added to multiple wait sets, because that would make it
+    /// unsafe to simultaneously wait on those wait sets.
+    pub fn add_subscription<T: rosidl_runtime_rs::Message>(
+        &mut self,
+        subscription: Arc<Subscription<T>>,
+    ) -> Result<(), RclrsError> {
+        // SAFETY: The implementation of this trait for subscriptions checks that the subscription
+        // has not already been added to a different wait set.
+        unsafe { subscription.add_to_wait_set(self) }
     }
 
     /// Removes all entities from the wait set.


### PR DESCRIPTION
The contents of `SubscriptionHandle` are moved into `Subscription`.

This creates the problem that the `SubscriptionHandle` was returned by `SubscriptionBase`. We could also return the raw `rcl_subscription_t`, but I'd like to keep these types out of the public API.

Instead, I changed the `SubscriptionBase` trait to not return the thing to be added to the `WaitSet`, but to take the `WaitSet` as an argument and add the `rcl_subscription_t` directly to it. This has the benefit that this trait now is general enough to also cover clients, services etc. and thus I renamed it to `Waitable`.