### PR TITLE
Rename get_topic to topic_name

### DIFF
--- a/rclrs/src/node/publisher.rs
+++ b/rclrs/src/node/publisher.rs
@@ -102,7 +102,7 @@ where
     ///
     /// This returns the topic name after remapping, so it is not necessarily the
     /// topic name which was used when creating the publisher.
-    pub fn get_topic(&self) -> String {
+    pub fn topic_name(&self) -> String {
         // SAFETY: No preconditions for the functions called.
         // The unsafe variables created get converted to safe types before being returned
         unsafe {

--- a/rclrs/src/node/subscription.rs
+++ b/rclrs/src/node/subscription.rs
@@ -129,7 +129,7 @@ where
     ///
     /// This returns the topic name after remapping, so it is not necessarily the
     /// topic name which was used when creating the subscription.
-    pub fn get_topic(&self) -> String {
+    pub fn topic_name(&self) -> String {
         // SAFETY: No preconditions for the function used
         // The unsafe variables get converted to safe types before being returned
         unsafe {


### PR DESCRIPTION
This is to be consistent with the prevalent style, which is not to use "get_" prefixes for getters.