### PR TITLE
Declare fn new in waitables as pub(crate)

### DIFF
--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -184,17 +184,11 @@ impl Node {
     ///
     /// [1]: crate::Client
     // TODO: make client's lifetime depend on node's lifetime
-    pub fn create_client<T>(
-        &mut self,
-        topic: &str,
-    ) -> Result<Arc<crate::node::client::Client<T>>, RclrsError>
+    pub fn create_client<T>(&mut self, topic: &str) -> Result<Arc<Client<T>>, RclrsError>
     where
         T: rosidl_runtime_rs::Service,
     {
-        let client = Arc::new(crate::node::client::Client::<T>::new(self, topic)?);
-        self.clients
-            .push(Arc::downgrade(&client) as Weak<dyn ClientBase>);
-        Ok(client)
+        Client::<T>::new(self, topic)
     }
 
     /// Creates a [`Publisher`][1].
@@ -220,17 +214,12 @@ impl Node {
         &mut self,
         topic: &str,
         callback: F,
-    ) -> Result<Arc<crate::node::service::Service<T>>, RclrsError>
+    ) -> Result<Arc<Service<T>>, RclrsError>
     where
         T: rosidl_runtime_rs::Service,
         F: Fn(&rmw_request_id_t, T::Request) -> T::Response + 'static + Send,
     {
-        let service = Arc::new(crate::node::service::Service::<T>::new(
-            self, topic, callback,
-        )?);
-        self.services
-            .push(Arc::downgrade(&service) as Weak<dyn ServiceBase>);
-        Ok(service)
+        Service::<T>::new(self, topic, callback)
     }
 
     /// Creates a [`Subscription`][1].
@@ -247,10 +236,7 @@ impl Node {
         T: Message,
         F: FnMut(T) + 'static + Send,
     {
-        let subscription = Arc::new(Subscription::<T>::new(self, topic, qos, callback)?);
-        self.subscriptions
-            .push(Arc::downgrade(&subscription) as Weak<dyn SubscriptionBase>);
-        Ok(subscription)
+        Subscription::new(self, topic, qos, callback)
     }
 
     /// Returns the subscriptions that have not been dropped yet.

--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -184,11 +184,17 @@ impl Node {
     ///
     /// [1]: crate::Client
     // TODO: make client's lifetime depend on node's lifetime
-    pub fn create_client<T>(&mut self, topic: &str) -> Result<Arc<Client<T>>, RclrsError>
+    pub fn create_client<T>(
+        &mut self,
+        topic: &str,
+    ) -> Result<Arc<crate::node::client::Client<T>>, RclrsError>
     where
         T: rosidl_runtime_rs::Service,
     {
-        Client::<T>::new(self, topic)
+        let client = Arc::new(crate::node::client::Client::<T>::new(self, topic)?);
+        self.clients
+            .push(Arc::downgrade(&client) as Weak<dyn ClientBase>);
+        Ok(client)
     }
 
     /// Creates a [`Publisher`][1].
@@ -214,12 +220,17 @@ impl Node {
         &mut self,
         topic: &str,
         callback: F,
-    ) -> Result<Arc<Service<T>>, RclrsError>
+    ) -> Result<Arc<crate::node::service::Service<T>>, RclrsError>
     where
         T: rosidl_runtime_rs::Service,
         F: Fn(&rmw_request_id_t, T::Request) -> T::Response + 'static + Send,
     {
-        Service::<T>::new(self, topic, callback)
+        let service = Arc::new(crate::node::service::Service::<T>::new(
+            self, topic, callback,
+        )?);
+        self.services
+            .push(Arc::downgrade(&service) as Weak<dyn ServiceBase>);
+        Ok(service)
     }
 
     /// Creates a [`Subscription`][1].
@@ -236,7 +247,10 @@ impl Node {
         T: Message,
         F: FnMut(T) + 'static + Send,
     {
-        Subscription::new(self, topic, qos, callback)
+        let subscription = Arc::new(Subscription::<T>::new(self, topic, qos, callback)?);
+        self.subscriptions
+            .push(Arc::downgrade(&subscription) as Weak<dyn SubscriptionBase>);
+        Ok(subscription)
     }
 
     /// Returns the subscriptions that have not been dropped yet.

--- a/rclrs/src/node/client.rs
+++ b/rclrs/src/node/client.rs
@@ -70,7 +70,7 @@ where
     T: rosidl_runtime_rs::Service,
 {
     /// Creates a new client.
-    pub fn new(node: &Node, topic: &str) -> Result<Self, RclrsError>
+    pub fn new(node: &mut Node, topic: &str) -> Result<Arc<Self>, RclrsError>
     where
         T: rosidl_runtime_rs::Service,
     {
@@ -107,14 +107,15 @@ where
             rcl_node_mtx: node.rcl_node_mtx.clone(),
             in_use_by_wait_set: Arc::new(AtomicBool::new(false)),
         });
-
-        Ok(Self {
+        let client = Arc::new(Self {
             handle,
             requests: Mutex::new(HashMap::new()),
             futures: Arc::new(Mutex::new(
                 HashMap::<RequestId, oneshot::Sender<T::Response>>::new(),
             )),
-        })
+        });
+        node.clients.push(Arc::downgrade(&client) as _);
+        Ok(client)
     }
 
     /// Sends a request with a callback to be called with the response.

--- a/rclrs/src/node/client.rs
+++ b/rclrs/src/node/client.rs
@@ -70,7 +70,7 @@ where
     T: rosidl_runtime_rs::Service,
 {
     /// Creates a new client.
-    pub fn new(node: &mut Node, topic: &str) -> Result<Arc<Self>, RclrsError>
+    pub(crate) fn new(node: &Node, topic: &str) -> Result<Self, RclrsError>
     where
         T: rosidl_runtime_rs::Service,
     {
@@ -107,15 +107,14 @@ where
             rcl_node_mtx: node.rcl_node_mtx.clone(),
             in_use_by_wait_set: Arc::new(AtomicBool::new(false)),
         });
-        let client = Arc::new(Self {
+
+        Ok(Self {
             handle,
             requests: Mutex::new(HashMap::new()),
             futures: Arc::new(Mutex::new(
                 HashMap::<RequestId, oneshot::Sender<T::Response>>::new(),
             )),
-        });
-        node.clients.push(Arc::downgrade(&client) as _);
-        Ok(client)
+        })
     }
 
     /// Sends a request with a callback to be called with the response.

--- a/rclrs/src/node/client.rs
+++ b/rclrs/src/node/client.rs
@@ -56,6 +56,9 @@ type RequestValue<Response> = Box<dyn FnOnce(Response) + 'static + Send>;
 type RequestId = i64;
 
 /// Main class responsible for sending requests to a ROS service.
+///
+/// The only available way to instantiate clients is via [`Node::create_client`], this is to
+/// ensure that [`Node`]s can track all the clients that have been created.
 pub struct Client<T>
 where
     T: rosidl_runtime_rs::Service,
@@ -71,6 +74,8 @@ where
 {
     /// Creates a new client.
     pub(crate) fn new(node: &Node, topic: &str) -> Result<Self, RclrsError>
+    // This uses pub(crate) visibility to avoid instantiating this struct outside
+    // [`Node::create_client`], see the struct's documentation for the rationale
     where
         T: rosidl_runtime_rs::Service,
     {

--- a/rclrs/src/node/service.rs
+++ b/rclrs/src/node/service.rs
@@ -69,7 +69,7 @@ where
     T: rosidl_runtime_rs::Service,
 {
     /// Creates a new service.
-    pub fn new<F>(node: &mut Node, topic: &str, callback: F) -> Result<Arc<Self>, RclrsError>
+    pub(crate) fn new<F>(node: &Node, topic: &str, callback: F) -> Result<Self, RclrsError>
     where
         T: rosidl_runtime_rs::Service,
         F: Fn(&rmw_request_id_t, T::Request) -> T::Response + 'static + Send,
@@ -107,13 +107,11 @@ where
             node_handle: node.rcl_node_mtx.clone(),
             in_use_by_wait_set: Arc::new(AtomicBool::new(false)),
         });
-        let service = Arc::new(Self {
+
+        Ok(Self {
             handle,
             callback: Mutex::new(Box::new(callback)),
-        });
-        node.services.push(Arc::downgrade(&service) as _);
-
-        Ok(service)
+        })
     }
 
     /// Fetches a new request.

--- a/rclrs/src/node/service.rs
+++ b/rclrs/src/node/service.rs
@@ -55,6 +55,9 @@ type ServiceCallback<Request, Response> =
     Box<dyn Fn(&rmw_request_id_t, Request) -> Response + 'static + Send>;
 
 /// Main class responsible for responding to requests sent by ROS clients.
+///
+/// The only available way to instantiate services is via [`Node::create_service`], this is to
+/// ensure that [`Node`]s can track all the services that have been created.
 pub struct Service<T>
 where
     T: rosidl_runtime_rs::Service,
@@ -70,6 +73,8 @@ where
 {
     /// Creates a new service.
     pub(crate) fn new<F>(node: &Node, topic: &str, callback: F) -> Result<Self, RclrsError>
+    // This uses pub(crate) visibility to avoid instantiating this struct outside
+    // [`Node::create_service`], see the struct's documentation for the rationale
     where
         T: rosidl_runtime_rs::Service,
         F: Fn(&rmw_request_id_t, T::Request) -> T::Response + 'static + Send,

--- a/rclrs/src/node/service.rs
+++ b/rclrs/src/node/service.rs
@@ -69,7 +69,7 @@ where
     T: rosidl_runtime_rs::Service,
 {
     /// Creates a new service.
-    pub fn new<F>(node: &Node, topic: &str, callback: F) -> Result<Self, RclrsError>
+    pub fn new<F>(node: &mut Node, topic: &str, callback: F) -> Result<Arc<Self>, RclrsError>
     where
         T: rosidl_runtime_rs::Service,
         F: Fn(&rmw_request_id_t, T::Request) -> T::Response + 'static + Send,
@@ -107,11 +107,13 @@ where
             node_handle: node.rcl_node_mtx.clone(),
             in_use_by_wait_set: Arc::new(AtomicBool::new(false)),
         });
-
-        Ok(Self {
+        let service = Arc::new(Self {
             handle,
             callback: Mutex::new(Box::new(callback)),
-        })
+        });
+        node.services.push(Arc::downgrade(&service) as _);
+
+        Ok(service)
     }
 
     /// Fetches a new request.

--- a/rclrs/src/node/subscription.rs
+++ b/rclrs/src/node/subscription.rs
@@ -59,6 +59,9 @@ pub trait SubscriptionBase: Send + Sync {
 /// When a subscription is created, it may take some time to get "matched" with a corresponding
 /// publisher.
 ///
+/// The only available way to instantiate subscriptions is via [`Node::create_subscription`], this
+/// is to ensure that [`Node`]s can track all the subscriptions that have been created.
+///
 /// [1]: crate::spin_once
 /// [2]: crate::spin
 pub struct Subscription<T>
@@ -82,6 +85,8 @@ where
         qos: QoSProfile,
         callback: F,
     ) -> Result<Self, RclrsError>
+    // This uses pub(crate) visibility to avoid instantiating this struct outside
+    // [`Node::create_subscription`], see the struct's documentation for the rationale
     where
         T: Message,
         F: FnMut(T) + 'static + Send,

--- a/rclrs/src/node/subscription.rs
+++ b/rclrs/src/node/subscription.rs
@@ -218,13 +218,13 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{create_node, Context, Subscription, QOS_PROFILE_DEFAULT};
+    use crate::{create_node, Context, QOS_PROFILE_DEFAULT};
 
     #[test]
     fn test_instantiate_subscriber() -> Result<(), RclrsError> {
         let context =
             Context::new(vec![]).expect("Context instantiation is expected to be a success");
-        let node = create_node(&context, "test_new_subscriber")?;
+        let mut node = create_node(&context, "test_new_subscriber")?;
         let _subscriber = node.create_subscription::<std_msgs::msg::String, _>(
             "test",
             QOS_PROFILE_DEFAULT,


### PR DESCRIPTION
This PR restricts the visibility of `fn new` in waitables (`Subscription`, `Client`, `Service`) so that only other code in the crate can access it. This prevents users from instantiating these structures and therefore we ensure that the only way of creating them is via the `Node::create_X` methods so that any internal logic is not bypassed.