### PR TITLE
Fix path handling in rosidl_generator_rs on Windows

### DIFF
--- a/rosidl_generator_rs/rosidl_generator_rs/__init__.py
+++ b/rosidl_generator_rs/rosidl_generator_rs/__init__.py
@@ -64,7 +64,7 @@ def generate_rs(generator_arguments_file, typesupport_impls):
     (Path(args['output_dir']) / 'rust/src').mkdir(parents=True, exist_ok=True)
 
     for dep_tuple in args.get('ros_interface_dependencies', []):
-        dep_parts = dep_tuple.rsplit(':', 1)
+        dep_parts = dep_tuple.split(':', 1)
         assert len(dep_parts) == 2
         if dep_parts[0] != package_name:
             dependency_packages.add(dep_parts[0])


### PR DESCRIPTION
Paths on Windows can contain colons. With rsplit, the drive letter was grouped with the package name.