### PR TITLE
Declare fn new in waitables as pub(crate)

### DIFF
--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -184,11 +184,17 @@ impl Node {
     ///
     /// [1]: crate::Client
     // TODO: make client's lifetime depend on node's lifetime
-    pub fn create_client<T>(&mut self, topic: &str) -> Result<Arc<Client<T>>, RclrsError>
+    pub fn create_client<T>(
+        &mut self,
+        topic: &str,
+    ) -> Result<Arc<crate::node::client::Client<T>>, RclrsError>
     where
         T: rosidl_runtime_rs::Service,
     {
-        Client::<T>::new(self, topic)
+        let client = Arc::new(crate::node::client::Client::<T>::new(self, topic)?);
+        self.clients
+            .push(Arc::downgrade(&client) as Weak<dyn ClientBase>);
+        Ok(client)
     }
 
     /// Creates a [`Publisher`][1].
@@ -214,12 +220,17 @@ impl Node {
         &mut self,
         topic: &str,
         callback: F,
-    ) -> Result<Arc<Service<T>>, RclrsError>
+    ) -> Result<Arc<crate::node::service::Service<T>>, RclrsError>
     where
         T: rosidl_runtime_rs::Service,
         F: Fn(&rmw_request_id_t, T::Request) -> T::Response + 'static + Send,
     {
-        Service::<T>::new(self, topic, callback)
+        let service = Arc::new(crate::node::service::Service::<T>::new(
+            self, topic, callback,
+        )?);
+        self.services
+            .push(Arc::downgrade(&service) as Weak<dyn ServiceBase>);
+        Ok(service)
     }
 
     /// Creates a [`Subscription`][1].
@@ -236,7 +247,10 @@ impl Node {
         T: Message,
         F: FnMut(T) + 'static + Send,
     {
-        Subscription::new(self, topic, qos, callback)
+        let subscription = Arc::new(Subscription::<T>::new(self, topic, qos, callback)?);
+        self.subscriptions
+            .push(Arc::downgrade(&subscription) as Weak<dyn SubscriptionBase>);
+        Ok(subscription)
     }
 
     /// Returns the subscriptions that have not been dropped yet.

--- a/rclrs/src/node/client.rs
+++ b/rclrs/src/node/client.rs
@@ -78,7 +78,7 @@ where
     T: rosidl_runtime_rs::Service,
 {
     /// Creates a new client.
-    pub fn new(node: &mut Node, topic: &str) -> Result<Arc<Self>, RclrsError>
+    pub(crate) fn new(node: &Node, topic: &str) -> Result<Self, RclrsError>
     where
         T: rosidl_runtime_rs::Service,
     {
@@ -114,15 +114,14 @@ where
             rcl_client_mtx: Mutex::new(rcl_client),
             rcl_node_mtx: node.rcl_node_mtx.clone(),
         });
-        let client = Arc::new(Self {
+
+        Ok(Self {
             handle,
             requests: Mutex::new(HashMap::new()),
             futures: Arc::new(Mutex::new(
                 HashMap::<RequestId, oneshot::Sender<T::Response>>::new(),
             )),
-        });
-        node.clients.push(Arc::downgrade(&client) as _);
-        Ok(client)
+        })
     }
 
     /// Sends a request with a callback to be called with the response.

--- a/rclrs/src/node/client.rs
+++ b/rclrs/src/node/client.rs
@@ -64,6 +64,9 @@ type RequestValue<Response> = Box<dyn FnOnce(Response) + 'static + Send>;
 type RequestId = i64;
 
 /// Main class responsible for sending requests to a ROS service.
+///
+/// The only available way to instantiate clients is via [`Node::create_client`], this is to
+/// ensure that [`Node`]s can track all the clients that have been created.
 pub struct Client<T>
 where
     T: rosidl_runtime_rs::Service,
@@ -79,6 +82,8 @@ where
 {
     /// Creates a new client.
     pub(crate) fn new(node: &Node, topic: &str) -> Result<Self, RclrsError>
+    // This uses pub(crate) visibility to avoid instantiating this struct outside
+    // [`Node::create_client`], see the struct's documentation for the rationale
     where
         T: rosidl_runtime_rs::Service,
     {

--- a/rclrs/src/node/service.rs
+++ b/rclrs/src/node/service.rs
@@ -53,6 +53,9 @@ type ServiceCallback<Request, Response> =
     Box<dyn Fn(&rmw_request_id_t, Request) -> Response + 'static + Send>;
 
 /// Main class responsible for responding to requests sent by ROS clients.
+///
+/// The only available way to instantiate services is via [`Node::create_service`], this is to
+/// ensure that [`Node`]s can track all the services that have been created.
 pub struct Service<T>
 where
     T: rosidl_runtime_rs::Service,
@@ -68,6 +71,8 @@ where
 {
     /// Creates a new service.
     pub(crate) fn new<F>(node: &Node, topic: &str, callback: F) -> Result<Self, RclrsError>
+    // This uses pub(crate) visibility to avoid instantiating this struct outside
+    // [`Node::create_service`], see the struct's documentation for the rationale
     where
         T: rosidl_runtime_rs::Service,
         F: Fn(&rmw_request_id_t, T::Request) -> T::Response + 'static + Send,

--- a/rclrs/src/node/service.rs
+++ b/rclrs/src/node/service.rs
@@ -67,7 +67,7 @@ where
     T: rosidl_runtime_rs::Service,
 {
     /// Creates a new service.
-    pub fn new<F>(node: &mut Node, topic: &str, callback: F) -> Result<Arc<Self>, RclrsError>
+    pub(crate) fn new<F>(node: &Node, topic: &str, callback: F) -> Result<Self, RclrsError>
     where
         T: rosidl_runtime_rs::Service,
         F: Fn(&rmw_request_id_t, T::Request) -> T::Response + 'static + Send,
@@ -104,13 +104,11 @@ where
             handle: Mutex::new(service_handle),
             node_handle: node.rcl_node_mtx.clone(),
         });
-        let service = Arc::new(Self {
+
+        Ok(Self {
             handle,
             callback: Mutex::new(Box::new(callback)),
-        });
-        node.services.push(Arc::downgrade(&service) as _);
-
-        Ok(service)
+        })
     }
 
     /// Fetches a new request.

--- a/rclrs/src/node/subscription.rs
+++ b/rclrs/src/node/subscription.rs
@@ -57,6 +57,9 @@ pub trait SubscriptionBase: Send + Sync {
 /// When a subscription is created, it may take some time to get "matched" with a corresponding
 /// publisher.
 ///
+/// The only available way to instantiate subscriptions is via [`Node::create_subscription`], this
+/// is to ensure that [`Node`]s can track all the subscriptions that have been created.
+///
 /// [1]: crate::spin_once
 /// [2]: crate::spin
 pub struct Subscription<T>
@@ -80,6 +83,8 @@ where
         qos: QoSProfile,
         callback: F,
     ) -> Result<Self, RclrsError>
+    // This uses pub(crate) visibility to avoid instantiating this struct outside
+    // [`Node::create_subscription`], see the struct's documentation for the rationale
     where
         T: Message,
         F: FnMut(T) + 'static + Send,

--- a/rclrs/src/node/subscription.rs
+++ b/rclrs/src/node/subscription.rs
@@ -74,12 +74,12 @@ where
     T: Message,
 {
     /// Creates a new subscription.
-    pub fn new<F>(
-        node: &mut Node,
+    pub(crate) fn new<F>(
+        node: &Node,
         topic: &str,
         qos: QoSProfile,
         callback: F,
-    ) -> Result<Arc<Self>, RclrsError>
+    ) -> Result<Self, RclrsError>
     where
         T: Message,
         F: FnMut(T) + 'static + Send,
@@ -117,13 +117,12 @@ where
             rcl_subscription_mtx: Mutex::new(rcl_subscription),
             rcl_node_mtx: node.rcl_node_mtx.clone(),
         });
-        let subscription = Arc::new(Self {
+
+        Ok(Self {
             handle,
             callback: Mutex::new(Box::new(callback)),
             message: PhantomData,
-        });
-        node.subscriptions.push(Arc::downgrade(&subscription) as _);
-        Ok(subscription)
+        })
     }
 
     /// Returns the topic name of the subscription.
@@ -217,9 +216,8 @@ mod tests {
     fn test_instantiate_subscriber() -> Result<(), RclrsError> {
         let context =
             Context::new(vec![]).expect("Context instantiation is expected to be a success");
-        let mut node = create_node(&context, "test_new_subscriber")?;
-        let _subscriber = Subscription::<std_msgs::msg::String>::new(
-            &mut node,
+        let node = create_node(&context, "test_new_subscriber")?;
+        let _subscriber = node.create_subscription::<std_msgs::msg::String, _>(
             "test",
             QOS_PROFILE_DEFAULT,
             move |_: std_msgs::msg::String| {},


### PR DESCRIPTION
This PR restricts the visibility of `fn new` in waitables (`Subscription`, `Client`, `Service`) so that only other code in the crate can access it. This prevents users from instantiating these structures and therefore we ensure that the only way of creating them is via the `Node::create_X` methods so that any internal logic is not bypassed.