### PR TITLE
Implement Message for Box<T: Message> 

### DIFF
--- a/rosidl_runtime_rs/src/traits.rs
+++ b/rosidl_runtime_rs/src/traits.rs
@@ -144,6 +144,19 @@ pub trait Message: Clone + Debug + Default + 'static + Send + Sync {
     fn from_rmw_message(msg: Self::RmwMsg) -> Self;
 }
 
+/// Allows boxed values to be used by users in Publishers and Subscribers
+impl<T: Message> Message for Box<T> {
+    type RmwMsg = T::RmwMsg;
+
+    fn into_rmw_message(msg_cow: Cow<'_, Self>) -> Cow<'_, Self::RmwMsg> {
+        T::into_rmw_message(Cow::Owned(*msg_cow.into_owned()))
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Box::new(T::from_rmw_message(msg))
+    }
+}
+
 /// Trait for services.
 ///
 /// User code never needs to call this trait's method, much less implement this trait.

--- a/rosidl_runtime_rs/src/traits.rs
+++ b/rosidl_runtime_rs/src/traits.rs
@@ -144,7 +144,8 @@ pub trait Message: Clone + Debug + Default + 'static + Send + Sync {
     fn from_rmw_message(msg: Self::RmwMsg) -> Self;
 }
 
-/// Allows boxed values to be used by users in Publishers and Subscribers
+/// Allows boxed values to be used by users in Publishers and Subscriptions.
+// See https://github.com/ros2-rust/ros2_rust/pull/235 for a discussion of possible alternatives.
 impl<T: Message> Message for Box<T> {
     type RmwMsg = T::RmwMsg;
 


### PR DESCRIPTION
Fix for #185. Implements the Message trait for Box<T: Message> to allow for Boxed publishers and subscribers. 
You should now be able to do 
```rust
    let publisher =
        node.create_publisher::<Box<std_msgs::msg::String>>("topic", rclrs::QOS_PROFILE_DEFAULT)?;
    let mut message = Box::new(std_msgs::msg::String::default());
    publisher.publish(&message)?;
```
and 
```rust
    let _subscription = node.create_subscription::<Box<std_msgs::msg::String>, _>(
        "topic",
        rclrs::QOS_PROFILE_DEFAULT,
        move |msg: Box<std_msgs::msg::String>| {
            num_messages += 1;
            println!("I heard boxed: '{}'", (*msg).data);
            println!("(Got {} messages so far)", num_messages);
        },
    )?;
```
It's been 3 years since I last properly wrote Rust so I'm not sure my Cow handling is idiomatic. Also not sure if the trait implementation is in an appropriate location. 