### PR TITLE
Small bugfix for sequences of WStrings

### DIFF
--- a/rosidl_generator_rs/resource/msg_idiomatic.rs.em
+++ b/rosidl_generator_rs/resource/msg_idiomatic.rs.em
@@ -67,7 +67,7 @@ impl rosidl_runtime_rs::Message for @(type_name) {
 @#
 @#    == UnboundedSequence ==
 @[    elif isinstance(member.type, UnboundedSequence)]@
-@[        if isinstance(member.type.value_type, UnboundedString) or isinstance(member.type, UnboundedWString)]@
+@[        if isinstance(member.type.value_type, UnboundedString) or isinstance(member.type.value_type, UnboundedWString)]@
         @(get_rs_name(member.name)): msg.@(get_rs_name(member.name))
           .into_iter()
           .map(|elem| elem.as_str().into())
@@ -127,7 +127,7 @@ impl rosidl_runtime_rs::Message for @(type_name) {
 @#
 @#    == UnboundedSequence ==
 @[    elif isinstance(member.type, UnboundedSequence)]@
-@[        if isinstance(member.type.value_type, UnboundedString) or isinstance(member.type, UnboundedWString)]@
+@[        if isinstance(member.type.value_type, UnboundedString) or isinstance(member.type.value_type, UnboundedWString)]@
         @(get_rs_name(member.name)): msg.@(get_rs_name(member.name))
           .iter()
           .map(|elem| elem.as_str().into())
@@ -183,7 +183,7 @@ impl rosidl_runtime_rs::Message for @(type_name) {
 @[    elif isinstance(member.type, UnboundedSequence)]@
       @(get_rs_name(member.name)): msg.@(get_rs_name(member.name))
           .into_iter()
-@[        if isinstance(member.type.value_type, UnboundedString) or isinstance(member.type, UnboundedWString)]@
+@[        if isinstance(member.type.value_type, UnboundedString) or isinstance(member.type.value_type, UnboundedWString)]@
           .map(|elem| elem.to_string())
 @[        elif isinstance(member.type.value_type, NamedType) or isinstance(member.type.value_type, NamespacedType)]@
           .map(@(get_idiomatic_rs_type(member.type.value_type))::from_rmw_message)

--- a/rosidl_generator_rs/rosidl_generator_rs/__init__.py
+++ b/rosidl_generator_rs/rosidl_generator_rs/__init__.py
@@ -295,7 +295,7 @@ def make_get_idiomatic_rs_type(package_name):
         if isinstance(type_, UnboundedString) or isinstance(type_, UnboundedWString):
             return 'std::string::String'
         elif isinstance(type_, UnboundedSequence):
-            return 'Vec::<{}>'.format(get_idiomatic_rs_type(type_.value_type))
+            return 'Vec<{}>'.format(get_idiomatic_rs_type(type_.value_type))
         elif isinstance(type_, NamespacedType):
             return '::'.join(type_.namespaced_name()).replace(package_name, 'crate')
         elif isinstance(type_, Array):


### PR DESCRIPTION
Message packages containing unbounded sequences of WStrings, like test_msgs, would not compile because of this.

There is a special path for sequences of Strings/WStrings in the rosidl_generator_rs template in the `into_rmw_message()` function, but it wasn't taken for `WStrings` because of a copy-paste error.