### PR TITLE
Switch from actions-rs to dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,11 +52,8 @@ jobs:
         required-ros-distributions: ${{ matrix.ros_distribution }}
 
     - name: Setup Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
-        profile: minimal
-        toolchain: stable
-        override: true
         components: clippy, rustfmt
 
     - name: Install colcon-cargo and colcon-ros-cargo

--- a/rclrs/src/error.rs
+++ b/rclrs/src/error.rs
@@ -4,7 +4,7 @@ use std::ffi::{CStr, NulError};
 use std::fmt::{self, Display};
 
 /// The main error type.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum RclrsError {
     /// An error originating in the `rcl` layer.
     RclError {
@@ -59,7 +59,7 @@ impl Display for RclrsError {
 ///
 /// [1]: std::error::Error
 /// [2]: crate::RclrsError
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct RclErrorMsg(String);
 
 impl Display for RclErrorMsg {
@@ -87,7 +87,7 @@ impl Error for RclrsError {
 /// Most of these return codes should never occur in an `rclrs` application,
 /// since they are returned when `rcl` functions are used wrongly..
 #[repr(i32)]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum RclReturnCode {
     /// Success
     Ok = 0,

--- a/rclrs/src/node/graph.rs
+++ b/rclrs/src/node/graph.rs
@@ -38,7 +38,7 @@ impl Drop for rcutils_string_array_t {
 pub type TopicNamesAndTypes = HashMap<String, Vec<String>>;
 
 /// Stores a node's name and namespace
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct NodeNameInfo {
     /// The name of the node
     pub name: String,


### PR DESCRIPTION
The reason is that actions-rs became unmaintained (https://www.reddit.com/r/rust/comments/vyx4oj/actionsrs_organization_became_unmaintained/).
Also, dtolnay's rust-toolchain is simpler (at least in terms of code size).
Both are about equally fast (14s vs 12s in the runs I looked at, so 2s slower, but that doesn't matter compared to other steps).