### PR TITLE
Adds Guard Conditions

### DIFF
--- a/rclrs/CHANGELOG.rst
+++ b/rclrs/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog for package rclrs
 0.3
 ----------------
 * Loaned messages (zero-copy) (`#212 <https://github.com/ros2-rust/ros2_rust/pull/212>`_)
+* Graph queries (`#234 <https://github.com/ros2-rust/ros2_rust/pull/234>`_)
+* Guard conditions (`#249 <https://github.com/ros2-rust/ros2_rust/pull/249>`_)
 
 0.2 (2022-07-21)
 ----------------

--- a/rclrs/src/lib.rs
+++ b/rclrs/src/lib.rs
@@ -49,13 +49,14 @@ pub use rcl_bindings::rmw_request_id_t;
 pub fn spin_once(node: &Node, timeout: Option<Duration>) -> Result<(), RclrsError> {
     let live_subscriptions = node.live_subscriptions();
     let live_clients = node.live_clients();
+    let live_guard_conditions = node.live_guard_conditions();
     let live_services = node.live_services();
     let ctx = Context {
         rcl_context_mtx: node.rcl_context_mtx.clone(),
     };
     let mut wait_set = WaitSet::new(
         live_subscriptions.len(),
-        0,
+        live_guard_conditions.len(),
         0,
         live_clients.len(),
         live_services.len(),
@@ -69,6 +70,10 @@ pub fn spin_once(node: &Node, timeout: Option<Duration>) -> Result<(), RclrsErro
 
     for live_client in &live_clients {
         wait_set.add_client(live_client.clone())?;
+    }
+
+    for live_guard_condition in &live_guard_conditions {
+        wait_set.add_guard_condition(live_guard_condition.clone())?;
     }
 
     for live_service in &live_services {

--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -5,8 +5,9 @@ pub use self::graph::*;
 
 use crate::rcl_bindings::*;
 use crate::{
-    Client, ClientBase, Context, ParameterOverrideMap, Publisher, QoSProfile, RclrsError, Service,
-    ServiceBase, Subscription, SubscriptionBase, SubscriptionCallback, ToResult,
+    Client, ClientBase, Context, GuardCondition, ParameterOverrideMap, Publisher, QoSProfile,
+    RclrsError, Service, ServiceBase, Subscription, SubscriptionBase, SubscriptionCallback,
+    ToResult,
 };
 
 use std::cmp::PartialEq;
@@ -68,6 +69,7 @@ pub struct Node {
     pub(crate) rcl_node_mtx: Arc<Mutex<rcl_node_t>>,
     pub(crate) rcl_context_mtx: Arc<Mutex<rcl_context_t>>,
     pub(crate) clients: Vec<Weak<dyn ClientBase>>,
+    pub(crate) guard_conditions: Vec<Weak<GuardCondition>>,
     pub(crate) services: Vec<Weak<dyn ServiceBase>>,
     pub(crate) subscriptions: Vec<Weak<dyn SubscriptionBase>>,
     _parameter_map: ParameterOverrideMap,
@@ -189,6 +191,26 @@ impl Node {
         Ok(client)
     }
 
+    /// Creates a [`GuardCondition`][1].
+    ///
+    /// A weak pointer to the `GuardCondition` is stored within this node.
+    /// When this node is added to a wait set (e.g. when calling `spin_once`[2]
+    /// with this node as an argument), the guard condition can be used to
+    /// interrupt the wait.
+    ///
+    /// [1]: crate::GuardCondition
+    /// [2]: crate::spin_once
+    pub fn create_guard_condition(
+        &mut self,
+        context: &Context,
+        callback: Option<Box<dyn Fn() + Send + Sync>>,
+    ) -> Arc<GuardCondition> {
+        let guard_condition = Arc::new(GuardCondition::new(context, callback));
+        self.guard_conditions
+            .push(Arc::downgrade(&guard_condition) as Weak<GuardCondition>);
+        guard_condition
+    }
+
     /// Creates a [`Publisher`][1].
     ///
     /// [1]: crate::Publisher
@@ -252,6 +274,13 @@ impl Node {
 
     pub(crate) fn live_clients(&self) -> Vec<Arc<dyn ClientBase>> {
         self.clients.iter().filter_map(Weak::upgrade).collect()
+    }
+
+    pub(crate) fn live_guard_conditions(&self) -> Vec<Arc<GuardCondition>> {
+        self.guard_conditions
+            .iter()
+            .filter_map(Weak::upgrade)
+            .collect()
     }
 
     pub(crate) fn live_services(&self) -> Vec<Arc<dyn ServiceBase>> {

--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -203,7 +203,7 @@ impl Node {
     pub fn create_guard_condition(&mut self) -> Arc<GuardCondition> {
         let guard_condition = Arc::new(GuardCondition::new_with_rcl_context(
             &mut self.rcl_context_mtx.lock().unwrap(),
-            None::<fn()>,
+            None,
         ));
         self.guard_conditions
             .push(Arc::downgrade(&guard_condition) as Weak<GuardCondition>);
@@ -225,7 +225,7 @@ impl Node {
     {
         let guard_condition = Arc::new(GuardCondition::new_with_rcl_context(
             &mut self.rcl_context_mtx.lock().unwrap(),
-            Some(callback),
+            Some(Box::new(callback) as Box<dyn Fn() + Send + Sync>),
         ));
         self.guard_conditions
             .push(Arc::downgrade(&guard_condition) as Weak<GuardCondition>);

--- a/rclrs/src/node/builder.rs
+++ b/rclrs/src/node/builder.rs
@@ -276,6 +276,7 @@ impl NodeBuilder {
             rcl_node_mtx,
             rcl_context_mtx: self.context.clone(),
             clients: vec![],
+            guard_conditions: vec![],
             services: vec![],
             subscriptions: vec![],
             _parameter_map,

--- a/rclrs/src/wait.rs
+++ b/rclrs/src/wait.rs
@@ -369,7 +369,7 @@ mod tests {
     fn guard_condition_in_wait_set_readies() -> Result<(), RclrsError> {
         let context = Context::new([])?;
 
-        let guard_condition = Arc::new(GuardCondition::new(&context, None));
+        let guard_condition = Arc::new(GuardCondition::new(&context));
 
         let mut wait_set = WaitSet::new(0, 1, 0, 0, 0, 0, &context)?;
         wait_set.add_guard_condition(Arc::clone(&guard_condition))?;

--- a/rclrs/src/wait.rs
+++ b/rclrs/src/wait.rs
@@ -24,7 +24,9 @@ use std::time::Duration;
 use std::vec::Vec;
 
 mod exclusivity_guard;
+mod guard_condition;
 use exclusivity_guard::*;
+pub use guard_condition::*;
 
 /// A struct for waiting on subscriptions and other waitable entities to become ready.
 pub struct WaitSet {
@@ -36,6 +38,8 @@ pub struct WaitSet {
     // even in the error case.
     subscriptions: Vec<ExclusivityGuard<Arc<dyn SubscriptionBase>>>,
     clients: Vec<ExclusivityGuard<Arc<dyn ClientBase>>>,
+    // The guard conditions that are currently registered in the wait set.
+    guard_conditions: Vec<ExclusivityGuard<Arc<GuardCondition>>>,
     services: Vec<ExclusivityGuard<Arc<dyn ServiceBase>>>,
 }
 
@@ -45,6 +49,8 @@ pub struct ReadyEntities {
     pub subscriptions: Vec<Arc<dyn SubscriptionBase>>,
     /// A list of clients that have potentially received responses.
     pub clients: Vec<Arc<dyn ClientBase>>,
+    /// A list of guard conditions that have been triggered.
+    pub guard_conditions: Vec<Arc<GuardCondition>>,
     /// A list of services that have potentially received requests.
     pub services: Vec<Arc<dyn ServiceBase>>,
 }
@@ -105,6 +111,7 @@ impl WaitSet {
             rcl_wait_set,
             _rcl_context_mtx: context.rcl_context_mtx.clone(),
             subscriptions: Vec::new(),
+            guard_conditions: Vec::new(),
             clients: Vec::new(),
             services: Vec::new(),
         })
@@ -116,6 +123,7 @@ impl WaitSet {
     /// [`WaitSet::new`].
     pub fn clear(&mut self) {
         self.subscriptions.clear();
+        self.guard_conditions.clear();
         self.clients.clear();
         self.services.clear();
         // This cannot fail – the rcl_wait_set_clear function only checks that the input handle is
@@ -156,6 +164,38 @@ impl WaitSet {
         }
         .ok()?;
         self.subscriptions.push(exclusive_subscription);
+        Ok(())
+    }
+
+    /// Adds a guard condition to the wait set.
+    ///
+    /// # Errors
+    /// - If the guard condition was already added to this wait set or another one,
+    ///   [`AlreadyAddedToWaitSet`][1] will be returned
+    /// - If the number of guard conditions in the wait set is larger than the
+    ///   capacity set in [`WaitSet::new`], [`WaitSetFull`][2] will be returned
+    ///
+    /// [1]: crate::RclrsError
+    /// [2]: crate::RclReturnCode
+    pub fn add_guard_condition(
+        &mut self,
+        guard_condition: Arc<GuardCondition>,
+    ) -> Result<(), RclrsError> {
+        let exclusive_guard_condition = ExclusivityGuard::new(
+            Arc::clone(&guard_condition),
+            Arc::clone(&guard_condition.in_use_by_wait_set),
+        )?;
+
+        unsafe {
+            // SAFETY: Safe if the wait set and guard condition are initialized
+            rcl_wait_set_add_guard_condition(
+                &mut self.rcl_wait_set,
+                &*guard_condition.rcl_guard_condition.lock().unwrap(),
+                std::ptr::null_mut(),
+            )
+            .ok()?;
+        }
+        self.guard_conditions.push(exclusive_guard_condition);
         Ok(())
     }
 
@@ -262,6 +302,7 @@ impl WaitSet {
         let mut ready_entities = ReadyEntities {
             subscriptions: Vec::new(),
             clients: Vec::new(),
+            guard_conditions: Vec::new(),
             services: Vec::new(),
         };
         for (i, subscription) in self.subscriptions.iter().enumerate() {
@@ -275,6 +316,7 @@ impl WaitSet {
                     .push(Arc::clone(&subscription.waitable));
             }
         }
+
         for (i, client) in self.clients.iter().enumerate() {
             // SAFETY: The `clients` entry is an array of pointers, and this dereferencing is
             // equivalent to
@@ -284,6 +326,19 @@ impl WaitSet {
                 ready_entities.clients.push(Arc::clone(&client.waitable));
             }
         }
+
+        for (i, guard_condition) in self.guard_conditions.iter().enumerate() {
+            // SAFETY: The `clients` entry is an array of pointers, and this dereferencing is
+            // equivalent to
+            // https://github.com/ros2/rcl/blob/35a31b00a12f259d492bf53c0701003bd7f1745c/rcl/include/rcl/wait.h#L419
+            let wait_set_entry = unsafe { *self.rcl_wait_set.guard_conditions.add(i) };
+            if !wait_set_entry.is_null() {
+                ready_entities
+                    .guard_conditions
+                    .push(Arc::clone(&guard_condition.waitable));
+            }
+        }
+
         for (i, service) in self.services.iter().enumerate() {
             // SAFETY: The `services` entry is an array of pointers, and this dereferencing is
             // equivalent to
@@ -308,5 +363,21 @@ mod tests {
     fn wait_set_is_send_and_sync() {
         assert_send::<WaitSet>();
         assert_sync::<WaitSet>();
+    }
+
+    #[test]
+    fn guard_condition_in_wait_set_readies() -> Result<(), RclrsError> {
+        let context = Context::new([])?;
+
+        let guard_condition = Arc::new(GuardCondition::new(&context, None));
+
+        let mut wait_set = WaitSet::new(0, 1, 0, 0, 0, 0, &context)?;
+        wait_set.add_guard_condition(Arc::clone(&guard_condition))?;
+        guard_condition.trigger()?;
+
+        let readies = wait_set.wait(Some(std::time::Duration::from_millis(10)))?;
+        assert!(readies.guard_conditions.contains(&guard_condition));
+
+        Ok(())
     }
 }

--- a/rclrs/src/wait/guard_condition.rs
+++ b/rclrs/src/wait/guard_condition.rs
@@ -1,0 +1,176 @@
+use crate::rcl_bindings::*;
+use crate::{Context, RclrsError, ToResult};
+
+use std::sync::{atomic::AtomicBool, Arc, Mutex};
+
+/// A waitable entity used for waking up a wait set manually.
+///
+/// If a wait set that is currently waiting on events should be interrupted from a separate thread, this can be done
+/// by adding an `Arc<GuardCondition>` to the wait set, and calling `trigger()` on the same `GuardCondition` while
+/// the wait set is waiting.
+///
+/// The guard condition may be reused multiple times, but like other waitable entities, can not be used in
+/// multiple wait sets concurrently.
+///
+/// # Example
+/// ```
+/// # use rclrs::{Context, GuardCondition, WaitSet, RclrsError};
+/// # use std::sync::{Arc, atomic::Ordering};
+///
+/// let context = Context::new([])?;
+///
+/// let atomic_bool = Arc::new(std::sync::atomic::AtomicBool::new(false));
+/// let atomic_bool_for_closure = Arc::clone(&atomic_bool);
+///
+/// let gc = Arc::new(GuardCondition::new(
+///     &context,
+///     Some(Box::new(move || {
+///         atomic_bool_for_closure.store(true, Ordering::Relaxed);
+///     })),
+/// ));
+///
+/// let mut ws = WaitSet::new(0, 1, 0, 0, 0, 0, &context)?;
+/// ws.add_guard_condition(Arc::clone(&gc))?;
+///
+/// // Trigger the guard condition, firing the callback and waking the wait set being waited on, if any.
+/// gc.trigger()?;
+///
+/// // The provided callback has now been called.
+/// assert_eq!(atomic_bool.load(Ordering::Relaxed), true);
+///
+/// // The wait call will now immediately return.
+/// ws.wait(Some(std::time::Duration::from_millis(10)))?;
+///
+/// # Ok::<(), RclrsError>(())
+/// ```
+pub struct GuardCondition {
+    /// The rcl_guard_condition_t that this struct encapsulates.
+    pub(crate) rcl_guard_condition: Mutex<rcl_guard_condition_t>,
+    /// An optional callback to call when this guard condition is triggered.
+    callback: Option<Box<dyn Fn() + Send + Sync>>,
+    /// A flag to indicate if this guard condition has already been assigned to a wait set.
+    pub(crate) in_use_by_wait_set: Arc<AtomicBool>,
+}
+
+impl Drop for GuardCondition {
+    fn drop(&mut self) {
+        unsafe {
+            // SAFETY: No precondition for this function (besides passing in a valid guard condition)
+            rcl_guard_condition_fini(&mut *self.rcl_guard_condition.lock().unwrap());
+        }
+    }
+}
+
+impl PartialEq for GuardCondition {
+    fn eq(&self, other: &Self) -> bool {
+        // Because GuardCondition controls the creation of the rcl_guard_condition, each unique GuardCondition should have a unique
+        // rcl_guard_condition. Thus comparing equality of this member should be enough.
+        std::ptr::eq(
+            &self.rcl_guard_condition.lock().unwrap().impl_,
+            &other.rcl_guard_condition.lock().unwrap().impl_,
+        )
+    }
+}
+
+impl Eq for GuardCondition {}
+
+// SAFETY: rcl_guard_condition is the only member that doesn't implement Send, and it is designed to be accessed from other threads
+unsafe impl Send for rcl_guard_condition_t {}
+
+impl GuardCondition {
+    /// Creates a new guard condition.
+    pub fn new<F>(context: &Context, callback: Option<F>) -> Self
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        // SAFETY: Getting a zero initialized value is always safe
+        let mut guard_condition = unsafe { rcl_get_zero_initialized_guard_condition() };
+        unsafe {
+            // SAFETY: The context must be valid, and the guard condition must be zero-initialized
+            rcl_guard_condition_init(
+                &mut guard_condition,
+                &mut *context.rcl_context_mtx.lock().unwrap(),
+                rcl_guard_condition_get_default_options(),
+            );
+        }
+
+        Self {
+            rcl_guard_condition: Mutex::new(guard_condition),
+            callback: callback.map(|f| Box::new(f) as Box<dyn Fn() + Send + Sync>),
+            in_use_by_wait_set: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Triggers this guard condition, activating the wait set, and calling the optionally assigned callback.
+    pub fn trigger(&self) -> Result<(), RclrsError> {
+        unsafe {
+            // SAFETY: The rcl_guard_condition_t is valid.
+            rcl_trigger_guard_condition(&mut *self.rcl_guard_condition.lock().unwrap()).ok()?;
+        }
+        if let Some(callback) = &self.callback {
+            callback();
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::WaitSet;
+    use std::sync::atomic::Ordering;
+
+    #[test]
+    fn test_guard_condition() -> Result<(), RclrsError> {
+        let context = Context::new([])?;
+
+        let atomic_bool = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let atomic_bool_for_closure = Arc::clone(&atomic_bool);
+
+        let guard_condition = GuardCondition::new(
+            &context,
+            Some(Box::new(move || {
+                atomic_bool_for_closure.store(true, Ordering::Relaxed);
+            })),
+        );
+
+        guard_condition.trigger()?;
+
+        assert!(atomic_bool.load(Ordering::Relaxed));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_guard_condition_wait() -> Result<(), RclrsError> {
+        let context = Context::new([])?;
+
+        let atomic_bool = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let atomic_bool_for_closure = Arc::clone(&atomic_bool);
+
+        let guard_condition = Arc::new(GuardCondition::new(
+            &context,
+            Some(Box::new(move || {
+                atomic_bool_for_closure.store(true, Ordering::Relaxed);
+            })),
+        ));
+
+        let mut wait_set = WaitSet::new(0, 1, 0, 0, 0, 0, &context)?;
+        wait_set.add_guard_condition(Arc::clone(&guard_condition))?;
+        guard_condition.trigger()?;
+
+        assert!(atomic_bool.load(Ordering::Relaxed));
+        wait_set.wait(Some(std::time::Duration::from_millis(10)))?;
+
+        Ok(())
+    }
+
+    fn assert_send<T: Send>() {}
+    fn assert_sync<T: Sync>() {}
+
+    #[test]
+    fn test_guard_condition_is_send_and_sync() {
+        assert_send::<GuardCondition>();
+        assert_sync::<GuardCondition>();
+    }
+}


### PR DESCRIPTION
- Adds the Guard Condition struct encapsulating rcl_guard_condition_t.
- Adds optional callbacks and a trigger method to approximate the rclcpp
  implementation.
- Adds an `add_guard_condition` method to WaitSet to add the
  GuardCondition to the WaitSet