### PR TITLE
Add new rosidl_core repository to ros2_rust_rolling.repos

### DIFF
--- a/ros2_rust_rolling.repos
+++ b/ros2_rust_rolling.repos
@@ -2,24 +2,28 @@ repositories:
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git
-    version: master
+    version: rolling
   ros2/example_interfaces:
     type: git
     url: https://github.com/ros2/example_interfaces.git
-    version: master
+    version: rolling
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
-    version: master
+    version: rolling
   ros2/test_interface_files:
     type: git
     url: https://github.com/ros2/test_interface_files.git
-    version: master
+    version: rolling
+  ros2/rosidl_core:
+    type: git
+    url: https://github.com/ros2/rosidl_core.git
+    version: rolling
   ros2/rosidl_defaults:
     type: git
     url: https://github.com/ros2/rosidl_defaults.git
-    version: master
+    version: rolling
   ros2/unique_identifier_msgs:
     type: git
     url: https://github.com/ros2/unique_identifier_msgs.git
-    version: master
+    version: rolling


### PR DESCRIPTION
The build was broken, with an error about a missing `rosidl_core_generators` package that is a dependency of message packages.

In https://github.com/ros2/rosidl_defaults/pull/22, this package was split off from `rosidl_defaults` into a separate repo, which needed to be added.

I also changed the branches from 'master' to 'rolling', since they were renamed in all ROS 2 repos.