### PR TITLE
Add the --all-features flag to cargo test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -99,7 +99,7 @@ jobs:
         for path in $(colcon list | awk '$3 == "(ament_cargo)" && $1 != "examples_rclrs_minimal_pub_sub" && $1 != "examples_rclrs_minimal_client_service" { print $2 }'); do
         cd $path
         echo "Running cargo test in $path"
-        cargo test
+        cargo test --all-features
         cd -
         done
 


### PR DESCRIPTION
This partly addresses https://github.com/ros2-rust/ros2_rust/issues/135 – I think all feature combinations are too extreme. We can do that before we do a release, but not in a regular CI run.