### PR TITLE
Add publisher with member function example

### DIFF
--- a/examples/minimal_pub_sub/Cargo.toml
+++ b/examples/minimal_pub_sub/Cargo.toml
@@ -21,6 +21,10 @@ path = "src/zero_copy_subscriber.rs"
 name = "zero_copy_publisher"
 path = "src/zero_copy_publisher.rs"
 
+[[bin]]
+name = "publisher_member_function"
+path = "src/publisher_member_function.rs"
+
 [dependencies]
 anyhow = {version = "1", features = ["backtrace"]}
 

--- a/examples/minimal_pub_sub/src/publisher_member_function.rs
+++ b/examples/minimal_pub_sub/src/publisher_member_function.rs
@@ -1,0 +1,59 @@
+use std::{
+    env,
+    sync::{Arc, Mutex},
+    thread,
+    time::Duration,
+};
+
+use anyhow::Result;
+
+struct Publisher {
+    publisher: Arc<Mutex<rclrs::Publisher<std_msgs::msg::String>>>,
+    publish_count: Arc<Mutex<u32>>,
+}
+
+unsafe impl Send for Publisher {}
+
+impl Publisher {
+    pub fn new(context: &rclrs::Context) -> Self {
+        let node = rclrs::create_node(context, "publisher").unwrap();
+
+        let publisher = node
+            .create_publisher::<std_msgs::msg::String>("topic", rclrs::QOS_PROFILE_DEFAULT)
+            .unwrap();
+
+        Self {
+            publisher: Arc::new(Mutex::new(publisher)),
+            publish_count: Arc::new(Mutex::new(0)),
+        }
+    }
+
+    fn init(&mut self) {
+        let publish_count = self.publish_count.clone();
+        let publisher = self.publisher.clone();
+
+        thread::spawn(move || loop {
+            thread::sleep(Duration::from_secs(1));
+
+            let msg = std_msgs::msg::String {
+                data: format!("Hello, world! {}", publish_count.lock().unwrap()),
+            };
+
+            println!("Publishing: [{}]", msg.data);
+
+            publisher.lock().unwrap().publish(msg).unwrap();
+            let mut num_count = publish_count.lock().unwrap();
+            *num_count += 1;
+        });
+    }
+}
+
+fn main() -> Result<(), rclrs::RclrsError> {
+    let context = rclrs::Context::new(env::args())?;
+    let mut publisher = Publisher::new(&context);
+    publisher.init();
+    while context.ok() {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    Ok(())
+}


### PR DESCRIPTION
I thought that it can be quite useful to have this in examples. It's like a mix between [one of the rclcpp examples](https://github.com/ros2/examples/blob/rolling/rclcpp/topics/minimal_publisher/member_function.cpp) and republisher from [tutorial](https://github.com/ros2-rust/ros2_rust/blob/main/docs/writing-your-first-rclrs-node.md).

What I don't like is that it's still not 100% member function, ideally we would have something like:
```
    fn init(&mut self) {
        thread::spawn(move || loop {
            self.publish();
        });
    }
    
    fn publish(&self){
            thread::sleep(Duration::from_secs(1));

            let mut msg = std_msgs::msg::String::default();

            msg.data = format!("Hello, world! {}", publish_count.lock().unwrap());

            println!("Publishing: [{}]", msg.data);

            publisher.lock().unwrap().publish(msg).unwrap();
            let mut num_count = publish_count.lock().unwrap();
            *num_count += 1;
    }
```

But then I didn't came up with an elegant solution to that, without any errors on self lifetime.