### PR TITLE
Specify Rust 1.63 in Dockerfile & CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,7 +52,7 @@ jobs:
         required-ros-distributions: ${{ matrix.ros_distribution }}
 
     - name: Setup Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.63.0
       with:
         components: clippy, rustfmt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Rust and the cargo-ament-build plugin
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.62.0 -y
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.63.0 -y
 ENV PATH=/root/.cargo/bin:$PATH
 RUN cargo install cargo-ament-build
 


### PR DESCRIPTION
This is required now due to https://blog.rust-lang.org/2022/08/11/Rust-1.63.0.html#turbofish-for-generics-in-functions-with-impl-trait

Specifying an exact version in CI will also help against the build accidentally breaking due to new clippy lints etc.