### PR TITLE
Fix compilation error in examples

### DIFF
--- a/examples/message_demo/src/message_demo.rs
+++ b/examples/message_demo/src/message_demo.rs
@@ -143,20 +143,16 @@ fn demonstrate_pubsub() -> Result<(), Error> {
         rclrs::QOS_PROFILE_DEFAULT,
     )?;
 
-    let _idiomatic_subscription = node
-        .create_subscription::<rclrs_example_msgs::msg::VariousTypes, _>(
-            "topic",
-            rclrs::QOS_PROFILE_DEFAULT,
-            move |_msg: rclrs_example_msgs::msg::VariousTypes| println!("Got idiomatic message!"),
-        )?;
-    let _direct_subscription = node
-        .create_subscription::<rclrs_example_msgs::msg::rmw::VariousTypes, _>(
-            "topic",
-            rclrs::QOS_PROFILE_DEFAULT,
-            move |_msg: rclrs_example_msgs::msg::rmw::VariousTypes| {
-                println!("Got RMW-native message!")
-            },
-        )?;
+    let _idiomatic_subscription = node.create_subscription(
+        "topic",
+        rclrs::QOS_PROFILE_DEFAULT,
+        move |_msg: rclrs_example_msgs::msg::VariousTypes| println!("Got idiomatic message!"),
+    )?;
+    let _direct_subscription = node.create_subscription(
+        "topic",
+        rclrs::QOS_PROFILE_DEFAULT,
+        move |_msg: rclrs_example_msgs::msg::rmw::VariousTypes| println!("Got RMW-native message!"),
+    )?;
     println!("Sending idiomatic message.");
     idiomatic_publisher.publish(rclrs_example_msgs::msg::VariousTypes::default())?;
     rclrs::spin_once(&node, None)?;

--- a/examples/minimal_pub_sub/src/minimal_subscriber.rs
+++ b/examples/minimal_pub_sub/src/minimal_subscriber.rs
@@ -8,7 +8,7 @@ fn main() -> Result<(), Error> {
 
     let mut num_messages: usize = 0;
 
-    let _subscription = node.create_subscription::<std_msgs::msg::String, _>(
+    let _subscription = node.create_subscription(
         "topic",
         rclrs::QOS_PROFILE_DEFAULT,
         move |msg: std_msgs::msg::String| {

--- a/examples/minimal_pub_sub/src/zero_copy_subscriber.rs
+++ b/examples/minimal_pub_sub/src/zero_copy_subscriber.rs
@@ -9,7 +9,7 @@ fn main() -> Result<(), Error> {
 
     let mut num_messages: usize = 0;
 
-    let _subscription = node.create_subscription::<std_msgs::msg::UInt32, _>(
+    let _subscription = node.create_subscription(
         "topic",
         rclrs::QOS_PROFILE_DEFAULT,
         move |msg: std_msgs::msg::UInt32| {


### PR DESCRIPTION
Hi when I build the workspace the examples gave following compile error:

```
error[E0632]: cannot provide explicit generic arguments when `impl Trait` is used in argument position
  --> src/zero_copy_subscriber.rs:12:52
   |
12 |     let _subscription = node.create_subscription::<std_msgs::msg::UInt32, _>(
   |                                                    ^^^^^^^^^^^^^^^^^^^^^  ^ explicit generic argument not allowed
   |                                                    |
   |                                                    explicit generic argument not allowed
   |
   = note: see issue #83701 <https://github.com/rust-lang/rust/issues/83701> for more information

For more information about this error, try `rustc --explain E0632`.
```

Looks like I could fix this by removing part of the type declarations.

I'm really new to Rust lang, so this PR may not be the best solution.