### PR TITLE
Add support for constants to message generation

### DIFF
--- a/rclrs_example_msgs/msg/VariousTypes.msg
+++ b/rclrs_example_msgs/msg/VariousTypes.msg
@@ -32,3 +32,10 @@ NestedType[2] nested_array
 NestedType[] nested_seq_unbounded
 NestedType[<=3] nested_seq_bounded
 
+
+# binary, hexadecimal and octal constants are also possible
+int8 TWO_PLUS_TWO = 5
+# Only unbounded strings are possible
+string PASSWORD = "hunter2"
+# As determined by Edward J. Goodwin
+float32 PI = 3.0

--- a/rosidl_generator_rs/resource/msg.rs.em
+++ b/rosidl_generator_rs/resource/msg.rs.em
@@ -5,7 +5,8 @@ TEMPLATE(
     package_name=package_name, interface_path=interface_path,
     msg_specs=msg_specs,
     get_rs_name=get_rs_name, get_rmw_rs_type=get_rmw_rs_type,
-    get_idiomatic_rs_type=get_idiomatic_rs_type)
+    get_idiomatic_rs_type=get_idiomatic_rs_type,
+    constant_value_to_rs=constant_value_to_rs)
 }@
 }  // mod rmw
 
@@ -15,5 +16,6 @@ TEMPLATE(
     package_name=package_name, interface_path=interface_path,
     msg_specs=msg_specs,
     get_rs_name=get_rs_name, get_rmw_rs_type=get_rmw_rs_type,
-    get_idiomatic_rs_type=get_idiomatic_rs_type)
+    get_idiomatic_rs_type=get_idiomatic_rs_type,
+    constant_value_to_rs=constant_value_to_rs)
 }@

--- a/rosidl_generator_rs/resource/msg_idiomatic.rs.em
+++ b/rosidl_generator_rs/resource/msg_idiomatic.rs.em
@@ -1,4 +1,5 @@
 @{
+from rosidl_parser.definition import AbstractGenericString
 from rosidl_parser.definition import Array
 from rosidl_parser.definition import BasicType
 from rosidl_parser.definition import BoundedSequence
@@ -28,6 +29,30 @@ pub struct @(type_name) {
     pub @(get_rs_name(member.name)): @(get_idiomatic_rs_type(member.type)),
 @[end for]@
 }
+
+@[if msg_spec.constants]@
+impl @(type_name) {
+@[for constant in msg_spec.constants]@
+@{
+comments = getattr(constant, 'get_comment_lines', lambda: [])()
+}@
+@[  for line in comments]@
+@[    if line]@
+    /// @(line)
+@[    else]@
+    ///
+@[    end if]@
+@[  end for]@
+@[  if isinstance(constant.type, BasicType)]@
+    pub const @(get_rs_name(constant.name)): @(get_rmw_rs_type(constant.type)) = @(constant_value_to_rs(constant.type, constant.value));
+@[  elif isinstance(constant.type, AbstractGenericString)]@
+    pub const @(get_rs_name(constant.name)): &'static str = @(constant_value_to_rs(constant.type, constant.value));
+@[  else]@
+@{assert False, 'Unhandled constant type: ' + str(constant.type)}@
+@[  end if]@
+@[end for]@
+}
+@[end if]
 
 impl Default for @(type_name) {
   fn default() -> Self {

--- a/rosidl_generator_rs/resource/srv.rs.em
+++ b/rosidl_generator_rs/resource/srv.rs.em
@@ -12,7 +12,8 @@ TEMPLATE(
     package_name=package_name, interface_path=interface_path,
     msg_specs=req_res_specs,
     get_rs_name=get_rs_name, get_rmw_rs_type=get_rmw_rs_type,
-    get_idiomatic_rs_type=get_idiomatic_rs_type)
+    get_idiomatic_rs_type=get_idiomatic_rs_type,
+    constant_value_to_rs=constant_value_to_rs)
 }@
 
 @[for subfolder, srv_spec in srv_specs]
@@ -48,7 +49,8 @@ TEMPLATE(
     package_name=package_name, interface_path=interface_path,
     msg_specs=req_res_specs,
     get_rs_name=get_rs_name, get_rmw_rs_type=get_rmw_rs_type,
-    get_idiomatic_rs_type=get_idiomatic_rs_type)
+    get_idiomatic_rs_type=get_idiomatic_rs_type,
+    constant_value_to_rs=constant_value_to_rs)
 }@
 
 @[for subfolder, srv_spec in srv_specs]

--- a/rosidl_generator_rs/rosidl_generator_rs/__init__.py
+++ b/rosidl_generator_rs/rosidl_generator_rs/__init__.py
@@ -243,28 +243,14 @@ def primitive_value_to_rs(type_, value):
 def constant_value_to_rs(type_, value):
     assert value is not None
 
-    if type_ == 'bool':
-        return 'true' if value else 'false'
-
-    if type_ in [
-            'byte',
-            'char',
-            'int8',
-            'uint8',
-            'int16',
-            'uint16',
-            'int32',
-            'uint32',
-            'int64',
-            'uint64',
-            'float64',
-    ]:
+    if isinstance(type_, BasicType):
+        if type_.typename == 'boolean':
+            return 'true' if value else 'false'
+        elif type_.typename == 'float32':
+            return '%sf' % value
         return str(value)
 
-    if type_ == 'float32':
-        return '%sf' % value
-
-    if type_ == 'string':
+    if isinstance(type_, AbstractGenericString):
         return '"%s"' % escape_string(value)
 
     assert False, "unknown constant type '%s'" % type_


### PR DESCRIPTION
This will produce:

```
impl VariousTypes {
    /// binary, hexadecimal and octal constants are also possible
    pub const TWO_PLUS_TWO: i8 = 5;
    /// Only unbounded strings are possible
    pub const PASSWORD: &'static str = "hunter2";
    /// As determined by Edward J. Goodwin
    pub const PI: f32 = 3.0;
 }
 ```

Implementation notes:
* Comments on constants are not supported in Foxy, hence the `getattr`
* I changed `constant_value_to_rs` to operate on an rosidl type identifier, not a string. That was more straightforward both for the caller and the implementation of the function.
* I theoretically could have mapped strings to a static variable of type `BoundedString`, but having a constant of type `&str` seemed more useful.