### PR TITLE
Format all code with group_imports = StdExternalCrate

### DIFF
--- a/examples/message_demo/src/message_demo.rs
+++ b/examples/message_demo/src/message_demo.rs
@@ -1,7 +1,7 @@
-use anyhow::{Error, Result};
 use std::convert::TryInto;
 use std::env;
 
+use anyhow::{Error, Result};
 use rosidl_runtime_rs::{seq, BoundedSequence, Message, Sequence};
 
 fn check_default_values() {

--- a/examples/minimal_client_service/src/minimal_client.rs
+++ b/examples/minimal_client_service/src/minimal_client.rs
@@ -1,5 +1,6 @@
-use anyhow::{Error, Result};
 use std::env;
+
+use anyhow::{Error, Result};
 
 fn main() -> Result<(), Error> {
     let context = rclrs::Context::new(env::args())?;

--- a/examples/minimal_client_service/src/minimal_client_async.rs
+++ b/examples/minimal_client_service/src/minimal_client_async.rs
@@ -1,5 +1,6 @@
-use anyhow::{Error, Result};
 use std::env;
+
+use anyhow::{Error, Result};
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {

--- a/examples/minimal_client_service/src/minimal_service.rs
+++ b/examples/minimal_client_service/src/minimal_service.rs
@@ -1,5 +1,6 @@
-use anyhow::{Error, Result};
 use std::env;
+
+use anyhow::{Error, Result};
 
 fn handle_service(
     _request_header: &rclrs::rmw_request_id_t,

--- a/examples/minimal_pub_sub/src/minimal_publisher.rs
+++ b/examples/minimal_pub_sub/src/minimal_publisher.rs
@@ -1,5 +1,6 @@
-use anyhow::{Error, Result};
 use std::env;
+
+use anyhow::{Error, Result};
 
 fn main() -> Result<(), Error> {
     let context = rclrs::Context::new(env::args())?;

--- a/examples/minimal_pub_sub/src/minimal_subscriber.rs
+++ b/examples/minimal_pub_sub/src/minimal_subscriber.rs
@@ -1,5 +1,6 @@
-use anyhow::{Error, Result};
 use std::env;
+
+use anyhow::{Error, Result};
 
 fn main() -> Result<(), Error> {
     let context = rclrs::Context::new(env::args())?;

--- a/examples/minimal_pub_sub/src/zero_copy_publisher.rs
+++ b/examples/minimal_pub_sub/src/zero_copy_publisher.rs
@@ -1,5 +1,6 @@
-use anyhow::{Error, Result};
 use std::env;
+
+use anyhow::{Error, Result};
 
 fn main() -> Result<(), Error> {
     let context = rclrs::Context::new(env::args())?;

--- a/rclrs/src/arguments.rs
+++ b/rclrs/src/arguments.rs
@@ -1,9 +1,11 @@
-use crate::error::*;
-use crate::rcl_bindings::*;
-use libc::c_void;
 use std::ffi::CString;
 use std::os::raw::c_char;
 use std::ptr::null_mut;
+
+use libc::c_void;
+
+use crate::error::*;
+use crate::rcl_bindings::*;
 
 /// Extract non-ROS arguments from program's input arguments.
 ///

--- a/rclrs/src/client.rs
+++ b/rclrs/src/client.rs
@@ -1,16 +1,16 @@
-use futures::channel::oneshot;
 use std::boxed::Box;
 use std::collections::HashMap;
 use std::ffi::CString;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex, MutexGuard};
 
+use futures::channel::oneshot;
+use rosidl_runtime_rs::Message;
+
 use crate::error::{RclReturnCode, ToResult};
 use crate::MessageCow;
 use crate::Node;
 use crate::{rcl_bindings::*, RclrsError};
-
-use rosidl_runtime_rs::Message;
 
 // SAFETY: The functions accessing this type, including drop(), shouldn't care about the thread
 // they are running in. Therefore, this type can be safely sent to another thread.

--- a/rclrs/src/context.rs
+++ b/rclrs/src/context.rs
@@ -1,11 +1,11 @@
-use crate::rcl_bindings::*;
-use crate::{RclrsError, ToResult};
-
 use std::ffi::CString;
 use std::os::raw::c_char;
 use std::string::String;
 use std::sync::{Arc, Mutex};
 use std::vec::Vec;
+
+use crate::rcl_bindings::*;
+use crate::{RclrsError, ToResult};
 
 impl Drop for rcl_context_t {
     fn drop(&mut self) {

--- a/rclrs/src/error.rs
+++ b/rclrs/src/error.rs
@@ -1,7 +1,8 @@
-use crate::rcl_bindings::*;
 use std::error::Error;
 use std::ffi::{CStr, NulError};
 use std::fmt::{self, Display};
+
+use crate::rcl_bindings::*;
 
 /// The main error type.
 #[derive(Debug, PartialEq, Eq)]

--- a/rclrs/src/lib.rs
+++ b/rclrs/src/lib.rs
@@ -19,6 +19,8 @@ mod wait;
 
 mod rcl_bindings;
 
+use std::time::Duration;
+
 pub use arguments::*;
 pub use client::*;
 pub use context::*;
@@ -27,14 +29,11 @@ pub use node::*;
 pub use parameter::*;
 pub use publisher::*;
 pub use qos::*;
+use rcl_bindings::rcl_context_is_valid;
+pub use rcl_bindings::rmw_request_id_t;
 pub use service::*;
 pub use subscription::*;
 pub use wait::*;
-
-use rcl_bindings::rcl_context_is_valid;
-use std::time::Duration;
-
-pub use rcl_bindings::rmw_request_id_t;
 
 /// Polls the node for new messages and executes the corresponding callbacks.
 ///

--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -1,15 +1,5 @@
 mod builder;
 mod graph;
-pub use self::builder::*;
-pub use self::graph::*;
-
-use crate::rcl_bindings::*;
-use crate::{
-    Client, ClientBase, Context, GuardCondition, ParameterOverrideMap, Publisher, QoSProfile,
-    RclrsError, Service, ServiceBase, Subscription, SubscriptionBase, SubscriptionCallback,
-    ToResult,
-};
-
 use std::cmp::PartialEq;
 use std::ffi::CStr;
 use std::fmt;
@@ -18,6 +8,15 @@ use std::vec::Vec;
 
 use libc::c_char;
 use rosidl_runtime_rs::Message;
+
+pub use self::builder::*;
+pub use self::graph::*;
+use crate::rcl_bindings::*;
+use crate::{
+    Client, ClientBase, Context, GuardCondition, ParameterOverrideMap, Publisher, QoSProfile,
+    RclrsError, Service, ServiceBase, Subscription, SubscriptionBase, SubscriptionCallback,
+    ToResult,
+};
 
 impl Drop for rcl_node_t {
     fn drop(&mut self) {

--- a/rclrs/src/node/builder.rs
+++ b/rclrs/src/node/builder.rs
@@ -1,11 +1,11 @@
+use std::ffi::CString;
+use std::sync::{Arc, Mutex};
+
 use crate::rcl_bindings::*;
 use crate::{
     node::call_string_getter_with_handle, resolve_parameter_overrides, Context, Node, RclrsError,
     ToResult,
 };
-
-use std::ffi::CString;
-use std::sync::{Arc, Mutex};
 
 /// A builder for creating a [`Node`][1].
 ///

--- a/rclrs/src/parameter/override_map.rs
+++ b/rclrs/src/parameter/override_map.rs
@@ -1,8 +1,10 @@
-use crate::rcl_bindings::*;
-use crate::{ParameterValue, RclrsError, ToResult};
-use libc::c_char;
 use std::collections::BTreeMap;
 use std::ffi::CStr;
+
+use libc::c_char;
+
+use crate::rcl_bindings::*;
+use crate::{ParameterValue, RclrsError, ToResult};
 
 // Internal helper struct, iterator for rcl_params_t
 struct RclParamsIter<'a> {
@@ -137,11 +139,13 @@ pub(crate) unsafe fn resolve_parameter_overrides(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::error::Error;
     use std::ffi::CString;
     use std::io::Write;
+
     use tempfile::NamedTempFile;
+
+    use super::*;
 
     // These files have values for every possible four-bit number, with the four bits being
     // * `/**` global params

--- a/rclrs/src/parameter/value.rs
+++ b/rclrs/src/parameter/value.rs
@@ -1,5 +1,6 @@
-use crate::rcl_bindings::*;
 use std::ffi::CStr;
+
+use crate::rcl_bindings::*;
 
 /// A parameter value.
 ///

--- a/rclrs/src/publisher.rs
+++ b/rclrs/src/publisher.rs
@@ -1,8 +1,3 @@
-use crate::error::{RclrsError, ToResult};
-use crate::qos::QoSProfile;
-use crate::rcl_bindings::*;
-use crate::Node;
-
 use std::borrow::Cow;
 use std::ffi::CStr;
 use std::ffi::CString;
@@ -10,6 +5,11 @@ use std::marker::PhantomData;
 use std::sync::{Arc, Mutex};
 
 use rosidl_runtime_rs::{Message, RmwMessage};
+
+use crate::error::{RclrsError, ToResult};
+use crate::qos::QoSProfile;
+use crate::rcl_bindings::*;
+use crate::Node;
 
 mod loaned_message;
 pub use loaned_message::*;

--- a/rclrs/src/publisher/loaned_message.rs
+++ b/rclrs/src/publisher/loaned_message.rs
@@ -1,9 +1,9 @@
-use crate::rcl_bindings::*;
-use crate::{Publisher, RclrsError, ToResult};
+use std::ops::{Deref, DerefMut};
 
 use rosidl_runtime_rs::RmwMessage;
 
-use std::ops::{Deref, DerefMut};
+use crate::rcl_bindings::*;
+use crate::{Publisher, RclrsError, ToResult};
 
 /// A message that is owned by the middleware, loaned for publishing.
 ///

--- a/rclrs/src/qos.rs
+++ b/rclrs/src/qos.rs
@@ -1,6 +1,6 @@
-use crate::rcl_bindings::*;
-
 use std::time::Duration;
+
+use crate::rcl_bindings::*;
 
 /// The `HISTORY` DDS QoS policy.
 ///

--- a/rclrs/src/service.rs
+++ b/rclrs/src/service.rs
@@ -3,10 +3,10 @@ use std::ffi::CString;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex, MutexGuard};
 
+use rosidl_runtime_rs::Message;
+
 use crate::error::{RclReturnCode, ToResult};
 use crate::{rcl_bindings::*, MessageCow, Node, RclrsError};
-
-use rosidl_runtime_rs::Message;
 
 // SAFETY: The functions accessing this type, including drop(), shouldn't care about the thread
 // they are running in. Therefore, this type can be safely sent to another thread.

--- a/rclrs/src/subscription.rs
+++ b/rclrs/src/subscription.rs
@@ -1,8 +1,3 @@
-use crate::error::{RclReturnCode, ToResult};
-use crate::qos::QoSProfile;
-use crate::Node;
-use crate::{rcl_bindings::*, RclrsError};
-
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::marker::PhantomData;
@@ -10,6 +5,11 @@ use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use rosidl_runtime_rs::{Message, RmwMessage};
+
+use crate::error::{RclReturnCode, ToResult};
+use crate::qos::QoSProfile;
+use crate::Node;
+use crate::{rcl_bindings::*, RclrsError};
 
 mod callback;
 mod message_info;

--- a/rclrs/src/subscription/callback.rs
+++ b/rclrs/src/subscription/callback.rs
@@ -1,7 +1,7 @@
+use rosidl_runtime_rs::Message;
+
 use super::MessageInfo;
 use crate::ReadOnlyLoanedMessage;
-
-use rosidl_runtime_rs::Message;
 
 /// A trait for allowed callbacks for subscriptions.
 ///

--- a/rclrs/src/subscription/message_info.rs
+++ b/rclrs/src/subscription/message_info.rs
@@ -1,6 +1,6 @@
-use crate::rcl_bindings::*;
-
 use std::time::{Duration, SystemTime};
+
+use crate::rcl_bindings::*;
 
 /// An identifier for a publisher in the local context.
 ///

--- a/rclrs/src/subscription/readonly_loaned_message.rs
+++ b/rclrs/src/subscription/readonly_loaned_message.rs
@@ -1,9 +1,9 @@
-use crate::rcl_bindings::*;
-use crate::{Subscription, ToResult};
+use std::ops::Deref;
 
 use rosidl_runtime_rs::Message;
 
-use std::ops::Deref;
+use crate::rcl_bindings::*;
+use crate::{Subscription, ToResult};
 
 /// A message that is owned by the middleware, loaned out for reading.
 ///

--- a/rclrs/src/wait.rs
+++ b/rclrs/src/wait.rs
@@ -15,13 +15,13 @@
 // DISTRIBUTION A. Approved for public release; distribution unlimited.
 // OPSEC #4584.
 
-use crate::error::{to_rclrs_result, RclReturnCode, RclrsError, ToResult};
-use crate::rcl_bindings::*;
-use crate::{ClientBase, Context, ServiceBase, SubscriptionBase};
-
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use std::vec::Vec;
+
+use crate::error::{to_rclrs_result, RclReturnCode, RclrsError, ToResult};
+use crate::rcl_bindings::*;
+use crate::{ClientBase, Context, ServiceBase, SubscriptionBase};
 
 mod exclusivity_guard;
 mod guard_condition;

--- a/rclrs/src/wait/exclusivity_guard.rs
+++ b/rclrs/src/wait/exclusivity_guard.rs
@@ -37,9 +37,10 @@ impl<T> ExclusivityGuard<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
+
+    use super::*;
 
     #[test]
     fn test_exclusivity_guard() {

--- a/rclrs/src/wait/guard_condition.rs
+++ b/rclrs/src/wait/guard_condition.rs
@@ -1,7 +1,7 @@
+use std::sync::{atomic::AtomicBool, Arc, Mutex};
+
 use crate::rcl_bindings::*;
 use crate::{Context, RclrsError, ToResult};
-
-use std::sync::{atomic::AtomicBool, Arc, Mutex};
 
 /// A waitable entity used for waking up a wait set manually.
 ///
@@ -135,9 +135,10 @@ impl GuardCondition {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::Ordering;
+
     use super::*;
     use crate::WaitSet;
-    use std::sync::atomic::Ordering;
 
     #[test]
     fn test_guard_condition() -> Result<(), RclrsError> {

--- a/rclrs_tests/src/graph_tests.rs
+++ b/rclrs_tests/src/graph_tests.rs
@@ -1,7 +1,6 @@
 use rclrs::{
     Context, Node, NodeBuilder, RclrsError, TopicNamesAndTypes, QOS_PROFILE_SYSTEM_DEFAULT,
 };
-
 use test_msgs::{msg, srv};
 
 struct TestGraph {

--- a/rosidl_runtime_rs/src/sequence.rs
+++ b/rosidl_runtime_rs/src/sequence.rs
@@ -681,8 +681,9 @@ macro_rules! seq {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use quickcheck::{quickcheck, Arbitrary, Gen};
+
+    use super::*;
 
     impl<T: Arbitrary + SequenceAlloc> Arbitrary for Sequence<T> {
         fn arbitrary(g: &mut Gen) -> Self {

--- a/rosidl_runtime_rs/src/sequence/serde.rs
+++ b/rosidl_runtime_rs/src/sequence/serde.rs
@@ -49,8 +49,9 @@ impl<T: Serialize + SequenceAlloc, const N: usize> Serialize for BoundedSequence
 
 #[cfg(test)]
 mod tests {
-    use crate::{BoundedSequence, Sequence};
     use quickcheck::quickcheck;
+
+    use crate::{BoundedSequence, Sequence};
 
     quickcheck! {
         fn test_json_roundtrip_sequence(xs: Sequence<i32>) -> bool {

--- a/rosidl_runtime_rs/src/string.rs
+++ b/rosidl_runtime_rs/src/string.rs
@@ -467,8 +467,9 @@ impl std::error::Error for StringExceedsBoundsError {}
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use quickcheck::{Arbitrary, Gen};
+
+    use super::*;
 
     impl Arbitrary for String {
         fn arbitrary(g: &mut Gen) -> Self {

--- a/rosidl_runtime_rs/src/string/serde.rs
+++ b/rosidl_runtime_rs/src/string/serde.rs
@@ -86,8 +86,9 @@ impl<const N: usize> Serialize for BoundedWString<N> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{BoundedString, BoundedWString, String, WString};
     use quickcheck::quickcheck;
+
+    use crate::{BoundedString, BoundedWString, String, WString};
 
     quickcheck! {
         fn test_json_roundtrip_string(s: String) -> bool {


### PR DESCRIPTION
This non-default `rustfmt` option was mentioned in https://blog.rust-lang.org/inside-rust/2022/09/29/announcing-the-rust-style-team.html. I think it's nice to have a consistent order for `use` statements.

I didn't create a `.rustfmt.toml` file with this setting because the setting requires nightly Rust, and I'm not sure if we want to require that for development.