### PR TITLE
Fix a bug in graph query function and add regression test

### DIFF
--- a/rclrs/src/node/graph.rs
+++ b/rclrs/src/node/graph.rs
@@ -47,6 +47,7 @@ pub struct NodeNameInfo {
 }
 
 /// Contains topic endpoint information
+#[derive(Debug, PartialEq, Eq)]
 pub struct TopicEndpointInfo {
     /// The name of the endpoint node
     pub node_name: String,
@@ -374,7 +375,7 @@ impl Node {
                 &*self.rcl_node_mtx.lock().unwrap(),
                 &mut rcutils_get_default_allocator(),
                 topic.as_ptr(),
-                true,
+                false,
                 &mut rcl_publishers_info,
             )
             .ok()?;


### PR DESCRIPTION
It's an easy mistake to make – in https://github.com/ros2/rcl/blob/rolling/rcl/include/rcl/graph.h, some functions have a `no_demangle` argument and others have a `no_mangle` argument. The `no_mangle` argument should be `true`, but it was false. 