### PR TITLE
Vendor rcl_interfaces as a private module into rclrs

### DIFF
--- a/rclrs/package.xml
+++ b/rclrs/package.xml
@@ -16,6 +16,8 @@
   <build_depend>libclang-dev</build_depend>
   <build_depend>rosidl_runtime_rs</build_depend>
   <build_depend>rcl</build_depend>
+  <depend>builtin_interfaces</depend>
+  <depend>rcl_interfaces</depend>
 
   <export>
     <build_type>ament_cargo</build_type>

--- a/rclrs/src/lib.rs
+++ b/rclrs/src/lib.rs
@@ -15,6 +15,7 @@ mod publisher;
 mod qos;
 mod service;
 mod subscription;
+mod vendor;
 mod wait;
 
 mod rcl_bindings;

--- a/rclrs/src/parameter/service.rs
+++ b/rclrs/src/parameter/service.rs
@@ -1,0 +1,89 @@
+use std::sync::{Arc, Weak, Mutex};
+
+use crate::vendor::rcl_interfaces::srv::rmw::*;
+use crate::vendor::rcl_interfaces::msg::rmw::*;
+use rosidl_runtime_rs::{Sequence, seq};
+
+use crate::{rmw_request_id_t, Node, RclrsError, Service, ServiceBase};
+use crate::rcl_bindings::rcl_node_t;
+
+pub struct ParameterService {
+    describe_parameters_service: Arc<Service<DescribeParameters>>,
+    get_parameter_types_service: Arc<Service<GetParameterTypes>>,
+    get_parameters_service: Arc<Service<GetParameters>>,
+    list_parameters_service: Arc<Service<ListParameters>>,
+    set_parameters_service: Arc<Service<SetParameters>>,
+    set_parameters_atomically_service: Arc<Service<SetParametersAtomically>>,
+}
+
+impl ParameterService {
+    pub fn new(rcl_node_mtx: Arc<Mutex<rcl_node_t>>) -> Result<Self, RclrsError> {
+        let describe_parameters_service = Service::new(Arc::clone(&rcl_node_mtx),
+            "describe_parameters",
+            |req_id: &rmw_request_id_t, req: DescribeParameters_Request| {
+                DescribeParameters_Response {
+                    descriptors: seq![]
+                }
+            },
+        )?;
+        let get_parameter_types_service = Service::new(Arc::clone(&rcl_node_mtx),
+            "get_parameter_types",
+            |req_id: &rmw_request_id_t, req: GetParameterTypes_Request| {
+                GetParameterTypes_Response {
+                    types: seq![]
+                }
+            },
+        )?;
+        let get_parameters_service = Service::new(Arc::clone(&rcl_node_mtx),
+            "get_parameters",
+            |req_id: &rmw_request_id_t, req: GetParameters_Request| {
+                GetParameters_Response {
+                    values: seq![]
+                }
+            },
+        )?;
+        let list_parameters_service = Service::new(Arc::clone(&rcl_node_mtx),
+            "list_parameters",
+            |req_id: &rmw_request_id_t, req: ListParameters_Request| {
+                ListParameters_Response {
+                    result: ListParametersResult::default()
+                }
+            },
+        )?;
+        let set_parameters_service = Service::new(Arc::clone(&rcl_node_mtx),
+            "set_parameters",
+            |req_id: &rmw_request_id_t, req: SetParameters_Request| {
+                SetParameters_Response {
+                    results: seq![]
+                }
+            },
+        )?;
+        let set_parameters_atomically_service = Service::new(Arc::clone(&rcl_node_mtx),
+            "set_parameters_atomically",
+            |req_id: &rmw_request_id_t, req: SetParametersAtomically_Request| {
+                SetParametersAtomically_Response {
+                    result: SetParametersResult::default()
+                }
+            },
+        )?;
+        Ok(Self {
+            describe_parameters_service: Arc::new(describe_parameters_service),
+            get_parameter_types_service: Arc::new(get_parameter_types_service),
+            get_parameters_service: Arc::new(get_parameters_service),
+            list_parameters_service: Arc::new(list_parameters_service),
+            set_parameters_service: Arc::new(set_parameters_service),
+            set_parameters_atomically_service: Arc::new(set_parameters_atomically_service),
+        })
+    }
+
+    pub fn services(&self) -> Vec<Weak<dyn ServiceBase>> {
+        vec![
+            Arc::downgrade(&self.describe_parameters_service) as Weak<dyn ServiceBase>,
+            Arc::downgrade(&self.get_parameter_types_service) as Weak<dyn ServiceBase>,
+            Arc::downgrade(&self.get_parameters_service) as Weak<dyn ServiceBase>,
+            Arc::downgrade(&self.list_parameters_service) as Weak<dyn ServiceBase>,
+            Arc::downgrade(&self.set_parameters_service) as Weak<dyn ServiceBase>,
+            Arc::downgrade(&self.set_parameters_atomically_service) as Weak<dyn ServiceBase>,
+        ]
+    }
+}

--- a/rclrs/src/vendor/builtin_interfaces/mod.rs
+++ b/rclrs/src/vendor/builtin_interfaces/mod.rs
@@ -1,0 +1,3 @@
+#![allow(non_camel_case_types)]
+
+pub mod msg;

--- a/rclrs/src/vendor/builtin_interfaces/msg.rs
+++ b/rclrs/src/vendor/builtin_interfaces/msg.rs
@@ -1,0 +1,258 @@
+pub mod rmw {
+    #[cfg(feature = "serde")]
+    use serde::{Deserialize, Serialize};
+
+    #[link(name = "builtin_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__builtin_interfaces__msg__Duration(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    #[link(name = "builtin_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn builtin_interfaces__msg__Duration__init(msg: *mut Duration) -> bool;
+        fn builtin_interfaces__msg__Duration__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Duration>,
+            size: usize,
+        ) -> bool;
+        fn builtin_interfaces__msg__Duration__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Duration>,
+        );
+        fn builtin_interfaces__msg__Duration__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Duration>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Duration>,
+        ) -> bool;
+    }
+
+    // Corresponds to builtin_interfaces__msg__Duration
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Duration {
+        pub sec: i32,
+        pub nanosec: u32,
+    }
+
+    impl Default for Duration {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !builtin_interfaces__msg__Duration__init(&mut msg as *mut _) {
+                    panic!("Call to builtin_interfaces__msg__Duration__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Duration {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { builtin_interfaces__msg__Duration__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { builtin_interfaces__msg__Duration__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { builtin_interfaces__msg__Duration__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Duration {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Duration
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "builtin_interfaces/msg/Duration";
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__builtin_interfaces__msg__Duration()
+            }
+        }
+    }
+
+    #[link(name = "builtin_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__builtin_interfaces__msg__Time(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    #[link(name = "builtin_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn builtin_interfaces__msg__Time__init(msg: *mut Time) -> bool;
+        fn builtin_interfaces__msg__Time__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Time>,
+            size: usize,
+        ) -> bool;
+        fn builtin_interfaces__msg__Time__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Time>,
+        );
+        fn builtin_interfaces__msg__Time__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Time>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Time>,
+        ) -> bool;
+    }
+
+    // Corresponds to builtin_interfaces__msg__Time
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Time {
+        pub sec: i32,
+        pub nanosec: u32,
+    }
+
+    impl Default for Time {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !builtin_interfaces__msg__Time__init(&mut msg as *mut _) {
+                    panic!("Call to builtin_interfaces__msg__Time__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Time {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { builtin_interfaces__msg__Time__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { builtin_interfaces__msg__Time__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { builtin_interfaces__msg__Time__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Time {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Time
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "builtin_interfaces/msg/Time";
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__builtin_interfaces__msg__Time(
+                )
+            }
+        }
+    }
+} // mod rmw
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Duration {
+    pub sec: i32,
+    pub nanosec: u32,
+}
+
+impl Default for Duration {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::builtin_interfaces::msg::rmw::Duration::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Duration {
+    type RmwMsg = crate::vendor::builtin_interfaces::msg::rmw::Duration;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                sec: msg.sec,
+                nanosec: msg.nanosec,
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                sec: msg.sec,
+                nanosec: msg.nanosec,
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            sec: msg.sec,
+            nanosec: msg.nanosec,
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Time {
+    pub sec: i32,
+    pub nanosec: u32,
+}
+
+impl Default for Time {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::builtin_interfaces::msg::rmw::Time::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Time {
+    type RmwMsg = crate::vendor::builtin_interfaces::msg::rmw::Time;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                sec: msg.sec,
+                nanosec: msg.nanosec,
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                sec: msg.sec,
+                nanosec: msg.nanosec,
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            sec: msg.sec,
+            nanosec: msg.nanosec,
+        }
+    }
+}

--- a/rclrs/src/vendor/mod.rs
+++ b/rclrs/src/vendor/mod.rs
@@ -1,0 +1,6 @@
+//! Created by vendor_interfaces.py
+#![allow(dead_code)]
+#![allow(clippy::derive_partial_eq_without_eq)]
+
+pub mod builtin_interfaces;
+pub mod rcl_interfaces;

--- a/rclrs/src/vendor/rcl_interfaces/mod.rs
+++ b/rclrs/src/vendor/rcl_interfaces/mod.rs
@@ -1,0 +1,5 @@
+#![allow(non_camel_case_types)]
+
+pub mod msg;
+
+pub mod srv;

--- a/rclrs/src/vendor/rcl_interfaces/msg.rs
+++ b/rclrs/src/vendor/rcl_interfaces/msg.rs
@@ -1,0 +1,1775 @@
+pub mod rmw {
+    #[cfg(feature = "serde")]
+    use serde::{Deserialize, Serialize};
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__msg__FloatingPointRange(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn rcl_interfaces__msg__FloatingPointRange__init(msg: *mut FloatingPointRange) -> bool;
+        fn rcl_interfaces__msg__FloatingPointRange__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<FloatingPointRange>,
+            size: usize,
+        ) -> bool;
+        fn rcl_interfaces__msg__FloatingPointRange__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<FloatingPointRange>,
+        );
+        fn rcl_interfaces__msg__FloatingPointRange__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<FloatingPointRange>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<FloatingPointRange>,
+        ) -> bool;
+    }
+
+    // Corresponds to rcl_interfaces__msg__FloatingPointRange
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct FloatingPointRange {
+        pub from_value: f64,
+        pub to_value: f64,
+        pub step: f64,
+    }
+
+    impl Default for FloatingPointRange {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !rcl_interfaces__msg__FloatingPointRange__init(&mut msg as *mut _) {
+                    panic!("Call to rcl_interfaces__msg__FloatingPointRange__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for FloatingPointRange {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__msg__FloatingPointRange__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__msg__FloatingPointRange__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__msg__FloatingPointRange__Sequence__copy(in_seq, out_seq as *mut _)
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for FloatingPointRange {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for FloatingPointRange
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "rcl_interfaces/msg/FloatingPointRange";
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__msg__FloatingPointRange()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__msg__IntegerRange(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn rcl_interfaces__msg__IntegerRange__init(msg: *mut IntegerRange) -> bool;
+        fn rcl_interfaces__msg__IntegerRange__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<IntegerRange>,
+            size: usize,
+        ) -> bool;
+        fn rcl_interfaces__msg__IntegerRange__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<IntegerRange>,
+        );
+        fn rcl_interfaces__msg__IntegerRange__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<IntegerRange>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<IntegerRange>,
+        ) -> bool;
+    }
+
+    // Corresponds to rcl_interfaces__msg__IntegerRange
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct IntegerRange {
+        pub from_value: i64,
+        pub to_value: i64,
+        pub step: u64,
+    }
+
+    impl Default for IntegerRange {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !rcl_interfaces__msg__IntegerRange__init(&mut msg as *mut _) {
+                    panic!("Call to rcl_interfaces__msg__IntegerRange__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for IntegerRange {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__msg__IntegerRange__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__msg__IntegerRange__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__msg__IntegerRange__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for IntegerRange {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for IntegerRange
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "rcl_interfaces/msg/IntegerRange";
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__msg__IntegerRange()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__msg__ListParametersResult(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn rcl_interfaces__msg__ListParametersResult__init(msg: *mut ListParametersResult) -> bool;
+        fn rcl_interfaces__msg__ListParametersResult__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<ListParametersResult>,
+            size: usize,
+        ) -> bool;
+        fn rcl_interfaces__msg__ListParametersResult__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<ListParametersResult>,
+        );
+        fn rcl_interfaces__msg__ListParametersResult__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<ListParametersResult>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<ListParametersResult>,
+        ) -> bool;
+    }
+
+    // Corresponds to rcl_interfaces__msg__ListParametersResult
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct ListParametersResult {
+        pub names: rosidl_runtime_rs::Sequence<rosidl_runtime_rs::String>,
+        pub prefixes: rosidl_runtime_rs::Sequence<rosidl_runtime_rs::String>,
+    }
+
+    impl Default for ListParametersResult {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !rcl_interfaces__msg__ListParametersResult__init(&mut msg as *mut _) {
+                    panic!("Call to rcl_interfaces__msg__ListParametersResult__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for ListParametersResult {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__msg__ListParametersResult__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__msg__ListParametersResult__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__msg__ListParametersResult__Sequence__copy(in_seq, out_seq as *mut _)
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for ListParametersResult {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for ListParametersResult
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "rcl_interfaces/msg/ListParametersResult";
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__msg__ListParametersResult()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__msg__Log(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn rcl_interfaces__msg__Log__init(msg: *mut Log) -> bool;
+        fn rcl_interfaces__msg__Log__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Log>,
+            size: usize,
+        ) -> bool;
+        fn rcl_interfaces__msg__Log__Sequence__fini(seq: *mut rosidl_runtime_rs::Sequence<Log>);
+        fn rcl_interfaces__msg__Log__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Log>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Log>,
+        ) -> bool;
+    }
+
+    // Corresponds to rcl_interfaces__msg__Log
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Log {
+        pub stamp: crate::vendor::builtin_interfaces::msg::rmw::Time,
+        pub level: u8,
+        pub name: rosidl_runtime_rs::String,
+        pub msg: rosidl_runtime_rs::String,
+        pub file: rosidl_runtime_rs::String,
+        pub function: rosidl_runtime_rs::String,
+        pub line: u32,
+    }
+
+    impl Log {
+        /// Debug is for pedantic information, which is useful when debugging issues.
+        pub const DEBUG: u8 = 10;
+        /// Info is the standard informational level and is used to report expected
+        /// information.
+        pub const INFO: u8 = 20;
+        /// Warning is for information that may potentially cause issues or possibly unexpected
+        /// behavior.
+        pub const WARN: u8 = 30;
+        /// Error is for information that this node cannot resolve.
+        pub const ERROR: u8 = 40;
+        /// Information about a impending node shutdown.
+        pub const FATAL: u8 = 50;
+    }
+
+    impl Default for Log {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !rcl_interfaces__msg__Log__init(&mut msg as *mut _) {
+                    panic!("Call to rcl_interfaces__msg__Log__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Log {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__msg__Log__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__msg__Log__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__msg__Log__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Log {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Log
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "rcl_interfaces/msg/Log";
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__msg__Log()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__msg__ParameterDescriptor(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn rcl_interfaces__msg__ParameterDescriptor__init(msg: *mut ParameterDescriptor) -> bool;
+        fn rcl_interfaces__msg__ParameterDescriptor__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<ParameterDescriptor>,
+            size: usize,
+        ) -> bool;
+        fn rcl_interfaces__msg__ParameterDescriptor__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<ParameterDescriptor>,
+        );
+        fn rcl_interfaces__msg__ParameterDescriptor__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<ParameterDescriptor>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<ParameterDescriptor>,
+        ) -> bool;
+    }
+
+    // Corresponds to rcl_interfaces__msg__ParameterDescriptor
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct ParameterDescriptor {
+        pub name: rosidl_runtime_rs::String,
+        pub type_: u8,
+        pub description: rosidl_runtime_rs::String,
+        pub additional_constraints: rosidl_runtime_rs::String,
+        pub read_only: bool,
+        pub floating_point_range: rosidl_runtime_rs::BoundedSequence<
+            crate::vendor::rcl_interfaces::msg::rmw::FloatingPointRange,
+            1,
+        >,
+        pub integer_range: rosidl_runtime_rs::BoundedSequence<
+            crate::vendor::rcl_interfaces::msg::rmw::IntegerRange,
+            1,
+        >,
+    }
+
+    impl Default for ParameterDescriptor {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !rcl_interfaces__msg__ParameterDescriptor__init(&mut msg as *mut _) {
+                    panic!("Call to rcl_interfaces__msg__ParameterDescriptor__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for ParameterDescriptor {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__msg__ParameterDescriptor__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__msg__ParameterDescriptor__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__msg__ParameterDescriptor__Sequence__copy(in_seq, out_seq as *mut _)
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for ParameterDescriptor {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for ParameterDescriptor
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "rcl_interfaces/msg/ParameterDescriptor";
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__msg__ParameterDescriptor()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__msg__ParameterEventDescriptors(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn rcl_interfaces__msg__ParameterEventDescriptors__init(
+            msg: *mut ParameterEventDescriptors,
+        ) -> bool;
+        fn rcl_interfaces__msg__ParameterEventDescriptors__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<ParameterEventDescriptors>,
+            size: usize,
+        ) -> bool;
+        fn rcl_interfaces__msg__ParameterEventDescriptors__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<ParameterEventDescriptors>,
+        );
+        fn rcl_interfaces__msg__ParameterEventDescriptors__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<ParameterEventDescriptors>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<ParameterEventDescriptors>,
+        ) -> bool;
+    }
+
+    // Corresponds to rcl_interfaces__msg__ParameterEventDescriptors
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct ParameterEventDescriptors {
+        pub new_parameters: rosidl_runtime_rs::Sequence<
+            crate::vendor::rcl_interfaces::msg::rmw::ParameterDescriptor,
+        >,
+        pub changed_parameters: rosidl_runtime_rs::Sequence<
+            crate::vendor::rcl_interfaces::msg::rmw::ParameterDescriptor,
+        >,
+        pub deleted_parameters: rosidl_runtime_rs::Sequence<
+            crate::vendor::rcl_interfaces::msg::rmw::ParameterDescriptor,
+        >,
+    }
+
+    impl Default for ParameterEventDescriptors {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !rcl_interfaces__msg__ParameterEventDescriptors__init(&mut msg as *mut _) {
+                    panic!("Call to rcl_interfaces__msg__ParameterEventDescriptors__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for ParameterEventDescriptors {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__msg__ParameterEventDescriptors__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__msg__ParameterEventDescriptors__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__msg__ParameterEventDescriptors__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for ParameterEventDescriptors {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for ParameterEventDescriptors
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "rcl_interfaces/msg/ParameterEventDescriptors";
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__msg__ParameterEventDescriptors()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__msg__ParameterEvent(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn rcl_interfaces__msg__ParameterEvent__init(msg: *mut ParameterEvent) -> bool;
+        fn rcl_interfaces__msg__ParameterEvent__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<ParameterEvent>,
+            size: usize,
+        ) -> bool;
+        fn rcl_interfaces__msg__ParameterEvent__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<ParameterEvent>,
+        );
+        fn rcl_interfaces__msg__ParameterEvent__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<ParameterEvent>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<ParameterEvent>,
+        ) -> bool;
+    }
+
+    // Corresponds to rcl_interfaces__msg__ParameterEvent
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct ParameterEvent {
+        pub stamp: crate::vendor::builtin_interfaces::msg::rmw::Time,
+        pub node: rosidl_runtime_rs::String,
+        pub new_parameters:
+            rosidl_runtime_rs::Sequence<crate::vendor::rcl_interfaces::msg::rmw::Parameter>,
+        pub changed_parameters:
+            rosidl_runtime_rs::Sequence<crate::vendor::rcl_interfaces::msg::rmw::Parameter>,
+        pub deleted_parameters:
+            rosidl_runtime_rs::Sequence<crate::vendor::rcl_interfaces::msg::rmw::Parameter>,
+    }
+
+    impl Default for ParameterEvent {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !rcl_interfaces__msg__ParameterEvent__init(&mut msg as *mut _) {
+                    panic!("Call to rcl_interfaces__msg__ParameterEvent__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for ParameterEvent {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__msg__ParameterEvent__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__msg__ParameterEvent__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__msg__ParameterEvent__Sequence__copy(in_seq, out_seq as *mut _)
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for ParameterEvent {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for ParameterEvent
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "rcl_interfaces/msg/ParameterEvent";
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__msg__ParameterEvent()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__msg__Parameter(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn rcl_interfaces__msg__Parameter__init(msg: *mut Parameter) -> bool;
+        fn rcl_interfaces__msg__Parameter__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Parameter>,
+            size: usize,
+        ) -> bool;
+        fn rcl_interfaces__msg__Parameter__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Parameter>,
+        );
+        fn rcl_interfaces__msg__Parameter__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Parameter>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Parameter>,
+        ) -> bool;
+    }
+
+    // Corresponds to rcl_interfaces__msg__Parameter
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Parameter {
+        pub name: rosidl_runtime_rs::String,
+        pub value: crate::vendor::rcl_interfaces::msg::rmw::ParameterValue,
+    }
+
+    impl Default for Parameter {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !rcl_interfaces__msg__Parameter__init(&mut msg as *mut _) {
+                    panic!("Call to rcl_interfaces__msg__Parameter__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Parameter {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__msg__Parameter__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__msg__Parameter__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__msg__Parameter__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Parameter {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Parameter
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "rcl_interfaces/msg/Parameter";
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__msg__Parameter()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__msg__ParameterType(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn rcl_interfaces__msg__ParameterType__init(msg: *mut ParameterType) -> bool;
+        fn rcl_interfaces__msg__ParameterType__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<ParameterType>,
+            size: usize,
+        ) -> bool;
+        fn rcl_interfaces__msg__ParameterType__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<ParameterType>,
+        );
+        fn rcl_interfaces__msg__ParameterType__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<ParameterType>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<ParameterType>,
+        ) -> bool;
+    }
+
+    // Corresponds to rcl_interfaces__msg__ParameterType
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct ParameterType {
+        pub structure_needs_at_least_one_member: u8,
+    }
+
+    impl ParameterType {
+        /// Default value, which implies this is not a valid parameter.
+        pub const PARAMETER_NOT_SET: u8 = 0;
+        pub const PARAMETER_BOOL: u8 = 1;
+        pub const PARAMETER_INTEGER: u8 = 2;
+        pub const PARAMETER_DOUBLE: u8 = 3;
+        pub const PARAMETER_STRING: u8 = 4;
+        pub const PARAMETER_BYTE_ARRAY: u8 = 5;
+        pub const PARAMETER_BOOL_ARRAY: u8 = 6;
+        pub const PARAMETER_INTEGER_ARRAY: u8 = 7;
+        pub const PARAMETER_DOUBLE_ARRAY: u8 = 8;
+        pub const PARAMETER_STRING_ARRAY: u8 = 9;
+    }
+
+    impl Default for ParameterType {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !rcl_interfaces__msg__ParameterType__init(&mut msg as *mut _) {
+                    panic!("Call to rcl_interfaces__msg__ParameterType__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for ParameterType {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__msg__ParameterType__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__msg__ParameterType__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__msg__ParameterType__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for ParameterType {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for ParameterType
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "rcl_interfaces/msg/ParameterType";
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__msg__ParameterType()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__msg__ParameterValue(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn rcl_interfaces__msg__ParameterValue__init(msg: *mut ParameterValue) -> bool;
+        fn rcl_interfaces__msg__ParameterValue__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<ParameterValue>,
+            size: usize,
+        ) -> bool;
+        fn rcl_interfaces__msg__ParameterValue__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<ParameterValue>,
+        );
+        fn rcl_interfaces__msg__ParameterValue__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<ParameterValue>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<ParameterValue>,
+        ) -> bool;
+    }
+
+    // Corresponds to rcl_interfaces__msg__ParameterValue
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct ParameterValue {
+        pub type_: u8,
+        pub bool_value: bool,
+        pub integer_value: i64,
+        pub double_value: f64,
+        pub string_value: rosidl_runtime_rs::String,
+        pub byte_array_value: rosidl_runtime_rs::Sequence<u8>,
+        pub bool_array_value: rosidl_runtime_rs::Sequence<bool>,
+        pub integer_array_value: rosidl_runtime_rs::Sequence<i64>,
+        pub double_array_value: rosidl_runtime_rs::Sequence<f64>,
+        pub string_array_value: rosidl_runtime_rs::Sequence<rosidl_runtime_rs::String>,
+    }
+
+    impl Default for ParameterValue {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !rcl_interfaces__msg__ParameterValue__init(&mut msg as *mut _) {
+                    panic!("Call to rcl_interfaces__msg__ParameterValue__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for ParameterValue {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__msg__ParameterValue__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__msg__ParameterValue__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__msg__ParameterValue__Sequence__copy(in_seq, out_seq as *mut _)
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for ParameterValue {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for ParameterValue
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "rcl_interfaces/msg/ParameterValue";
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__msg__ParameterValue()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__msg__SetParametersResult(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn rcl_interfaces__msg__SetParametersResult__init(msg: *mut SetParametersResult) -> bool;
+        fn rcl_interfaces__msg__SetParametersResult__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<SetParametersResult>,
+            size: usize,
+        ) -> bool;
+        fn rcl_interfaces__msg__SetParametersResult__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<SetParametersResult>,
+        );
+        fn rcl_interfaces__msg__SetParametersResult__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<SetParametersResult>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<SetParametersResult>,
+        ) -> bool;
+    }
+
+    // Corresponds to rcl_interfaces__msg__SetParametersResult
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct SetParametersResult {
+        pub successful: bool,
+        pub reason: rosidl_runtime_rs::String,
+    }
+
+    impl Default for SetParametersResult {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !rcl_interfaces__msg__SetParametersResult__init(&mut msg as *mut _) {
+                    panic!("Call to rcl_interfaces__msg__SetParametersResult__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for SetParametersResult {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__msg__SetParametersResult__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__msg__SetParametersResult__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__msg__SetParametersResult__Sequence__copy(in_seq, out_seq as *mut _)
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for SetParametersResult {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for SetParametersResult
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "rcl_interfaces/msg/SetParametersResult";
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__msg__SetParametersResult()
+            }
+        }
+    }
+} // mod rmw
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct FloatingPointRange {
+    pub from_value: f64,
+    pub to_value: f64,
+    pub step: f64,
+}
+
+impl Default for FloatingPointRange {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::rcl_interfaces::msg::rmw::FloatingPointRange::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for FloatingPointRange {
+    type RmwMsg = crate::vendor::rcl_interfaces::msg::rmw::FloatingPointRange;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                from_value: msg.from_value,
+                to_value: msg.to_value,
+                step: msg.step,
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                from_value: msg.from_value,
+                to_value: msg.to_value,
+                step: msg.step,
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            from_value: msg.from_value,
+            to_value: msg.to_value,
+            step: msg.step,
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct IntegerRange {
+    pub from_value: i64,
+    pub to_value: i64,
+    pub step: u64,
+}
+
+impl Default for IntegerRange {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::rcl_interfaces::msg::rmw::IntegerRange::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for IntegerRange {
+    type RmwMsg = crate::vendor::rcl_interfaces::msg::rmw::IntegerRange;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                from_value: msg.from_value,
+                to_value: msg.to_value,
+                step: msg.step,
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                from_value: msg.from_value,
+                to_value: msg.to_value,
+                step: msg.step,
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            from_value: msg.from_value,
+            to_value: msg.to_value,
+            step: msg.step,
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct ListParametersResult {
+    pub names: Vec<std::string::String>,
+    pub prefixes: Vec<std::string::String>,
+}
+
+impl Default for ListParametersResult {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::rcl_interfaces::msg::rmw::ListParametersResult::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for ListParametersResult {
+    type RmwMsg = crate::vendor::rcl_interfaces::msg::rmw::ListParametersResult;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                names: msg
+                    .names
+                    .into_iter()
+                    .map(|elem| elem.as_str().into())
+                    .collect(),
+                prefixes: msg
+                    .prefixes
+                    .into_iter()
+                    .map(|elem| elem.as_str().into())
+                    .collect(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                names: msg.names.iter().map(|elem| elem.as_str().into()).collect(),
+                prefixes: msg
+                    .prefixes
+                    .iter()
+                    .map(|elem| elem.as_str().into())
+                    .collect(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            names: msg.names.into_iter().map(|elem| elem.to_string()).collect(),
+            prefixes: msg
+                .prefixes
+                .into_iter()
+                .map(|elem| elem.to_string())
+                .collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Log {
+    pub stamp: crate::vendor::builtin_interfaces::msg::Time,
+    pub level: u8,
+    pub name: std::string::String,
+    pub msg: std::string::String,
+    pub file: std::string::String,
+    pub function: std::string::String,
+    pub line: u32,
+}
+
+impl Log {
+    /// Debug is for pedantic information, which is useful when debugging issues.
+    pub const DEBUG: u8 = 10;
+    /// Info is the standard informational level and is used to report expected
+    /// information.
+    pub const INFO: u8 = 20;
+    /// Warning is for information that may potentially cause issues or possibly unexpected
+    /// behavior.
+    pub const WARN: u8 = 30;
+    /// Error is for information that this node cannot resolve.
+    pub const ERROR: u8 = 40;
+    /// Information about a impending node shutdown.
+    pub const FATAL: u8 = 50;
+}
+
+impl Default for Log {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::rcl_interfaces::msg::rmw::Log::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Log {
+    type RmwMsg = crate::vendor::rcl_interfaces::msg::rmw::Log;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                stamp: crate::vendor::builtin_interfaces::msg::Time::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.stamp),
+                )
+                .into_owned(),
+                level: msg.level,
+                name: msg.name.as_str().into(),
+                msg: msg.msg.as_str().into(),
+                file: msg.file.as_str().into(),
+                function: msg.function.as_str().into(),
+                line: msg.line,
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                stamp: crate::vendor::builtin_interfaces::msg::Time::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.stamp),
+                )
+                .into_owned(),
+                level: msg.level,
+                name: msg.name.as_str().into(),
+                msg: msg.msg.as_str().into(),
+                file: msg.file.as_str().into(),
+                function: msg.function.as_str().into(),
+                line: msg.line,
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            stamp: crate::vendor::builtin_interfaces::msg::Time::from_rmw_message(msg.stamp),
+            level: msg.level,
+            name: msg.name.to_string(),
+            msg: msg.msg.to_string(),
+            file: msg.file.to_string(),
+            function: msg.function.to_string(),
+            line: msg.line,
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct ParameterDescriptor {
+    pub name: std::string::String,
+    pub type_: u8,
+    pub description: std::string::String,
+    pub additional_constraints: std::string::String,
+    pub read_only: bool,
+    pub floating_point_range: rosidl_runtime_rs::BoundedSequence<
+        crate::vendor::rcl_interfaces::msg::rmw::FloatingPointRange,
+        1,
+    >,
+    pub integer_range: rosidl_runtime_rs::BoundedSequence<
+        crate::vendor::rcl_interfaces::msg::rmw::IntegerRange,
+        1,
+    >,
+}
+
+impl Default for ParameterDescriptor {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::rcl_interfaces::msg::rmw::ParameterDescriptor::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for ParameterDescriptor {
+    type RmwMsg = crate::vendor::rcl_interfaces::msg::rmw::ParameterDescriptor;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                name: msg.name.as_str().into(),
+                type_: msg.type_,
+                description: msg.description.as_str().into(),
+                additional_constraints: msg.additional_constraints.as_str().into(),
+                read_only: msg.read_only,
+                floating_point_range: msg.floating_point_range,
+                integer_range: msg.integer_range,
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                name: msg.name.as_str().into(),
+                type_: msg.type_,
+                description: msg.description.as_str().into(),
+                additional_constraints: msg.additional_constraints.as_str().into(),
+                read_only: msg.read_only,
+                floating_point_range: msg.floating_point_range.clone(),
+                integer_range: msg.integer_range.clone(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            name: msg.name.to_string(),
+            type_: msg.type_,
+            description: msg.description.to_string(),
+            additional_constraints: msg.additional_constraints.to_string(),
+            read_only: msg.read_only,
+            floating_point_range: msg.floating_point_range,
+            integer_range: msg.integer_range,
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct ParameterEventDescriptors {
+    pub new_parameters: Vec<crate::vendor::rcl_interfaces::msg::ParameterDescriptor>,
+    pub changed_parameters: Vec<crate::vendor::rcl_interfaces::msg::ParameterDescriptor>,
+    pub deleted_parameters: Vec<crate::vendor::rcl_interfaces::msg::ParameterDescriptor>,
+}
+
+impl Default for ParameterEventDescriptors {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::rcl_interfaces::msg::rmw::ParameterEventDescriptors::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for ParameterEventDescriptors {
+    type RmwMsg = crate::vendor::rcl_interfaces::msg::rmw::ParameterEventDescriptors;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                new_parameters: msg
+                    .new_parameters
+                    .into_iter()
+                    .map(|elem| {
+                        crate::vendor::rcl_interfaces::msg::ParameterDescriptor::into_rmw_message(
+                            std::borrow::Cow::Owned(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+                changed_parameters: msg
+                    .changed_parameters
+                    .into_iter()
+                    .map(|elem| {
+                        crate::vendor::rcl_interfaces::msg::ParameterDescriptor::into_rmw_message(
+                            std::borrow::Cow::Owned(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+                deleted_parameters: msg
+                    .deleted_parameters
+                    .into_iter()
+                    .map(|elem| {
+                        crate::vendor::rcl_interfaces::msg::ParameterDescriptor::into_rmw_message(
+                            std::borrow::Cow::Owned(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                new_parameters: msg
+                    .new_parameters
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::rcl_interfaces::msg::ParameterDescriptor::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+                changed_parameters: msg
+                    .changed_parameters
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::rcl_interfaces::msg::ParameterDescriptor::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+                deleted_parameters: msg
+                    .deleted_parameters
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::rcl_interfaces::msg::ParameterDescriptor::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            new_parameters: msg
+                .new_parameters
+                .into_iter()
+                .map(crate::vendor::rcl_interfaces::msg::ParameterDescriptor::from_rmw_message)
+                .collect(),
+            changed_parameters: msg
+                .changed_parameters
+                .into_iter()
+                .map(crate::vendor::rcl_interfaces::msg::ParameterDescriptor::from_rmw_message)
+                .collect(),
+            deleted_parameters: msg
+                .deleted_parameters
+                .into_iter()
+                .map(crate::vendor::rcl_interfaces::msg::ParameterDescriptor::from_rmw_message)
+                .collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct ParameterEvent {
+    pub stamp: crate::vendor::builtin_interfaces::msg::Time,
+    pub node: std::string::String,
+    pub new_parameters: Vec<crate::vendor::rcl_interfaces::msg::Parameter>,
+    pub changed_parameters: Vec<crate::vendor::rcl_interfaces::msg::Parameter>,
+    pub deleted_parameters: Vec<crate::vendor::rcl_interfaces::msg::Parameter>,
+}
+
+impl Default for ParameterEvent {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::rcl_interfaces::msg::rmw::ParameterEvent::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for ParameterEvent {
+    type RmwMsg = crate::vendor::rcl_interfaces::msg::rmw::ParameterEvent;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                stamp: crate::vendor::builtin_interfaces::msg::Time::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.stamp),
+                )
+                .into_owned(),
+                node: msg.node.as_str().into(),
+                new_parameters: msg
+                    .new_parameters
+                    .into_iter()
+                    .map(|elem| {
+                        crate::vendor::rcl_interfaces::msg::Parameter::into_rmw_message(
+                            std::borrow::Cow::Owned(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+                changed_parameters: msg
+                    .changed_parameters
+                    .into_iter()
+                    .map(|elem| {
+                        crate::vendor::rcl_interfaces::msg::Parameter::into_rmw_message(
+                            std::borrow::Cow::Owned(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+                deleted_parameters: msg
+                    .deleted_parameters
+                    .into_iter()
+                    .map(|elem| {
+                        crate::vendor::rcl_interfaces::msg::Parameter::into_rmw_message(
+                            std::borrow::Cow::Owned(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                stamp: crate::vendor::builtin_interfaces::msg::Time::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.stamp),
+                )
+                .into_owned(),
+                node: msg.node.as_str().into(),
+                new_parameters: msg
+                    .new_parameters
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::rcl_interfaces::msg::Parameter::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+                changed_parameters: msg
+                    .changed_parameters
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::rcl_interfaces::msg::Parameter::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+                deleted_parameters: msg
+                    .deleted_parameters
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::rcl_interfaces::msg::Parameter::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            stamp: crate::vendor::builtin_interfaces::msg::Time::from_rmw_message(msg.stamp),
+            node: msg.node.to_string(),
+            new_parameters: msg
+                .new_parameters
+                .into_iter()
+                .map(crate::vendor::rcl_interfaces::msg::Parameter::from_rmw_message)
+                .collect(),
+            changed_parameters: msg
+                .changed_parameters
+                .into_iter()
+                .map(crate::vendor::rcl_interfaces::msg::Parameter::from_rmw_message)
+                .collect(),
+            deleted_parameters: msg
+                .deleted_parameters
+                .into_iter()
+                .map(crate::vendor::rcl_interfaces::msg::Parameter::from_rmw_message)
+                .collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Parameter {
+    pub name: std::string::String,
+    pub value: crate::vendor::rcl_interfaces::msg::ParameterValue,
+}
+
+impl Default for Parameter {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::rcl_interfaces::msg::rmw::Parameter::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Parameter {
+    type RmwMsg = crate::vendor::rcl_interfaces::msg::rmw::Parameter;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                name: msg.name.as_str().into(),
+                value: crate::vendor::rcl_interfaces::msg::ParameterValue::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.value),
+                )
+                .into_owned(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                name: msg.name.as_str().into(),
+                value: crate::vendor::rcl_interfaces::msg::ParameterValue::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.value),
+                )
+                .into_owned(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            name: msg.name.to_string(),
+            value: crate::vendor::rcl_interfaces::msg::ParameterValue::from_rmw_message(msg.value),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct ParameterType {
+    pub structure_needs_at_least_one_member: u8,
+}
+
+impl ParameterType {
+    /// Default value, which implies this is not a valid parameter.
+    pub const PARAMETER_NOT_SET: u8 = 0;
+    pub const PARAMETER_BOOL: u8 = 1;
+    pub const PARAMETER_INTEGER: u8 = 2;
+    pub const PARAMETER_DOUBLE: u8 = 3;
+    pub const PARAMETER_STRING: u8 = 4;
+    pub const PARAMETER_BYTE_ARRAY: u8 = 5;
+    pub const PARAMETER_BOOL_ARRAY: u8 = 6;
+    pub const PARAMETER_INTEGER_ARRAY: u8 = 7;
+    pub const PARAMETER_DOUBLE_ARRAY: u8 = 8;
+    pub const PARAMETER_STRING_ARRAY: u8 = 9;
+}
+
+impl Default for ParameterType {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::rcl_interfaces::msg::rmw::ParameterType::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for ParameterType {
+    type RmwMsg = crate::vendor::rcl_interfaces::msg::rmw::ParameterType;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                structure_needs_at_least_one_member: msg.structure_needs_at_least_one_member,
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                structure_needs_at_least_one_member: msg.structure_needs_at_least_one_member,
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            structure_needs_at_least_one_member: msg.structure_needs_at_least_one_member,
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct ParameterValue {
+    pub type_: u8,
+    pub bool_value: bool,
+    pub integer_value: i64,
+    pub double_value: f64,
+    pub string_value: std::string::String,
+    pub byte_array_value: Vec<u8>,
+    pub bool_array_value: Vec<bool>,
+    pub integer_array_value: Vec<i64>,
+    pub double_array_value: Vec<f64>,
+    pub string_array_value: Vec<std::string::String>,
+}
+
+impl Default for ParameterValue {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::rcl_interfaces::msg::rmw::ParameterValue::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for ParameterValue {
+    type RmwMsg = crate::vendor::rcl_interfaces::msg::rmw::ParameterValue;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                type_: msg.type_,
+                bool_value: msg.bool_value,
+                integer_value: msg.integer_value,
+                double_value: msg.double_value,
+                string_value: msg.string_value.as_str().into(),
+                byte_array_value: msg.byte_array_value.into(),
+                bool_array_value: msg.bool_array_value.into(),
+                integer_array_value: msg.integer_array_value.into(),
+                double_array_value: msg.double_array_value.into(),
+                string_array_value: msg
+                    .string_array_value
+                    .into_iter()
+                    .map(|elem| elem.as_str().into())
+                    .collect(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                type_: msg.type_,
+                bool_value: msg.bool_value,
+                integer_value: msg.integer_value,
+                double_value: msg.double_value,
+                string_value: msg.string_value.as_str().into(),
+                byte_array_value: msg.byte_array_value.as_slice().into(),
+                bool_array_value: msg.bool_array_value.as_slice().into(),
+                integer_array_value: msg.integer_array_value.as_slice().into(),
+                double_array_value: msg.double_array_value.as_slice().into(),
+                string_array_value: msg
+                    .string_array_value
+                    .iter()
+                    .map(|elem| elem.as_str().into())
+                    .collect(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            type_: msg.type_,
+            bool_value: msg.bool_value,
+            integer_value: msg.integer_value,
+            double_value: msg.double_value,
+            string_value: msg.string_value.to_string(),
+            byte_array_value: msg.byte_array_value.into_iter().collect(),
+            bool_array_value: msg.bool_array_value.into_iter().collect(),
+            integer_array_value: msg.integer_array_value.into_iter().collect(),
+            double_array_value: msg.double_array_value.into_iter().collect(),
+            string_array_value: msg
+                .string_array_value
+                .into_iter()
+                .map(|elem| elem.to_string())
+                .collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct SetParametersResult {
+    pub successful: bool,
+    pub reason: std::string::String,
+}
+
+impl Default for SetParametersResult {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::rcl_interfaces::msg::rmw::SetParametersResult::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for SetParametersResult {
+    type RmwMsg = crate::vendor::rcl_interfaces::msg::rmw::SetParametersResult;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                successful: msg.successful,
+                reason: msg.reason.as_str().into(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                successful: msg.successful,
+                reason: msg.reason.as_str().into(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            successful: msg.successful,
+            reason: msg.reason.to_string(),
+        }
+    }
+}

--- a/rclrs/src/vendor/rcl_interfaces/srv.rs
+++ b/rclrs/src/vendor/rcl_interfaces/srv.rs
@@ -1,0 +1,2003 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct DescribeParameters_Request {
+    pub names: Vec<std::string::String>,
+}
+
+impl Default for DescribeParameters_Request {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::rcl_interfaces::srv::rmw::DescribeParameters_Request::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for DescribeParameters_Request {
+    type RmwMsg = crate::vendor::rcl_interfaces::srv::rmw::DescribeParameters_Request;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                names: msg
+                    .names
+                    .into_iter()
+                    .map(|elem| elem.as_str().into())
+                    .collect(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                names: msg.names.iter().map(|elem| elem.as_str().into()).collect(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            names: msg.names.into_iter().map(|elem| elem.to_string()).collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct DescribeParameters_Response {
+    pub descriptors: Vec<crate::vendor::rcl_interfaces::msg::ParameterDescriptor>,
+}
+
+impl Default for DescribeParameters_Response {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::rcl_interfaces::srv::rmw::DescribeParameters_Response::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for DescribeParameters_Response {
+    type RmwMsg = crate::vendor::rcl_interfaces::srv::rmw::DescribeParameters_Response;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                descriptors: msg
+                    .descriptors
+                    .into_iter()
+                    .map(|elem| {
+                        crate::vendor::rcl_interfaces::msg::ParameterDescriptor::into_rmw_message(
+                            std::borrow::Cow::Owned(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                descriptors: msg
+                    .descriptors
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::rcl_interfaces::msg::ParameterDescriptor::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            descriptors: msg
+                .descriptors
+                .into_iter()
+                .map(crate::vendor::rcl_interfaces::msg::ParameterDescriptor::from_rmw_message)
+                .collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct GetParameters_Request {
+    pub names: Vec<std::string::String>,
+}
+
+impl Default for GetParameters_Request {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::rcl_interfaces::srv::rmw::GetParameters_Request::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for GetParameters_Request {
+    type RmwMsg = crate::vendor::rcl_interfaces::srv::rmw::GetParameters_Request;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                names: msg
+                    .names
+                    .into_iter()
+                    .map(|elem| elem.as_str().into())
+                    .collect(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                names: msg.names.iter().map(|elem| elem.as_str().into()).collect(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            names: msg.names.into_iter().map(|elem| elem.to_string()).collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct GetParameters_Response {
+    pub values: Vec<crate::vendor::rcl_interfaces::msg::ParameterValue>,
+}
+
+impl Default for GetParameters_Response {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::rcl_interfaces::srv::rmw::GetParameters_Response::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for GetParameters_Response {
+    type RmwMsg = crate::vendor::rcl_interfaces::srv::rmw::GetParameters_Response;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                values: msg
+                    .values
+                    .into_iter()
+                    .map(|elem| {
+                        crate::vendor::rcl_interfaces::msg::ParameterValue::into_rmw_message(
+                            std::borrow::Cow::Owned(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                values: msg
+                    .values
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::rcl_interfaces::msg::ParameterValue::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            values: msg
+                .values
+                .into_iter()
+                .map(crate::vendor::rcl_interfaces::msg::ParameterValue::from_rmw_message)
+                .collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct GetParameterTypes_Request {
+    pub names: Vec<std::string::String>,
+}
+
+impl Default for GetParameterTypes_Request {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::rcl_interfaces::srv::rmw::GetParameterTypes_Request::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for GetParameterTypes_Request {
+    type RmwMsg = crate::vendor::rcl_interfaces::srv::rmw::GetParameterTypes_Request;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                names: msg
+                    .names
+                    .into_iter()
+                    .map(|elem| elem.as_str().into())
+                    .collect(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                names: msg.names.iter().map(|elem| elem.as_str().into()).collect(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            names: msg.names.into_iter().map(|elem| elem.to_string()).collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct GetParameterTypes_Response {
+    pub types: Vec<u8>,
+}
+
+impl Default for GetParameterTypes_Response {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::rcl_interfaces::srv::rmw::GetParameterTypes_Response::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for GetParameterTypes_Response {
+    type RmwMsg = crate::vendor::rcl_interfaces::srv::rmw::GetParameterTypes_Response;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                types: msg.types.into(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                types: msg.types.as_slice().into(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            types: msg.types.into_iter().collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct ListParameters_Request {
+    pub prefixes: Vec<std::string::String>,
+    pub depth: u64,
+}
+
+impl ListParameters_Request {
+    pub const DEPTH_RECURSIVE: u64 = 0;
+}
+
+impl Default for ListParameters_Request {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::rcl_interfaces::srv::rmw::ListParameters_Request::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for ListParameters_Request {
+    type RmwMsg = crate::vendor::rcl_interfaces::srv::rmw::ListParameters_Request;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                prefixes: msg
+                    .prefixes
+                    .into_iter()
+                    .map(|elem| elem.as_str().into())
+                    .collect(),
+                depth: msg.depth,
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                prefixes: msg
+                    .prefixes
+                    .iter()
+                    .map(|elem| elem.as_str().into())
+                    .collect(),
+                depth: msg.depth,
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            prefixes: msg
+                .prefixes
+                .into_iter()
+                .map(|elem| elem.to_string())
+                .collect(),
+            depth: msg.depth,
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct ListParameters_Response {
+    pub result: crate::vendor::rcl_interfaces::msg::ListParametersResult,
+}
+
+impl Default for ListParameters_Response {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::rcl_interfaces::srv::rmw::ListParameters_Response::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for ListParameters_Response {
+    type RmwMsg = crate::vendor::rcl_interfaces::srv::rmw::ListParameters_Response;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                result: crate::vendor::rcl_interfaces::msg::ListParametersResult::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.result),
+                )
+                .into_owned(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                result: crate::vendor::rcl_interfaces::msg::ListParametersResult::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.result),
+                )
+                .into_owned(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            result: crate::vendor::rcl_interfaces::msg::ListParametersResult::from_rmw_message(
+                msg.result,
+            ),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct SetParametersAtomically_Request {
+    pub parameters: Vec<crate::vendor::rcl_interfaces::msg::Parameter>,
+}
+
+impl Default for SetParametersAtomically_Request {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::rcl_interfaces::srv::rmw::SetParametersAtomically_Request::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for SetParametersAtomically_Request {
+    type RmwMsg = crate::vendor::rcl_interfaces::srv::rmw::SetParametersAtomically_Request;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                parameters: msg
+                    .parameters
+                    .into_iter()
+                    .map(|elem| {
+                        crate::vendor::rcl_interfaces::msg::Parameter::into_rmw_message(
+                            std::borrow::Cow::Owned(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                parameters: msg
+                    .parameters
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::rcl_interfaces::msg::Parameter::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            parameters: msg
+                .parameters
+                .into_iter()
+                .map(crate::vendor::rcl_interfaces::msg::Parameter::from_rmw_message)
+                .collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct SetParametersAtomically_Response {
+    pub result: crate::vendor::rcl_interfaces::msg::SetParametersResult,
+}
+
+impl Default for SetParametersAtomically_Response {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::rcl_interfaces::srv::rmw::SetParametersAtomically_Response::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for SetParametersAtomically_Response {
+    type RmwMsg = crate::vendor::rcl_interfaces::srv::rmw::SetParametersAtomically_Response;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                result: crate::vendor::rcl_interfaces::msg::SetParametersResult::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.result),
+                )
+                .into_owned(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                result: crate::vendor::rcl_interfaces::msg::SetParametersResult::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.result),
+                )
+                .into_owned(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            result: crate::vendor::rcl_interfaces::msg::SetParametersResult::from_rmw_message(
+                msg.result,
+            ),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct SetParameters_Request {
+    pub parameters: Vec<crate::vendor::rcl_interfaces::msg::Parameter>,
+}
+
+impl Default for SetParameters_Request {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::rcl_interfaces::srv::rmw::SetParameters_Request::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for SetParameters_Request {
+    type RmwMsg = crate::vendor::rcl_interfaces::srv::rmw::SetParameters_Request;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                parameters: msg
+                    .parameters
+                    .into_iter()
+                    .map(|elem| {
+                        crate::vendor::rcl_interfaces::msg::Parameter::into_rmw_message(
+                            std::borrow::Cow::Owned(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                parameters: msg
+                    .parameters
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::rcl_interfaces::msg::Parameter::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            parameters: msg
+                .parameters
+                .into_iter()
+                .map(crate::vendor::rcl_interfaces::msg::Parameter::from_rmw_message)
+                .collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct SetParameters_Response {
+    pub results: Vec<crate::vendor::rcl_interfaces::msg::SetParametersResult>,
+}
+
+impl Default for SetParameters_Response {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::rcl_interfaces::srv::rmw::SetParameters_Response::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for SetParameters_Response {
+    type RmwMsg = crate::vendor::rcl_interfaces::srv::rmw::SetParameters_Response;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                results: msg
+                    .results
+                    .into_iter()
+                    .map(|elem| {
+                        crate::vendor::rcl_interfaces::msg::SetParametersResult::into_rmw_message(
+                            std::borrow::Cow::Owned(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                results: msg
+                    .results
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::rcl_interfaces::msg::SetParametersResult::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            results: msg
+                .results
+                .into_iter()
+                .map(crate::vendor::rcl_interfaces::msg::SetParametersResult::from_rmw_message)
+                .collect(),
+        }
+    }
+}
+
+#[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__DescribeParameters(
+    ) -> *const std::os::raw::c_void;
+}
+
+// Corresponds to rcl_interfaces__srv__DescribeParameters
+pub struct DescribeParameters;
+
+impl rosidl_runtime_rs::Service for DescribeParameters {
+    type Request = crate::vendor::rcl_interfaces::srv::DescribeParameters_Request;
+    type Response = crate::vendor::rcl_interfaces::srv::DescribeParameters_Response;
+
+    fn get_type_support() -> *const std::os::raw::c_void {
+        // SAFETY: No preconditions for this function.
+        unsafe {
+            rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__DescribeParameters()
+        }
+    }
+}
+
+#[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__GetParameters(
+    ) -> *const std::os::raw::c_void;
+}
+
+// Corresponds to rcl_interfaces__srv__GetParameters
+pub struct GetParameters;
+
+impl rosidl_runtime_rs::Service for GetParameters {
+    type Request = crate::vendor::rcl_interfaces::srv::GetParameters_Request;
+    type Response = crate::vendor::rcl_interfaces::srv::GetParameters_Response;
+
+    fn get_type_support() -> *const std::os::raw::c_void {
+        // SAFETY: No preconditions for this function.
+        unsafe {
+            rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__GetParameters()
+        }
+    }
+}
+
+#[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__GetParameterTypes(
+    ) -> *const std::os::raw::c_void;
+}
+
+// Corresponds to rcl_interfaces__srv__GetParameterTypes
+pub struct GetParameterTypes;
+
+impl rosidl_runtime_rs::Service for GetParameterTypes {
+    type Request = crate::vendor::rcl_interfaces::srv::GetParameterTypes_Request;
+    type Response = crate::vendor::rcl_interfaces::srv::GetParameterTypes_Response;
+
+    fn get_type_support() -> *const std::os::raw::c_void {
+        // SAFETY: No preconditions for this function.
+        unsafe {
+            rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__GetParameterTypes()
+        }
+    }
+}
+
+#[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__ListParameters(
+    ) -> *const std::os::raw::c_void;
+}
+
+// Corresponds to rcl_interfaces__srv__ListParameters
+pub struct ListParameters;
+
+impl rosidl_runtime_rs::Service for ListParameters {
+    type Request = crate::vendor::rcl_interfaces::srv::ListParameters_Request;
+    type Response = crate::vendor::rcl_interfaces::srv::ListParameters_Response;
+
+    fn get_type_support() -> *const std::os::raw::c_void {
+        // SAFETY: No preconditions for this function.
+        unsafe {
+            rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__ListParameters()
+        }
+    }
+}
+
+#[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__SetParametersAtomically(
+    ) -> *const std::os::raw::c_void;
+}
+
+// Corresponds to rcl_interfaces__srv__SetParametersAtomically
+pub struct SetParametersAtomically;
+
+impl rosidl_runtime_rs::Service for SetParametersAtomically {
+    type Request = crate::vendor::rcl_interfaces::srv::SetParametersAtomically_Request;
+    type Response = crate::vendor::rcl_interfaces::srv::SetParametersAtomically_Response;
+
+    fn get_type_support() -> *const std::os::raw::c_void {
+        // SAFETY: No preconditions for this function.
+        unsafe {
+            rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__SetParametersAtomically()
+        }
+    }
+}
+
+#[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__SetParameters(
+    ) -> *const std::os::raw::c_void;
+}
+
+// Corresponds to rcl_interfaces__srv__SetParameters
+pub struct SetParameters;
+
+impl rosidl_runtime_rs::Service for SetParameters {
+    type Request = crate::vendor::rcl_interfaces::srv::SetParameters_Request;
+    type Response = crate::vendor::rcl_interfaces::srv::SetParameters_Response;
+
+    fn get_type_support() -> *const std::os::raw::c_void {
+        // SAFETY: No preconditions for this function.
+        unsafe {
+            rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__SetParameters()
+        }
+    }
+}
+
+pub mod rmw {
+    #[cfg(feature = "serde")]
+    use serde::{Deserialize, Serialize};
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__DescribeParameters_Request(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn rcl_interfaces__srv__DescribeParameters_Request__init(
+            msg: *mut DescribeParameters_Request,
+        ) -> bool;
+        fn rcl_interfaces__srv__DescribeParameters_Request__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<DescribeParameters_Request>,
+            size: usize,
+        ) -> bool;
+        fn rcl_interfaces__srv__DescribeParameters_Request__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<DescribeParameters_Request>,
+        );
+        fn rcl_interfaces__srv__DescribeParameters_Request__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<DescribeParameters_Request>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<DescribeParameters_Request>,
+        ) -> bool;
+    }
+
+    // Corresponds to rcl_interfaces__srv__DescribeParameters_Request
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct DescribeParameters_Request {
+        pub names: rosidl_runtime_rs::Sequence<rosidl_runtime_rs::String>,
+    }
+
+    impl Default for DescribeParameters_Request {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !rcl_interfaces__srv__DescribeParameters_Request__init(&mut msg as *mut _) {
+                    panic!(
+                        "Call to rcl_interfaces__srv__DescribeParameters_Request__init() failed"
+                    );
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for DescribeParameters_Request {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__DescribeParameters_Request__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__DescribeParameters_Request__Sequence__fini(seq as *mut _)
+            }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__DescribeParameters_Request__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for DescribeParameters_Request {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for DescribeParameters_Request
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "rcl_interfaces/srv/DescribeParameters_Request";
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__DescribeParameters_Request()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__DescribeParameters_Response(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn rcl_interfaces__srv__DescribeParameters_Response__init(
+            msg: *mut DescribeParameters_Response,
+        ) -> bool;
+        fn rcl_interfaces__srv__DescribeParameters_Response__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<DescribeParameters_Response>,
+            size: usize,
+        ) -> bool;
+        fn rcl_interfaces__srv__DescribeParameters_Response__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<DescribeParameters_Response>,
+        );
+        fn rcl_interfaces__srv__DescribeParameters_Response__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<DescribeParameters_Response>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<DescribeParameters_Response>,
+        ) -> bool;
+    }
+
+    // Corresponds to rcl_interfaces__srv__DescribeParameters_Response
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct DescribeParameters_Response {
+        pub descriptors: rosidl_runtime_rs::Sequence<
+            crate::vendor::rcl_interfaces::msg::rmw::ParameterDescriptor,
+        >,
+    }
+
+    impl Default for DescribeParameters_Response {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !rcl_interfaces__srv__DescribeParameters_Response__init(&mut msg as *mut _) {
+                    panic!(
+                        "Call to rcl_interfaces__srv__DescribeParameters_Response__init() failed"
+                    );
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for DescribeParameters_Response {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__DescribeParameters_Response__Sequence__init(
+                    seq as *mut _,
+                    size,
+                )
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__DescribeParameters_Response__Sequence__fini(seq as *mut _)
+            }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__DescribeParameters_Response__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for DescribeParameters_Response {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for DescribeParameters_Response
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "rcl_interfaces/srv/DescribeParameters_Response";
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__DescribeParameters_Response()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__GetParameters_Request(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn rcl_interfaces__srv__GetParameters_Request__init(
+            msg: *mut GetParameters_Request,
+        ) -> bool;
+        fn rcl_interfaces__srv__GetParameters_Request__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<GetParameters_Request>,
+            size: usize,
+        ) -> bool;
+        fn rcl_interfaces__srv__GetParameters_Request__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<GetParameters_Request>,
+        );
+        fn rcl_interfaces__srv__GetParameters_Request__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<GetParameters_Request>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<GetParameters_Request>,
+        ) -> bool;
+    }
+
+    // Corresponds to rcl_interfaces__srv__GetParameters_Request
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct GetParameters_Request {
+        pub names: rosidl_runtime_rs::Sequence<rosidl_runtime_rs::String>,
+    }
+
+    impl Default for GetParameters_Request {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !rcl_interfaces__srv__GetParameters_Request__init(&mut msg as *mut _) {
+                    panic!("Call to rcl_interfaces__srv__GetParameters_Request__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for GetParameters_Request {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__GetParameters_Request__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__srv__GetParameters_Request__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__GetParameters_Request__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for GetParameters_Request {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for GetParameters_Request
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "rcl_interfaces/srv/GetParameters_Request";
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__GetParameters_Request()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__GetParameters_Response(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn rcl_interfaces__srv__GetParameters_Response__init(
+            msg: *mut GetParameters_Response,
+        ) -> bool;
+        fn rcl_interfaces__srv__GetParameters_Response__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<GetParameters_Response>,
+            size: usize,
+        ) -> bool;
+        fn rcl_interfaces__srv__GetParameters_Response__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<GetParameters_Response>,
+        );
+        fn rcl_interfaces__srv__GetParameters_Response__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<GetParameters_Response>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<GetParameters_Response>,
+        ) -> bool;
+    }
+
+    // Corresponds to rcl_interfaces__srv__GetParameters_Response
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct GetParameters_Response {
+        pub values:
+            rosidl_runtime_rs::Sequence<crate::vendor::rcl_interfaces::msg::rmw::ParameterValue>,
+    }
+
+    impl Default for GetParameters_Response {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !rcl_interfaces__srv__GetParameters_Response__init(&mut msg as *mut _) {
+                    panic!("Call to rcl_interfaces__srv__GetParameters_Response__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for GetParameters_Response {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__GetParameters_Response__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__srv__GetParameters_Response__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__GetParameters_Response__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for GetParameters_Response {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for GetParameters_Response
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "rcl_interfaces/srv/GetParameters_Response";
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__GetParameters_Response()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__GetParameterTypes_Request(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn rcl_interfaces__srv__GetParameterTypes_Request__init(
+            msg: *mut GetParameterTypes_Request,
+        ) -> bool;
+        fn rcl_interfaces__srv__GetParameterTypes_Request__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<GetParameterTypes_Request>,
+            size: usize,
+        ) -> bool;
+        fn rcl_interfaces__srv__GetParameterTypes_Request__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<GetParameterTypes_Request>,
+        );
+        fn rcl_interfaces__srv__GetParameterTypes_Request__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<GetParameterTypes_Request>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<GetParameterTypes_Request>,
+        ) -> bool;
+    }
+
+    // Corresponds to rcl_interfaces__srv__GetParameterTypes_Request
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct GetParameterTypes_Request {
+        pub names: rosidl_runtime_rs::Sequence<rosidl_runtime_rs::String>,
+    }
+
+    impl Default for GetParameterTypes_Request {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !rcl_interfaces__srv__GetParameterTypes_Request__init(&mut msg as *mut _) {
+                    panic!("Call to rcl_interfaces__srv__GetParameterTypes_Request__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for GetParameterTypes_Request {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__GetParameterTypes_Request__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__srv__GetParameterTypes_Request__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__GetParameterTypes_Request__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for GetParameterTypes_Request {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for GetParameterTypes_Request
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "rcl_interfaces/srv/GetParameterTypes_Request";
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__GetParameterTypes_Request()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__GetParameterTypes_Response(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn rcl_interfaces__srv__GetParameterTypes_Response__init(
+            msg: *mut GetParameterTypes_Response,
+        ) -> bool;
+        fn rcl_interfaces__srv__GetParameterTypes_Response__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<GetParameterTypes_Response>,
+            size: usize,
+        ) -> bool;
+        fn rcl_interfaces__srv__GetParameterTypes_Response__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<GetParameterTypes_Response>,
+        );
+        fn rcl_interfaces__srv__GetParameterTypes_Response__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<GetParameterTypes_Response>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<GetParameterTypes_Response>,
+        ) -> bool;
+    }
+
+    // Corresponds to rcl_interfaces__srv__GetParameterTypes_Response
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct GetParameterTypes_Response {
+        pub types: rosidl_runtime_rs::Sequence<u8>,
+    }
+
+    impl Default for GetParameterTypes_Response {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !rcl_interfaces__srv__GetParameterTypes_Response__init(&mut msg as *mut _) {
+                    panic!(
+                        "Call to rcl_interfaces__srv__GetParameterTypes_Response__init() failed"
+                    );
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for GetParameterTypes_Response {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__GetParameterTypes_Response__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__GetParameterTypes_Response__Sequence__fini(seq as *mut _)
+            }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__GetParameterTypes_Response__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for GetParameterTypes_Response {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for GetParameterTypes_Response
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "rcl_interfaces/srv/GetParameterTypes_Response";
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__GetParameterTypes_Response()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__ListParameters_Request(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn rcl_interfaces__srv__ListParameters_Request__init(
+            msg: *mut ListParameters_Request,
+        ) -> bool;
+        fn rcl_interfaces__srv__ListParameters_Request__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<ListParameters_Request>,
+            size: usize,
+        ) -> bool;
+        fn rcl_interfaces__srv__ListParameters_Request__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<ListParameters_Request>,
+        );
+        fn rcl_interfaces__srv__ListParameters_Request__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<ListParameters_Request>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<ListParameters_Request>,
+        ) -> bool;
+    }
+
+    // Corresponds to rcl_interfaces__srv__ListParameters_Request
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct ListParameters_Request {
+        pub prefixes: rosidl_runtime_rs::Sequence<rosidl_runtime_rs::String>,
+        pub depth: u64,
+    }
+
+    impl ListParameters_Request {
+        pub const DEPTH_RECURSIVE: u64 = 0;
+    }
+
+    impl Default for ListParameters_Request {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !rcl_interfaces__srv__ListParameters_Request__init(&mut msg as *mut _) {
+                    panic!("Call to rcl_interfaces__srv__ListParameters_Request__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for ListParameters_Request {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__ListParameters_Request__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__srv__ListParameters_Request__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__ListParameters_Request__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for ListParameters_Request {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for ListParameters_Request
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "rcl_interfaces/srv/ListParameters_Request";
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__ListParameters_Request()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__ListParameters_Response(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn rcl_interfaces__srv__ListParameters_Response__init(
+            msg: *mut ListParameters_Response,
+        ) -> bool;
+        fn rcl_interfaces__srv__ListParameters_Response__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<ListParameters_Response>,
+            size: usize,
+        ) -> bool;
+        fn rcl_interfaces__srv__ListParameters_Response__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<ListParameters_Response>,
+        );
+        fn rcl_interfaces__srv__ListParameters_Response__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<ListParameters_Response>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<ListParameters_Response>,
+        ) -> bool;
+    }
+
+    // Corresponds to rcl_interfaces__srv__ListParameters_Response
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct ListParameters_Response {
+        pub result: crate::vendor::rcl_interfaces::msg::rmw::ListParametersResult,
+    }
+
+    impl Default for ListParameters_Response {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !rcl_interfaces__srv__ListParameters_Response__init(&mut msg as *mut _) {
+                    panic!("Call to rcl_interfaces__srv__ListParameters_Response__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for ListParameters_Response {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__ListParameters_Response__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__srv__ListParameters_Response__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__ListParameters_Response__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for ListParameters_Response {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for ListParameters_Response
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "rcl_interfaces/srv/ListParameters_Response";
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__ListParameters_Response()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__SetParametersAtomically_Request(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn rcl_interfaces__srv__SetParametersAtomically_Request__init(
+            msg: *mut SetParametersAtomically_Request,
+        ) -> bool;
+        fn rcl_interfaces__srv__SetParametersAtomically_Request__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<SetParametersAtomically_Request>,
+            size: usize,
+        ) -> bool;
+        fn rcl_interfaces__srv__SetParametersAtomically_Request__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<SetParametersAtomically_Request>,
+        );
+        fn rcl_interfaces__srv__SetParametersAtomically_Request__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<SetParametersAtomically_Request>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<SetParametersAtomically_Request>,
+        ) -> bool;
+    }
+
+    // Corresponds to rcl_interfaces__srv__SetParametersAtomically_Request
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct SetParametersAtomically_Request {
+        pub parameters:
+            rosidl_runtime_rs::Sequence<crate::vendor::rcl_interfaces::msg::rmw::Parameter>,
+    }
+
+    impl Default for SetParametersAtomically_Request {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !rcl_interfaces__srv__SetParametersAtomically_Request__init(&mut msg as *mut _) {
+                    panic!("Call to rcl_interfaces__srv__SetParametersAtomically_Request__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for SetParametersAtomically_Request {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__SetParametersAtomically_Request__Sequence__init(
+                    seq as *mut _,
+                    size,
+                )
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__SetParametersAtomically_Request__Sequence__fini(seq as *mut _)
+            }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__SetParametersAtomically_Request__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for SetParametersAtomically_Request {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for SetParametersAtomically_Request
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "rcl_interfaces/srv/SetParametersAtomically_Request";
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__SetParametersAtomically_Request()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__SetParametersAtomically_Response(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn rcl_interfaces__srv__SetParametersAtomically_Response__init(
+            msg: *mut SetParametersAtomically_Response,
+        ) -> bool;
+        fn rcl_interfaces__srv__SetParametersAtomically_Response__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<SetParametersAtomically_Response>,
+            size: usize,
+        ) -> bool;
+        fn rcl_interfaces__srv__SetParametersAtomically_Response__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<SetParametersAtomically_Response>,
+        );
+        fn rcl_interfaces__srv__SetParametersAtomically_Response__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<SetParametersAtomically_Response>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<SetParametersAtomically_Response>,
+        ) -> bool;
+    }
+
+    // Corresponds to rcl_interfaces__srv__SetParametersAtomically_Response
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct SetParametersAtomically_Response {
+        pub result: crate::vendor::rcl_interfaces::msg::rmw::SetParametersResult,
+    }
+
+    impl Default for SetParametersAtomically_Response {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !rcl_interfaces__srv__SetParametersAtomically_Response__init(&mut msg as *mut _)
+                {
+                    panic!("Call to rcl_interfaces__srv__SetParametersAtomically_Response__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for SetParametersAtomically_Response {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__SetParametersAtomically_Response__Sequence__init(
+                    seq as *mut _,
+                    size,
+                )
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__SetParametersAtomically_Response__Sequence__fini(seq as *mut _)
+            }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__SetParametersAtomically_Response__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for SetParametersAtomically_Response {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for SetParametersAtomically_Response
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "rcl_interfaces/srv/SetParametersAtomically_Response";
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__SetParametersAtomically_Response()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__SetParameters_Request(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn rcl_interfaces__srv__SetParameters_Request__init(
+            msg: *mut SetParameters_Request,
+        ) -> bool;
+        fn rcl_interfaces__srv__SetParameters_Request__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<SetParameters_Request>,
+            size: usize,
+        ) -> bool;
+        fn rcl_interfaces__srv__SetParameters_Request__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<SetParameters_Request>,
+        );
+        fn rcl_interfaces__srv__SetParameters_Request__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<SetParameters_Request>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<SetParameters_Request>,
+        ) -> bool;
+    }
+
+    // Corresponds to rcl_interfaces__srv__SetParameters_Request
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct SetParameters_Request {
+        pub parameters:
+            rosidl_runtime_rs::Sequence<crate::vendor::rcl_interfaces::msg::rmw::Parameter>,
+    }
+
+    impl Default for SetParameters_Request {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !rcl_interfaces__srv__SetParameters_Request__init(&mut msg as *mut _) {
+                    panic!("Call to rcl_interfaces__srv__SetParameters_Request__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for SetParameters_Request {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__SetParameters_Request__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__srv__SetParameters_Request__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__SetParameters_Request__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for SetParameters_Request {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for SetParameters_Request
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "rcl_interfaces/srv/SetParameters_Request";
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__SetParameters_Request()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__SetParameters_Response(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn rcl_interfaces__srv__SetParameters_Response__init(
+            msg: *mut SetParameters_Response,
+        ) -> bool;
+        fn rcl_interfaces__srv__SetParameters_Response__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<SetParameters_Response>,
+            size: usize,
+        ) -> bool;
+        fn rcl_interfaces__srv__SetParameters_Response__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<SetParameters_Response>,
+        );
+        fn rcl_interfaces__srv__SetParameters_Response__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<SetParameters_Response>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<SetParameters_Response>,
+        ) -> bool;
+    }
+
+    // Corresponds to rcl_interfaces__srv__SetParameters_Response
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct SetParameters_Response {
+        pub results: rosidl_runtime_rs::Sequence<
+            crate::vendor::rcl_interfaces::msg::rmw::SetParametersResult,
+        >,
+    }
+
+    impl Default for SetParameters_Response {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !rcl_interfaces__srv__SetParameters_Response__init(&mut msg as *mut _) {
+                    panic!("Call to rcl_interfaces__srv__SetParameters_Response__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for SetParameters_Response {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__SetParameters_Response__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__srv__SetParameters_Response__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__SetParameters_Response__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for SetParameters_Response {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for SetParameters_Response
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "rcl_interfaces/srv/SetParameters_Response";
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__SetParameters_Response()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__DescribeParameters(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    // Corresponds to rcl_interfaces__srv__DescribeParameters
+    pub struct DescribeParameters;
+
+    impl rosidl_runtime_rs::Service for DescribeParameters {
+        type Request = crate::vendor::rcl_interfaces::srv::rmw::DescribeParameters_Request;
+        type Response = crate::vendor::rcl_interfaces::srv::rmw::DescribeParameters_Response;
+
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__DescribeParameters()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__GetParameters(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    // Corresponds to rcl_interfaces__srv__GetParameters
+    pub struct GetParameters;
+
+    impl rosidl_runtime_rs::Service for GetParameters {
+        type Request = crate::vendor::rcl_interfaces::srv::rmw::GetParameters_Request;
+        type Response = crate::vendor::rcl_interfaces::srv::rmw::GetParameters_Response;
+
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__GetParameters()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__GetParameterTypes(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    // Corresponds to rcl_interfaces__srv__GetParameterTypes
+    pub struct GetParameterTypes;
+
+    impl rosidl_runtime_rs::Service for GetParameterTypes {
+        type Request = crate::vendor::rcl_interfaces::srv::rmw::GetParameterTypes_Request;
+        type Response = crate::vendor::rcl_interfaces::srv::rmw::GetParameterTypes_Response;
+
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__GetParameterTypes()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__ListParameters(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    // Corresponds to rcl_interfaces__srv__ListParameters
+    pub struct ListParameters;
+
+    impl rosidl_runtime_rs::Service for ListParameters {
+        type Request = crate::vendor::rcl_interfaces::srv::rmw::ListParameters_Request;
+        type Response = crate::vendor::rcl_interfaces::srv::rmw::ListParameters_Response;
+
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__ListParameters()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__SetParametersAtomically(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    // Corresponds to rcl_interfaces__srv__SetParametersAtomically
+    pub struct SetParametersAtomically;
+
+    impl rosidl_runtime_rs::Service for SetParametersAtomically {
+        type Request = crate::vendor::rcl_interfaces::srv::rmw::SetParametersAtomically_Request;
+        type Response = crate::vendor::rcl_interfaces::srv::rmw::SetParametersAtomically_Response;
+
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__SetParametersAtomically()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__SetParameters(
+        ) -> *const std::os::raw::c_void;
+    }
+
+    // Corresponds to rcl_interfaces__srv__SetParameters
+    pub struct SetParameters;
+
+    impl rosidl_runtime_rs::Service for SetParameters {
+        type Request = crate::vendor::rcl_interfaces::srv::rmw::SetParameters_Request;
+        type Response = crate::vendor::rcl_interfaces::srv::rmw::SetParameters_Response;
+
+        fn get_type_support() -> *const std::os::raw::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__SetParameters()
+            }
+        }
+    }
+} // mod rmw

--- a/rclrs/vendor_interfaces.py
+++ b/rclrs/vendor_interfaces.py
@@ -1,0 +1,53 @@
+import argparse
+from pathlib import Path
+import shutil
+import subprocess
+
+def get_args():
+  parser = argparse.ArgumentParser(description='Vendor the rcl_interfaces and builtin_interfaces packages into rclrs')
+  parser.add_argument('install_base', metavar='install_base', type=Path,
+                      help='the install base (must have non-merged layout)')
+  return parser.parse_args()
+
+def adjust(pkg, text):
+  text = text.replace('builtin_interfaces::', 'crate::vendor::builtin_interfaces::')
+  text = text.replace('rcl_interfaces::', 'crate::vendor::rcl_interfaces::')
+  text = text.replace('crate::msg', f'crate::vendor::{pkg}::msg')
+  text = text.replace('crate::srv', f'crate::vendor::{pkg}::srv')
+  return text
+
+def copy_adjusted(pkg, src, dst):
+  dst.write_text(adjust(pkg, src.read_text()))
+  subprocess.check_call(['rustfmt', str(dst)])
+
+mod_contents = """//! Created by {}
+#![allow(dead_code)]
+#![allow(clippy::derive_partial_eq_without_eq)]
+
+pub mod builtin_interfaces;
+pub mod rcl_interfaces;
+""".format(Path(__file__).name)
+
+def main():
+  args = get_args()
+  assert args.install_base.is_dir(), "Install base does not exist"
+  assert (args.install_base / 'builtin_interfaces').is_dir(), "Install base does not contain builtin_interfaces"
+  assert (args.install_base / 'rcl_interfaces').is_dir(), "Install base does not contain rcl_interfaces"
+  rclrs_root = Path(__file__).parent
+  vendor_dir = rclrs_root / 'src' / 'vendor'
+  if vendor_dir.exists():
+    shutil.rmtree(vendor_dir)
+  for pkg in ['builtin_interfaces', 'rcl_interfaces']:
+    src = args.install_base / pkg / 'share' / pkg / 'rust' / 'src'
+    dst = vendor_dir / pkg
+    dst.mkdir(parents=True)
+    copy_adjusted(pkg, src / 'msg.rs', dst / 'msg.rs')
+    if (src / 'srv.rs').is_file():
+      copy_adjusted(pkg, src / 'srv.rs', dst / 'srv.rs')
+    copy_adjusted(pkg, src / 'lib.rs', dst / 'mod.rs')  # Rename lib.rs to mod.rs
+  (vendor_dir / 'mod.rs').write_text(mod_contents)
+    
+
+
+if __name__ == '__main__':
+  main()

--- a/rclrs/vendor_interfaces.py
+++ b/rclrs/vendor_interfaces.py
@@ -1,3 +1,11 @@
+# This script produces the `vendor` module inside `rclrs` by copying
+# the generated code for the `rcl_interfaces` package and its dependency
+# `builtin_interfaces` and adjusting the submodule paths in the code.
+# If these packages, or the `rosidl_generator_rs`, get changed, you can
+# update the `vendor` module by running this script.
+# The purpose is to avoid an external dependency on `rcl_interfaces`, which
+# is not published on crates.io.
+
 import argparse
 from pathlib import Path
 import shutil


### PR DESCRIPTION
The parameter services require the rcl_interfaces message and service types. I think this option is preferable to publishing rcl_interfaces on crates.io.

The script included in this PR produces the `vendor` module inside `rclrs` by copying the generated code for the `rcl_interfaces` package and its dependency `builtin_interfaces` and adjusting the submodule paths in the code.
If these packages, or the `rosidl_generator_rs` package, get changed, we can update the `vendor` module by running this script.