### PR TITLE
Rename *Base traits to *Waitable

### DIFF
--- a/rclrs/src/client.rs
+++ b/rclrs/src/client.rs
@@ -43,7 +43,7 @@ impl Drop for ClientHandle {
 /// Trait to be implemented by concrete Client structs.
 ///
 /// See [`Client<T>`] for an example.
-pub trait ClientBase: Send + Sync {
+pub trait ClientWaitable: Send + Sync {
     /// Internal function to get a reference to the `rcl` handle.
     fn handle(&self) -> &ClientHandle;
     /// Tries to take a new response and run the callback or future with it.
@@ -239,7 +239,7 @@ where
     }
 }
 
-impl<T> ClientBase for Client<T>
+impl<T> ClientWaitable for Client<T>
 where
     T: rosidl_runtime_rs::Service,
 {

--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -13,8 +13,8 @@ pub use self::builder::*;
 pub use self::graph::*;
 use crate::rcl_bindings::*;
 use crate::{
-    Client, ClientBase, Context, GuardCondition, ParameterOverrideMap, Publisher, QoSProfile,
-    RclrsError, Service, ServiceBase, Subscription, SubscriptionBase, SubscriptionCallback,
+    Client, ClientWaitable, Context, GuardCondition, ParameterOverrideMap, Publisher, QoSProfile,
+    RclrsError, Service, ServiceWaitable, Subscription, SubscriptionCallback, SubscriptionWaitable,
     ToResult,
 };
 
@@ -67,10 +67,10 @@ unsafe impl Send for rcl_node_t {}
 pub struct Node {
     pub(crate) rcl_node_mtx: Arc<Mutex<rcl_node_t>>,
     pub(crate) rcl_context_mtx: Arc<Mutex<rcl_context_t>>,
-    pub(crate) clients: Vec<Weak<dyn ClientBase>>,
+    pub(crate) clients: Vec<Weak<dyn ClientWaitable>>,
     pub(crate) guard_conditions: Vec<Weak<GuardCondition>>,
-    pub(crate) services: Vec<Weak<dyn ServiceBase>>,
-    pub(crate) subscriptions: Vec<Weak<dyn SubscriptionBase>>,
+    pub(crate) services: Vec<Weak<dyn ServiceWaitable>>,
+    pub(crate) subscriptions: Vec<Weak<dyn SubscriptionWaitable>>,
     _parameter_map: ParameterOverrideMap,
 }
 
@@ -186,7 +186,7 @@ impl Node {
     {
         let client = Arc::new(Client::<T>::new(self, topic)?);
         self.clients
-            .push(Arc::downgrade(&client) as Weak<dyn ClientBase>);
+            .push(Arc::downgrade(&client) as Weak<dyn ClientWaitable>);
         Ok(client)
     }
 
@@ -261,7 +261,7 @@ impl Node {
     {
         let service = Arc::new(Service::<T>::new(self, topic, callback)?);
         self.services
-            .push(Arc::downgrade(&service) as Weak<dyn ServiceBase>);
+            .push(Arc::downgrade(&service) as Weak<dyn ServiceWaitable>);
         Ok(service)
     }
 
@@ -280,19 +280,19 @@ impl Node {
     {
         let subscription = Arc::new(Subscription::<T>::new(self, topic, qos, callback)?);
         self.subscriptions
-            .push(Arc::downgrade(&subscription) as Weak<dyn SubscriptionBase>);
+            .push(Arc::downgrade(&subscription) as Weak<dyn SubscriptionWaitable>);
         Ok(subscription)
     }
 
     /// Returns the subscriptions that have not been dropped yet.
-    pub(crate) fn live_subscriptions(&self) -> Vec<Arc<dyn SubscriptionBase>> {
+    pub(crate) fn live_subscriptions(&self) -> Vec<Arc<dyn SubscriptionWaitable>> {
         self.subscriptions
             .iter()
             .filter_map(Weak::upgrade)
             .collect()
     }
 
-    pub(crate) fn live_clients(&self) -> Vec<Arc<dyn ClientBase>> {
+    pub(crate) fn live_clients(&self) -> Vec<Arc<dyn ClientWaitable>> {
         self.clients.iter().filter_map(Weak::upgrade).collect()
     }
 
@@ -303,7 +303,7 @@ impl Node {
             .collect()
     }
 
-    pub(crate) fn live_services(&self) -> Vec<Arc<dyn ServiceBase>> {
+    pub(crate) fn live_services(&self) -> Vec<Arc<dyn ServiceWaitable>> {
         self.services.iter().filter_map(Weak::upgrade).collect()
     }
 

--- a/rclrs/src/service.rs
+++ b/rclrs/src/service.rs
@@ -39,7 +39,7 @@ impl Drop for ServiceHandle {
 /// Trait to be implemented by concrete Service structs.
 ///
 /// See [`Service<T>`] for an example
-pub trait ServiceBase: Send + Sync {
+pub trait ServiceWaitable: Send + Sync {
     /// Internal function to get a reference to the `rcl` handle.
     fn handle(&self) -> &ServiceHandle;
     /// Tries to take a new request and run the callback with it.
@@ -158,7 +158,7 @@ where
     }
 }
 
-impl<T> ServiceBase for Service<T>
+impl<T> ServiceWaitable for Service<T>
 where
     T: rosidl_runtime_rs::Service,
 {

--- a/rclrs/src/subscription.rs
+++ b/rclrs/src/subscription.rs
@@ -47,7 +47,7 @@ impl Drop for SubscriptionHandle {
 }
 
 /// Trait to be implemented by concrete [`Subscription`]s.
-pub trait SubscriptionBase: Send + Sync {
+pub trait SubscriptionWaitable: Send + Sync {
     /// Internal function to get a reference to the `rcl` handle.
     fn handle(&self) -> &SubscriptionHandle;
     /// Tries to take a new message and run the callback with it.
@@ -248,7 +248,7 @@ where
     }
 }
 
-impl<T> SubscriptionBase for Subscription<T>
+impl<T> SubscriptionWaitable for Subscription<T>
 where
     T: Message,
 {


### PR DESCRIPTION
This is better in my opinion for a few reasons:
* "Base" suggests inheritance, but unlike in `rclcpp`, there is no inheritance in `rclrs`
* The functionality provided by e.g. `SubscriptionBase` in `rclcpp` and `rclrs` is very different, so using the same name for both suggests an equivalence that isn't there
* `*Waitable` is more descriptive, since the purpose of these traits is to interface subscriptions, services, and clients with wait sets