### PR TITLE
Add the DynamicMessage type itself

### DIFF
--- a/rclrs_tests/src/dynamic_message_tests.rs
+++ b/rclrs_tests/src/dynamic_message_tests.rs
@@ -3,6 +3,26 @@ use std::num::NonZeroUsize;
 use rclrs::dynamic_message::*;
 
 #[test]
+fn max_alignment_is_8() {
+    // The DynamicMessage type makes sure that its storage is aligned to 8
+    let alignments = [
+        std::mem::align_of::<msg::Builtins>(),
+        std::mem::align_of::<msg::Arrays>(),
+        std::mem::align_of::<msg::Empty>(),
+        std::mem::align_of::<msg::Strings>(),
+        std::mem::align_of::<msg::BoundedSequences>(),
+        std::mem::align_of::<msg::Nested>(),
+        std::mem::align_of::<msg::MultiNested>(),
+        std::mem::align_of::<msg::UnboundedSequences>(),
+        std::mem::align_of::<msg::WStrings>(),
+        std::mem::align_of::<msg::Constants>(),
+        std::mem::align_of::<msg::BasicTypes>(),
+        std::mem::align_of::<msg::Defaults>(),
+    ];
+    assert_eq!(alignments.into_iter().max().unwrap(), 8);
+}
+
+#[test]
 fn message_structure_is_accurate() {
     let arrays_metadata = DynamicMessageMetadata::new("test_msgs/msg/Arrays").unwrap();
     let arrays_structure = Box::new(arrays_metadata.structure().clone());


### PR DESCRIPTION
As well as conversion from/to concrete message types.

It's clear logically that the alignment has to be 8, since C messages only contain pointers and primitive types of alignment less than or equal to 8 – with the exception of `long double`. Should we require dynamic messages to be aligned to 16 bytes to support `long double`? Even `test_msgs` doesn't use `long double`. 