### PR TITLE
Extend string types

### DIFF
--- a/rosidl_runtime_rs/src/string.rs
+++ b/rosidl_runtime_rs/src/string.rs
@@ -225,6 +225,12 @@ macro_rules! string_impl {
             }
         }
 
+        impl From<&std::string::String> for $string {
+            fn from(s: &std::string::String) -> Self {
+                Self::from(s.as_str())
+            }
+        }
+
         impl FromIterator<char> for $string {
             fn from_iter<I: IntoIterator<Item = char>>(iter: I) -> Self {
                 let mut buf = <$string>::default();
@@ -322,25 +328,6 @@ impl From<&str> for String {
     }
 }
 
-impl From<&std::string::String> for String {
-    fn from(s: &std::string::String) -> Self {
-        let mut msg = Self {
-            data: ptr::null_mut(),
-            size: 0,
-            capacity: 0,
-        };
-
-        // SAFETY: It's okay to pass a non-zero-terminated string here since assignn uses the
-        // specified length and will append the 0 byte to the dest string itself.
-        if !unsafe {
-            rosidl_runtime_c__String__assignn(&mut msg as *mut _, s.as_ptr() as *const _, s.len())
-        } {
-            panic!("rosidl_runtime_c__String__assignn failed");
-        }
-        msg
-    }
-}
-
 impl String {
     /// Creates a CStr from this String.
     ///
@@ -355,29 +342,6 @@ impl String {
 
 impl From<&str> for WString {
     fn from(s: &str) -> Self {
-        let mut msg = Self {
-            data: ptr::null_mut(),
-            size: 0,
-            capacity: 0,
-        };
-        let buf: Vec<u16> = s.encode_utf16().collect();
-        // SAFETY: It's okay to pass a non-zero-terminated string here since assignn uses the
-        // specified length and will append the 0 to the dest string itself.
-        if !unsafe {
-            rosidl_runtime_c__U16String__assignn(
-                &mut msg as *mut _,
-                buf.as_ptr() as *const _,
-                buf.len(),
-            )
-        } {
-            panic!("rosidl_runtime_c__U16String__assignn failed");
-        }
-        msg
-    }
-}
-
-impl From<&std::string::String> for WString {
-    fn from(s: &std::string::String) -> Self {
         let mut msg = Self {
             data: ptr::null_mut(),
             size: 0,

--- a/rosidl_runtime_rs/src/string.rs
+++ b/rosidl_runtime_rs/src/string.rs
@@ -253,13 +253,7 @@ macro_rules! string_impl {
 
                 // SAFETY: It's okay to pass a non-zero-terminated string here since assignn
                 // uses the specified length and will append the 0 to the dest string itself.
-                if !unsafe {
-                    $assignn(
-                        self as *mut _,
-                        v.as_ptr() as *const _,
-                        v.len(),
-                    )
-                } {
+                if !unsafe { $assignn(self as *mut _, v.as_ptr() as *const _, v.len()) } {
                     panic!("$assignn failed");
                 }
             }
@@ -290,17 +284,14 @@ macro_rules! string_impl {
         }
 
         impl $string {
-
             /// Returns a copy of `self` as a vector without the trailing null byte.
             pub fn to_vec(&self) -> Vec<$char_type> {
                 let mut v: Vec<$char_type> = vec![];
 
                 // SAFETY: self.data points to self.size consecutive, initialized elements and
                 // isn't modified externally.
-                unsafe {
-                    let s = slice_from_raw_parts(self.data, self.size);
-                    v.extend_from_slice(s.as_ref().unwrap());
-                };
+                let s = unsafe { slice_from_raw_parts(self.data, self.size).as_ref() };
+                v.extend_from_slice(s.unwrap());
 
                 v
             }

--- a/rosidl_runtime_rs/src/string.rs
+++ b/rosidl_runtime_rs/src/string.rs
@@ -254,7 +254,6 @@ macro_rules! string_impl {
                     let mut buf = [0; 4];
                     c.$encoding_func(&mut buf);
 
-
                     let filtered_bytes: Vec<$unsigned_char_type> = buf
                         .into_iter()
                         .filter(|&c| c != (0 as $unsigned_char_type))


### PR DESCRIPTION
Implemented `Extend<char>`, `Extend<&'a char>`, `FromIterator<char>`, and `FromIterator<&'a char>` for String and WString.

Of note here is that with this change, String and WString now have interior mutability so they are no longer able to implement `Sync` safely.

Original Issue: https://github.com/ros2-rust/ros2_rust/issues/246