### PR TITLE
Return Arc from the create_node function to match other create_X functions

### DIFF
--- a/docs/writing-your-first-rclrs-node.md
+++ b/docs/writing-your-first-rclrs-node.md
@@ -76,7 +76,7 @@ Next, add a main function to launch it:
 fn main() -> Result<(), rclrs::RclrsError> {
     let context = rclrs::Context::new(std::env::args())?;
     let republisher = RepublisherNode::new(&context)?;
-    rclrs::spin(&republisher.node)
+    rclrs::spin(republisher.node)
 }
 ```
 
@@ -190,7 +190,7 @@ fn main() -> Result<(), rclrs::RclrsError> {
             republisher.republish()?;
         }
     });
-    rclrs::spin(&republisher.node)
+    rclrs::spin(republisher.node)
 }
 ```
 
@@ -212,7 +212,7 @@ fn main() -> Result<(), rclrs::RclrsError> {
             republisher_other_thread.republish()?;
         }
     });
-    rclrs::spin(&republisher.node)
+    rclrs::spin(republisher.node)
 }
 ```
 

--- a/docs/writing-your-first-rclrs-node.md
+++ b/docs/writing-your-first-rclrs-node.md
@@ -54,7 +54,7 @@ struct RepublisherNode {
 
 impl RepublisherNode {
     fn new(context: &rclrs::Context) -> Result<Self, rclrs::RclrsError> {
-        let mut node = rclrs::Node::new(context, "republisher")?;
+        let node = rclrs::Node::new(context, "republisher")?;
         let data = None;
         let _subscription = node.create_subscription(
             "in_topic",
@@ -121,7 +121,7 @@ struct RepublisherNode {
 
 impl RepublisherNode {
     fn new(context: &rclrs::Context) -> Result<Self, rclrs::RclrsError> {
-        let mut node = rclrs::Node::new(context, "republisher")?;
+        let node = rclrs::Node::new(context, "republisher")?;
         let data = Arc::new(Mutex::new(None));  // (3)
         let data_cb = Arc::clone(&data);
         let _subscription = {

--- a/examples/message_demo/src/message_demo.rs
+++ b/examples/message_demo/src/message_demo.rs
@@ -1,5 +1,6 @@
 use std::convert::TryInto;
 use std::env;
+use std::sync::Arc;
 
 use anyhow::{Error, Result};
 use rosidl_runtime_rs::{seq, BoundedSequence, Message, Sequence};
@@ -159,10 +160,10 @@ fn demonstrate_pubsub() -> Result<(), Error> {
         )?;
     println!("Sending idiomatic message.");
     idiomatic_publisher.publish(rclrs_example_msgs::msg::VariousTypes::default())?;
-    rclrs::spin_once(&node, None)?;
+    rclrs::spin_once(Arc::clone(&node), None)?;
     println!("Sending RMW-native message.");
     direct_publisher.publish(rclrs_example_msgs::msg::rmw::VariousTypes::default())?;
-    rclrs::spin_once(&node, None)?;
+    rclrs::spin_once(Arc::clone(&node), None)?;
 
     Ok(())
 }

--- a/examples/message_demo/src/message_demo.rs
+++ b/examples/message_demo/src/message_demo.rs
@@ -132,7 +132,7 @@ fn demonstrate_pubsub() -> Result<(), Error> {
     println!("================== Interoperability demo ==================");
     // Demonstrate interoperability between idiomatic and RMW-native message types
     let context = rclrs::Context::new(env::args())?;
-    let mut node = rclrs::create_node(&context, "message_demo")?;
+    let node = rclrs::create_node(&context, "message_demo")?;
 
     let idiomatic_publisher = node.create_publisher::<rclrs_example_msgs::msg::VariousTypes>(
         "topic",

--- a/examples/minimal_client_service/src/minimal_client.rs
+++ b/examples/minimal_client_service/src/minimal_client.rs
@@ -28,5 +28,5 @@ fn main() -> Result<(), Error> {
     std::thread::sleep(std::time::Duration::from_millis(500));
 
     println!("Waiting for response");
-    rclrs::spin(&node).map_err(|err| err.into())
+    rclrs::spin(node).map_err(|err| err.into())
 }

--- a/examples/minimal_client_service/src/minimal_client.rs
+++ b/examples/minimal_client_service/src/minimal_client.rs
@@ -5,7 +5,7 @@ use anyhow::{Error, Result};
 fn main() -> Result<(), Error> {
     let context = rclrs::Context::new(env::args())?;
 
-    let mut node = rclrs::create_node(&context, "minimal_client")?;
+    let node = rclrs::create_node(&context, "minimal_client")?;
 
     let client = node.create_client::<example_interfaces::srv::AddTwoInts>("add_two_ints")?;
 

--- a/examples/minimal_client_service/src/minimal_client_async.rs
+++ b/examples/minimal_client_service/src/minimal_client_async.rs
@@ -6,7 +6,7 @@ use anyhow::{Error, Result};
 async fn main() -> Result<(), Error> {
     let context = rclrs::Context::new(env::args())?;
 
-    let mut node = rclrs::create_node(&context, "minimal_client")?;
+    let node = rclrs::create_node(&context, "minimal_client")?;
 
     let client = node.create_client::<example_interfaces::srv::AddTwoInts>("add_two_ints")?;
 

--- a/examples/minimal_client_service/src/minimal_client_async.rs
+++ b/examples/minimal_client_service/src/minimal_client_async.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<(), Error> {
 
     println!("Waiting for response");
 
-    let rclrs_spin = tokio::task::spawn_blocking(move || rclrs::spin(&node));
+    let rclrs_spin = tokio::task::spawn_blocking(move || rclrs::spin(node));
 
     let response = future.await?;
     println!(

--- a/examples/minimal_client_service/src/minimal_service.rs
+++ b/examples/minimal_client_service/src/minimal_service.rs
@@ -21,5 +21,5 @@ fn main() -> Result<(), Error> {
         .create_service::<example_interfaces::srv::AddTwoInts, _>("add_two_ints", handle_service)?;
 
     println!("Starting server");
-    rclrs::spin(&node).map_err(|err| err.into())
+    rclrs::spin(node).map_err(|err| err.into())
 }

--- a/examples/minimal_client_service/src/minimal_service.rs
+++ b/examples/minimal_client_service/src/minimal_service.rs
@@ -15,7 +15,7 @@ fn handle_service(
 fn main() -> Result<(), Error> {
     let context = rclrs::Context::new(env::args())?;
 
-    let mut node = rclrs::create_node(&context, "minimal_service")?;
+    let node = rclrs::create_node(&context, "minimal_service")?;
 
     let _server = node
         .create_service::<example_interfaces::srv::AddTwoInts, _>("add_two_ints", handle_service)?;

--- a/examples/minimal_pub_sub/src/minimal_subscriber.rs
+++ b/examples/minimal_pub_sub/src/minimal_subscriber.rs
@@ -19,5 +19,5 @@ fn main() -> Result<(), Error> {
         },
     )?;
 
-    rclrs::spin(&node).map_err(|err| err.into())
+    rclrs::spin(node).map_err(|err| err.into())
 }

--- a/examples/minimal_pub_sub/src/minimal_subscriber.rs
+++ b/examples/minimal_pub_sub/src/minimal_subscriber.rs
@@ -5,7 +5,7 @@ use anyhow::{Error, Result};
 fn main() -> Result<(), Error> {
     let context = rclrs::Context::new(env::args())?;
 
-    let mut node = rclrs::create_node(&context, "minimal_subscriber")?;
+    let node = rclrs::create_node(&context, "minimal_subscriber")?;
 
     let mut num_messages: usize = 0;
 

--- a/examples/minimal_pub_sub/src/zero_copy_subscriber.rs
+++ b/examples/minimal_pub_sub/src/zero_copy_subscriber.rs
@@ -19,5 +19,5 @@ fn main() -> Result<(), Error> {
         },
     )?;
 
-    rclrs::spin(&node).map_err(|err| err.into())
+    rclrs::spin(node).map_err(|err| err.into())
 }

--- a/examples/minimal_pub_sub/src/zero_copy_subscriber.rs
+++ b/examples/minimal_pub_sub/src/zero_copy_subscriber.rs
@@ -5,7 +5,7 @@ use anyhow::{Error, Result};
 fn main() -> Result<(), Error> {
     let context = rclrs::Context::new(env::args())?;
 
-    let mut node = rclrs::create_node(&context, "minimal_subscriber")?;
+    let node = rclrs::create_node(&context, "minimal_subscriber")?;
 
     let mut num_messages: usize = 0;
 

--- a/rclrs/src/lib.rs
+++ b/rclrs/src/lib.rs
@@ -23,6 +23,7 @@ mod rcl_bindings;
 #[cfg(feature = "dyn_msg")]
 pub mod dynamic_message;
 
+use std::sync::Arc;
 use std::time::Duration;
 
 pub use arguments::*;
@@ -105,8 +106,8 @@ pub fn spin(node: &Node) -> Result<(), RclrsError> {
 /// assert!(node.is_ok());
 /// # Ok::<(), RclrsError>(())
 /// ```
-pub fn create_node(context: &Context, node_name: &str) -> Result<Node, RclrsError> {
-    Node::builder(context, node_name).build()
+pub fn create_node(context: &Context, node_name: &str) -> Result<Arc<Node>, RclrsError> {
+    Ok(Arc::new(Node::builder(context, node_name).build()?))
 }
 
 /// Creates a [`NodeBuilder`][1].

--- a/rclrs/src/lib.rs
+++ b/rclrs/src/lib.rs
@@ -51,7 +51,7 @@ pub use wait::*;
 ///
 /// [1]: crate::RclReturnCode
 pub fn spin_once(node: Arc<Node>, timeout: Option<Duration>) -> Result<(), RclrsError> {
-    let wait_set = WaitSet::new_for_node(&*node)?;
+    let wait_set = WaitSet::new_for_node(&node)?;
     let ready_entities = wait_set.wait(timeout)?;
 
     for ready_subscription in ready_entities.subscriptions {

--- a/rclrs/src/node/builder.rs
+++ b/rclrs/src/node/builder.rs
@@ -275,10 +275,10 @@ impl NodeBuilder {
         Ok(Node {
             rcl_node_mtx,
             rcl_context_mtx: self.context.clone(),
-            clients: vec![],
-            guard_conditions: vec![],
-            services: vec![],
-            subscriptions: vec![],
+            clients_mtx: Mutex::new(vec![]),
+            guard_conditions_mtx: Mutex::new(vec![]),
+            services_mtx: Mutex::new(vec![]),
+            subscriptions_mtx: Mutex::new(vec![]),
             _parameter_map,
         })
     }

--- a/rclrs_tests/src/graph_tests.rs
+++ b/rclrs_tests/src/graph_tests.rs
@@ -85,7 +85,7 @@ fn test_publishers() -> Result<(), RclrsError> {
 #[test]
 fn test_subscriptions() -> Result<(), RclrsError> {
     let namespace = "/test_subscriptions_graph";
-    let mut graph = construct_test_graph(namespace)?;
+    let graph = construct_test_graph(namespace)?;
 
     let node_2_empty_subscription = graph.node2.create_subscription::<msg::Empty, _>(
         "graph_test_topic_1",
@@ -149,7 +149,7 @@ fn test_subscriptions() -> Result<(), RclrsError> {
 
 #[test]
 fn test_topic_names_and_types() -> Result<(), RclrsError> {
-    let mut graph = construct_test_graph("test_topics_graph")?;
+    let graph = construct_test_graph("test_topics_graph")?;
 
     let _node_1_defaults_subscription = graph.node1.create_subscription::<msg::Defaults, _>(
         "graph_test_topic_3",
@@ -191,7 +191,7 @@ fn test_topic_names_and_types() -> Result<(), RclrsError> {
 #[test]
 fn test_services() -> Result<(), RclrsError> {
     let namespace = "/test_services_graph";
-    let mut graph = construct_test_graph(namespace)?;
+    let graph = construct_test_graph(namespace)?;
     let check_names_and_types = |names_and_types: TopicNamesAndTypes| {
         let types = names_and_types
             .get("/test_services_graph/graph_test_topic_4")
@@ -225,7 +225,7 @@ fn test_services() -> Result<(), RclrsError> {
 #[test]
 fn test_clients() -> Result<(), RclrsError> {
     let namespace = "/test_clients_graph";
-    let mut graph = construct_test_graph(namespace)?;
+    let graph = construct_test_graph(namespace)?;
     let _node_2_empty_client = graph
         .node2
         .create_client::<srv::Empty>("graph_test_topic_4")?;


### PR DESCRIPTION
This PR makes `create_node` consistent with other `create_X` functions by return an `Arc`. Additionally added fine-grained locks so that `create_X` functions don't need to take a mutable reference to `self`.

Returning an `Arc` is also akin to `rclcpp`'s behavior, which returns a `shared_ptr` from `create_node`.