### PR TITLE
Use ros2-testing debs for rolling

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,6 +48,7 @@ jobs:
       uses: ros-tooling/setup-ros@v0.6
       with:
         required-ros-distributions: ${{ matrix.ros_distribution }}
+        use-ros2-testing: ${{ matrix.ros_distribution == 'rolling' }}
 
     - name: Downgrade pydocstyle as a workaround for https://github.com/ament/ament_lint/issues/434
       run: |


### PR DESCRIPTION
This PR uses the Debian packages from the testing repository for rolling so we can catch API incompatibilities earlier. Given that the rolling job is marked as `continue-on-error` and so it won't cause the entire CI fail, in case there are any build errors, PRs can still be merged.