### PR TITLE
Fix hardcoded rmw_gid_t length

### DIFF
--- a/rclrs/src/rcl_bindings.rs
+++ b/rclrs/src/rcl_bindings.rs
@@ -7,3 +7,5 @@
 #![allow(missing_docs)]
 
 include!(concat!(env!("OUT_DIR"), "/rcl_bindings_generated.rs"));
+
+pub const RMW_GID_STORAGE_SIZE: usize = rmw_gid_storage_size_constant;

--- a/rclrs/src/rcl_wrapper.h
+++ b/rclrs/src/rcl_wrapper.h
@@ -5,3 +5,5 @@
 #include <rmw/types.h>
 #include <rosidl_typesupport_introspection_c/field_types.h>
 #include <rosidl_typesupport_introspection_c/message_introspection.h>
+
+const size_t rmw_gid_storage_size_constant = RMW_GID_STORAGE_SIZE;

--- a/rclrs/src/subscription/message_info.rs
+++ b/rclrs/src/subscription/message_info.rs
@@ -27,7 +27,7 @@ use crate::rcl_bindings::*;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PublisherGid {
     /// Bytes identifying a publisher in the RMW implementation.
-    pub data: [u8; 24],
+    pub data: [u8; RMW_GID_STORAGE_SIZE],
     /// A string containing the RMW implementation's name.
     ///
     /// The `data` member only uniquely identifies the publisher within
@@ -145,7 +145,7 @@ mod tests {
             publication_sequence_number: 0,
             reception_sequence_number: 0,
             publisher_gid: rmw_gid_t {
-                data: [0; 24],
+                data: [0; RMW_GID_STORAGE_SIZE],
                 implementation_identifier: std::ptr::null(),
             },
             from_intra_process: false,


### PR DESCRIPTION
This fixes the following build failure on rolling:

```
  error[E0308]: mismatched types
     --> src/subscription/message_info.rs:120:19
      |
  120 |             data: rmw_message_info.publisher_gid.data,
      |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an array with a fixed size of 24 elements, found one with 16 elements
```

