### PR TITLE
Remove workaround for pydocstyle

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,10 +50,6 @@ jobs:
         required-ros-distributions: ${{ matrix.ros_distribution }}
         use-ros2-testing: ${{ matrix.ros_distribution == 'rolling' }}
 
-    - name: Downgrade pydocstyle as a workaround for https://github.com/ament/ament_lint/issues/434
-      run: |
-        sudo pip install pydocstyle==6.1.1
-
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@1.63.0
       with:


### PR DESCRIPTION
Now that there's a new tagged version of `ament_lint` (https://github.com/ament/ament_lint/releases/tag/0.9.8), this should no longer be needed.