### PR TITLE
Allow usage of different ROS distributions in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM ros:humble as base
+ARG ROS_DISTRO=humble
+FROM ros:$ROS_DISTRO as base
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies

--- a/docs/building.md
+++ b/docs/building.md
@@ -56,7 +56,8 @@ Build the Docker image with
 
 ```shell
 # Make sure to run this in the workspace directory
-docker build -t ros2_rust_dev - < src/ros2_rust/Dockerfile
+# ROS_DISTRO can be humble|rolling
+docker build -f src/ros2_rust/Dockerfile --build-arg "ROS_DISTRO=humble" -t ros2_rust_dev
 ```
 
 and then run it with

--- a/docs/building.md
+++ b/docs/building.md
@@ -56,7 +56,7 @@ Build the Docker image with
 
 ```shell
 # Make sure to run this in the workspace directory
-# ROS_DISTRO can be humble|rolling
+# ROS_DISTRO can be humble|iron|rolling
 docker build -f src/ros2_rust/Dockerfile --build-arg "ROS_DISTRO=humble" -t ros2_rust_dev
 ```
 


### PR DESCRIPTION
Make it easy to create a Docker container with a different ROS distribution for development. 