### PR TITLE
Developer workflow improvements to build scripts

### DIFF
--- a/rclrs/Cargo.toml
+++ b/rclrs/Cargo.toml
@@ -19,7 +19,7 @@ ament_rs = { version = "0.2", optional = true }
 # Needed for clients
 futures = "0.3"
 # Needed for dynamic messages
-libloading = { version = "0.7", optional = true }
+libloading = { version = "0.8", optional = true }
 # Needed for the Message trait, among others
 rosidl_runtime_rs = "0.3"
 
@@ -29,7 +29,7 @@ tempfile = "3.3.0"
 
 [build-dependencies]
 # Needed for FFI
-bindgen = "0.59.1"
+bindgen = "0.66.1"
 
 [features]
 dyn_msg = ["ament_rs", "libloading"]

--- a/rosidl_runtime_rs/build.rs
+++ b/rosidl_runtime_rs/build.rs
@@ -20,4 +20,7 @@ fn main() {
         let library_path = Path::new(ament_prefix_path).join("lib");
         println!("cargo:rustc-link-search=native={}", library_path.display());
     }
+
+    // Invalidate the built crate whenever this script changes
+    println!("cargo:rerun-if-changed=build.rs");
 }


### PR DESCRIPTION
- Upgraded libloading to 0.8
- Added instructions to rerun build scripts if dependent files have changed
- Enabled bindgen to invalidate the built crate whenever any transitively included header files from the wrapper change
- Removed some default true options from our bindgen builder

This enables smoother development workflows when doing things like editing our build scripts, or swapping the source'd version of ROS without requiring a new workspace or having to manually go through and removing the `target/` folder for each crate.