### PR TITLE
Fixed an issue where cpu usage remained at 100%

### DIFF
--- a/rclrs/src/executor.rs
+++ b/rclrs/src/executor.rs
@@ -71,7 +71,7 @@ impl SingleThreadedExecutor {
                 | Err(RclrsError::RclError {
                     code: RclReturnCode::Timeout,
                     ..
-                }) => (),
+                }) => std::thread::yield_now(),
                 error => return error,
             }
         }


### PR DESCRIPTION
The loop in the spin function has no pause condition, which will cause the cpu to execute the loop at full load all the time during actual processing. I compared with rclcpp, which can have a pause condition to reduce cpu usage, so I added a pause condition to the loop to reduce cpu usage

https://github.com/ros2/rclcpp/blob/77db1ed25b4c26ab722a13c268521b923606c04d/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp#L97