### PR TITLE
Add support for deferred services

### DIFF
--- a/examples/minimal_client_service/Cargo.toml
+++ b/examples/minimal_client_service/Cargo.toml
@@ -16,6 +16,10 @@ path = "src/minimal_client_async.rs"
 name = "minimal_service"
 path = "src/minimal_service.rs"
 
+[[bin]]
+name = "minimal_deferred_service"
+path = "src/minimal_deferred_service.rs"
+
 [dependencies]
 anyhow = {version = "1", features = ["backtrace"]}
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time"] }

--- a/examples/minimal_client_service/src/minimal_deferred_service.rs
+++ b/examples/minimal_client_service/src/minimal_deferred_service.rs
@@ -1,0 +1,37 @@
+use std::{env, sync::mpsc::{self, Receiver}};
+use anyhow::{Error, Result};
+use example_interfaces::srv::{AddTwoInts, AddTwoInts_Request, AddTwoInts_Response};
+
+struct Payload {
+    request: AddTwoInts_Request,
+    response_sender: rclrs::ResponseSender<AddTwoInts_Response>,
+}
+
+fn worker_thread(receiver: Receiver<Payload>) {
+    loop {
+        let Ok(Payload { request, response_sender }) = receiver.recv() else {
+            return;
+        };
+        let sum = request.a + request.b;
+        if let Err(err) = response_sender.send(AddTwoInts_Response { sum }) {
+            println!("Error while sending result: {err:?}");
+        }
+    }
+}
+
+fn main() -> Result<(), Error> {
+    let context = rclrs::Context::new(env::args())?;
+
+    let node = rclrs::create_node(&context, "minimal_deferred_service")?;
+    let (sender, receiver) = mpsc::channel();
+    let _worker = std::thread::spawn(move || worker_thread(receiver));
+
+    let _server = node
+        .create_deferred_service::<AddTwoInts, _>(
+            "add_two_ints",
+            move |request, response_sender| {
+                sender.send(Payload { request, response_sender }).ok();
+            }
+        );
+    rclrs::spin(node).map_err(|err| err.into())
+}

--- a/rclrs/src/parameter/service.rs
+++ b/rclrs/src/parameter/service.rs
@@ -18,7 +18,7 @@ pub struct ParameterService {
 
 impl ParameterService {
     pub fn new(rcl_node_mtx: Arc<Mutex<rcl_node_t>>) -> Result<Self, RclrsError> {
-        let describe_parameters_service = Service::new(Arc::clone(&rcl_node_mtx),
+        let describe_parameters_service = Service::immediate(Arc::clone(&rcl_node_mtx),
             "describe_parameters",
             |req_id: &rmw_request_id_t, req: DescribeParameters_Request| {
                 DescribeParameters_Response {
@@ -26,7 +26,7 @@ impl ParameterService {
                 }
             },
         )?;
-        let get_parameter_types_service = Service::new(Arc::clone(&rcl_node_mtx),
+        let get_parameter_types_service = Service::immediate(Arc::clone(&rcl_node_mtx),
             "get_parameter_types",
             |req_id: &rmw_request_id_t, req: GetParameterTypes_Request| {
                 GetParameterTypes_Response {
@@ -34,7 +34,7 @@ impl ParameterService {
                 }
             },
         )?;
-        let get_parameters_service = Service::new(Arc::clone(&rcl_node_mtx),
+        let get_parameters_service = Service::immediate(Arc::clone(&rcl_node_mtx),
             "get_parameters",
             |req_id: &rmw_request_id_t, req: GetParameters_Request| {
                 GetParameters_Response {
@@ -42,7 +42,7 @@ impl ParameterService {
                 }
             },
         )?;
-        let list_parameters_service = Service::new(Arc::clone(&rcl_node_mtx),
+        let list_parameters_service = Service::immediate(Arc::clone(&rcl_node_mtx),
             "list_parameters",
             |req_id: &rmw_request_id_t, req: ListParameters_Request| {
                 ListParameters_Response {
@@ -50,7 +50,7 @@ impl ParameterService {
                 }
             },
         )?;
-        let set_parameters_service = Service::new(Arc::clone(&rcl_node_mtx),
+        let set_parameters_service = Service::immediate(Arc::clone(&rcl_node_mtx),
             "set_parameters",
             |req_id: &rmw_request_id_t, req: SetParameters_Request| {
                 SetParameters_Response {
@@ -58,7 +58,7 @@ impl ParameterService {
                 }
             },
         )?;
-        let set_parameters_atomically_service = Service::new(Arc::clone(&rcl_node_mtx),
+        let set_parameters_atomically_service = Service::immediate(Arc::clone(&rcl_node_mtx),
             "set_parameters_atomically",
             |req_id: &rmw_request_id_t, req: SetParametersAtomically_Request| {
                 SetParametersAtomically_Response {

--- a/rclrs_tests/Cargo.toml
+++ b/rclrs_tests/Cargo.toml
@@ -10,6 +10,8 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = {version = "1", features = ["backtrace"]}
 test_msgs = {version = "*"}
+example_interfaces = {version = "*"}
+tokio = { version = "1", features = ["macros", "rt", "sync"] }
 
 [dependencies.rclrs]
 version = "*"

--- a/rclrs_tests/package.xml
+++ b/rclrs_tests/package.xml
@@ -10,6 +10,7 @@
   <license>Apache License 2.0</license>
 
   <depend>test_msgs</depend>
+  <depend>example_interfaces</depend>
   <depend>rclrs</depend>
   <depend>rosidl_runtime_rs</depend>
 

--- a/rclrs_tests/src/lib.rs
+++ b/rclrs_tests/src/lib.rs
@@ -3,3 +3,4 @@
 mod client_service_tests;
 mod graph_tests;
 mod pub_sub_tests;
+mod service_tests;

--- a/rclrs_tests/src/service_tests.rs
+++ b/rclrs_tests/src/service_tests.rs
@@ -1,0 +1,85 @@
+use rclrs::*;
+use example_interfaces::srv::*;
+use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
+use tokio::sync::mpsc;
+
+#[tokio::test]
+async fn test_immediate_service() {
+    let context = Context::new([]).unwrap();
+    let node = create_node(&context, "test_immediate_service").unwrap();
+    let _service = node.create_service::<AddTwoInts, _>(
+        "add",
+        |_, request| AddTwoInts_Response { sum: request.a + request.b },
+    ).unwrap();
+    let client = node.create_client::<AddTwoInts>("add").unwrap();
+    let request = AddTwoInts_Request { a: 41, b: 1 };
+    let future = client.call_async(&request);
+    let run = Arc::new(AtomicBool::new(true));
+    let set_run = run.clone();
+    let _spinning = tokio::task::spawn_blocking(
+        move || {
+            while run.load(Ordering::Relaxed) {
+                if let Err(err) = spin_once(
+                    node.clone(), Some(std::time::Duration::new(1, 0))
+                ) {
+                    match err {
+                        RclrsError::RclError { code: RclReturnCode::Timeout, .. } => {
+                            return;
+                        }
+                        _ => panic!("{err:?}"),
+                    }
+                }
+            }
+        });
+    let response = future.await.unwrap();
+    assert_eq!(response.sum, 42);
+    set_run.store(false, Ordering::Relaxed);
+}
+
+#[tokio::test]
+async fn test_deferred_service() {
+    let context = Context::new([]).unwrap();
+    let node = create_node(&context, "test_deferred_service").unwrap();
+    let (sender, mut receiver) = mpsc::unbounded_channel::<Payload>();
+    tokio::spawn(async move {
+        while let Some(payload) = receiver.recv().await {
+            let Payload { request, response_sender } = payload;
+            let sum = request.a + request.b;
+            response_sender.send(AddTwoInts_Response { sum }).unwrap();
+        }
+    });
+
+    let _service = node.create_deferred_service::<AddTwoInts, _>(
+        "add",
+        move |request, response_sender| sender.send(Payload { request, response_sender }).unwrap(),
+    ).unwrap();
+
+    let client = node.create_client::<AddTwoInts>("add").unwrap();
+    let request = AddTwoInts_Request { a: 41, b: 1 };
+    let future = client.call_async(&request);
+    let run = Arc::new(AtomicBool::new(true));
+    let set_run = run.clone();
+    let _spinning = tokio::task::spawn_blocking(
+        move || {
+            while run.load(Ordering::Relaxed) {
+                if let Err(err) = spin_once(
+                    node.clone(), Some(std::time::Duration::new(1, 0))
+                ) {
+                    match err {
+                        RclrsError::RclError { code: RclReturnCode::Timeout, .. } => {
+                            return;
+                        }
+                        _ => panic!("{err:?}"),
+                    }
+                }
+            }
+        });
+    let response = future.await.unwrap();
+    assert_eq!(response.sum, 42);
+    set_run.store(false, Ordering::Relaxed);
+}
+
+struct Payload {
+    request: AddTwoInts_Request,
+    response_sender: ResponseSender<AddTwoInts_Response>,
+}


### PR DESCRIPTION
This PR is meant to be an MVP implementation of support for deferred services. This allows users to provide a service callback that does not immediately return a response, but instead is given a `ResponseSender` that it can use to send a response from elsewhere, e.g. a task running in a task pool.

I have some ideas for how to improve the ergonomics (e.g. automatically infer the service type based on the provided callback signature) and maybe allow one `Node::create_service()` function to produce both immediate and deferred services, but I'll save those ideas for a future PR since it may be controversial for being API breaking.