### PR TITLE
Add wchar support

### DIFF
--- a/examples/message_demo/src/message_demo.rs
+++ b/examples/message_demo/src/message_demo.rs
@@ -68,6 +68,14 @@ fn check_default_values() {
     );
 }
 
+fn check_default_idl_values() {
+    let idiomatic_msg = rclrs_example_msgs::msg::MyMessage::default();
+    let rmw_msg = rclrs_example_msgs::msg::rmw::MyMessage::default();
+
+    assert_eq!(idiomatic_msg.wchar_value, 0u16);
+    assert_eq!(rmw_msg.wchar_value, 0u16);
+}
+
 fn demonstrate_printing() {
     let default_msg = rclrs_example_msgs::msg::VariousTypes::default();
     println!("================== Compact debug representation ==================");
@@ -170,6 +178,7 @@ fn demonstrate_pubsub() -> Result<(), Error> {
 
 fn main() -> Result<(), Error> {
     check_default_values();
+    check_default_idl_values();
     demonstrate_printing();
     demonstrate_serde()?;
     demonstrate_sequences();

--- a/rclrs_example_msgs/CMakeLists.txt
+++ b/rclrs_example_msgs/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(rosidl_default_generators REQUIRED)
 set(msg_files
   "msg/NestedType.msg"
   "msg/VariousTypes.msg"
+  "msg/MyMessage.idl"
 )
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}

--- a/rclrs_example_msgs/CMakeLists.txt
+++ b/rclrs_example_msgs/CMakeLists.txt
@@ -18,9 +18,9 @@ set(msg_files
   "msg/VariousTypes.msg"
   "msg/MyMessage.idl"
 )
+
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}
-  ADD_LINTER_TESTS
 )
 
 ament_export_dependencies(rosidl_default_runtime)

--- a/rclrs_example_msgs/msg/MyMessage.idl
+++ b/rclrs_example_msgs/msg/MyMessage.idl
@@ -1,0 +1,86 @@
+// Taken and slightly adapted from
+// https://github.com/ros2/rosidl/blob/iron/rosidl_parser/test/msg/MyMessage.idl
+
+module rclrs_example_msgs {
+  module msg {
+    module MyMessage_Constants {
+      const short SHORT_CONSTANT = -23;
+      const unsigned long UNSIGNED_LONG_CONSTANT = 42;
+      const float FLOAT_CONSTANT = 1.25;
+      const boolean BOOLEAN_CONSTANT = TRUE;
+      const string STRING_CONSTANT = "string_value";
+      const wstring WSTRING_CONSTANT = "wstring_value_\u2122";
+      const string EMPTY_STRING_CONSTANT = "";
+    };
+
+    @verbatim ( language="comment", text="Documentation of MyMessage." "Adjacent string literal." )
+    @transfer_mode(SHMEM_REF)
+    struct MyMessage {
+      short short_value, short_value2;
+      @default ( value=123 )
+      unsigned short unsigned_short_value;
+      @key
+      @range ( min=-10, max=10 )
+      long long_value;
+      @verbatim (language="comment", text="")
+      unsigned long unsigned_long_value;
+      long long long_long_value;
+      unsigned long long unsigned_long_long_value;
+      float float_value;
+      double double_value;
+//      long double long_double_value;
+      char char_value;
+      wchar wchar_value;
+      boolean boolean_value;
+      octet octet_value;
+      int8 int8_value;
+      uint8 uint8_value;
+      int16 int16_value;
+      uint16 uint16_value;
+      int32 int32_value;
+      uint32 uint32_value;
+      int64 int64_value;
+      uint64 uint64_value;
+      string string_value;
+      string<5> bounded_string_value;
+      wstring wstring_value;
+      wstring<23> bounded_wstring_value;
+//      wstring<UNSIGNED_LONG_CONSTANT> constant_bounded_wstring_value;
+      sequence<short> unbounded_short_values;
+      sequence<short, 5> bounded_short_values;
+      sequence<string<3>> unbounded_values_of_bounded_strings;
+      sequence<string<3>, 4> bounded_values_of_bounded_strings;
+      short array_short_values[23];
+
+      // Tests of the floating point parser (7.2.6.4)
+      @default ( value=1.9e10 )
+      float int_and_frac_with_positive_scientific;
+      @default ( value=1.9e+10 )
+      float int_and_frac_with_explicit_positive_scientific;
+      @default ( value=1.1e-10)
+      float int_and_frac_with_negative_scientific;
+      @default ( value=0.00009 )
+      float int_and_frac;
+      @default ( value = 1. )
+      float int_with_empty_frac;
+      @default ( value = .1 )
+      float frac_only;
+      @default ( value=9e05 )
+      float int_with_positive_scientific;
+      @default ( value=9e+05 )
+      float int_with_explicit_positive_scientific;
+      @default ( value=9e-05 )
+      float int_with_negative_scientific;
+
+      // Tests of the fixed point parser (7.2.6.5)
+      @default ( value=8.7d )
+      float fixed_int_and_frac;
+      @default ( value=4.d )
+      float fixed_int_with_dot_only;
+      @default ( value=.3d )
+      float fixed_frac_only;
+      @default ( value=7d )
+      float fixed_int_only;
+    };
+  };
+};

--- a/rosidl_generator_rs/rosidl_generator_rs/__init__.py
+++ b/rosidl_generator_rs/rosidl_generator_rs/__init__.py
@@ -102,9 +102,9 @@ def generate_rs(generator_arguments_file, typesupport_impls):
         'constant_value_to_rs': constant_value_to_rs,
         'value_to_rs': value_to_rs,
         'convert_camel_case_to_lower_case_underscore':
-            rosidl_pycommon.convert_camel_case_to_lower_case_underscore,
+        rosidl_pycommon.convert_camel_case_to_lower_case_underscore,
         'convert_lower_case_underscore_to_camel_case':
-            convert_lower_case_underscore_to_camel_case,
+        convert_lower_case_underscore_to_camel_case,
         'msg_specs': [],
         'srv_specs': [],
         'package_name': args['package_name'],
@@ -168,7 +168,6 @@ def generate_rs(generator_arguments_file, typesupport_impls):
 
     return 0
 
-
 def get_rs_name(name):
     keywords = [
         # strict keywords
@@ -183,7 +182,6 @@ def get_rs_name(name):
     ]
     # If the field name is a reserved keyword in Rust append an underscore
     return name if not name in keywords else name + '_'
-
 
 def escape_string(s):
     s = s.replace('\\', '\\\\')
@@ -213,18 +211,18 @@ def primitive_value_to_rs(type_, value):
         return 'true' if value else 'false'
 
     if type_.type in [
-        'byte',
-        'char',
-        'wchar',
-        'int8',
-        'uint8',
-        'int16',
-        'uint16',
-        'int32',
-        'uint32',
-        'int64',
-        'uint64',
-        'float64',
+            'byte',
+            'char',
+            'wchar',
+            'int8',
+            'uint8',
+            'int16',
+            'uint16',
+            'int32',
+            'uint32',
+            'int64',
+            'uint64',
+            'float64',
     ]:
         return str(value)
 
@@ -251,7 +249,6 @@ def constant_value_to_rs(type_, value):
         return '"%s"' % escape_string(value)
 
     assert False, "unknown constant type '%s'" % type_
-
 
 # Type hierarchy:
 # 
@@ -283,7 +280,6 @@ def pre_field_serde(type_):
 
 def make_get_idiomatic_rs_type(package_name):
     get_rmw_rs_type = make_get_rmw_rs_type(package_name)
-
     def get_idiomatic_rs_type(type_):
         if isinstance(type_, UnboundedString) or isinstance(type_, UnboundedWString):
             return 'std::string::String'
@@ -295,9 +291,7 @@ def make_get_idiomatic_rs_type(package_name):
             return '[{}; {}]'.format(get_idiomatic_rs_type(type_.value_type), type_.size)
         else:
             return get_rmw_rs_type(type_)
-
     return get_idiomatic_rs_type
-
 
 def make_get_rmw_rs_type(package_name):
     def get_rmw_rs_type(type_):
@@ -347,9 +341,7 @@ def make_get_rmw_rs_type(package_name):
         elif isinstance(type_, UnboundedSequence):
             return 'rosidl_runtime_rs::Sequence<{}>'.format(get_rmw_rs_type(type_.value_type))
         elif isinstance(type_, BoundedSequence):
-            return 'rosidl_runtime_rs::BoundedSequence<{}, {}>'.format(get_rmw_rs_type(type_.value_type),
-                                                                       type_.maximum_size)
+            return 'rosidl_runtime_rs::BoundedSequence<{}, {}>'.format(get_rmw_rs_type(type_.value_type), type_.maximum_size)
 
         assert False, "unknown type '%s'" % type_.typename
-
     return get_rmw_rs_type

--- a/rosidl_generator_rs/rosidl_generator_rs/__init__.py
+++ b/rosidl_generator_rs/rosidl_generator_rs/__init__.py
@@ -14,7 +14,6 @@
 
 import os
 import pathlib
-import subprocess
 
 from pathlib import Path
 
@@ -24,12 +23,7 @@ else:
     import rosidl_pycommon
 
 from rosidl_parser.definition import AbstractGenericString
-from rosidl_parser.definition import AbstractNestedType
-from rosidl_parser.definition import AbstractSequence
-from rosidl_parser.definition import AbstractString
-from rosidl_parser.definition import AbstractWString
 from rosidl_parser.definition import Array
-from rosidl_parser.definition import BASIC_TYPES
 from rosidl_parser.definition import BasicType
 from rosidl_parser.definition import BoundedSequence
 from rosidl_parser.definition import BoundedString
@@ -219,6 +213,7 @@ def primitive_value_to_rs(type_, value):
     if type_.type in [
             'byte',
             'char',
+            'wchar',
             'int8',
             'uint8',
             'int16',

--- a/rosidl_generator_rs/rosidl_generator_rs/__init__.py
+++ b/rosidl_generator_rs/rosidl_generator_rs/__init__.py
@@ -14,7 +14,6 @@
 
 import os
 import pathlib
-import subprocess
 
 from pathlib import Path
 
@@ -24,12 +23,7 @@ else:
     import rosidl_pycommon
 
 from rosidl_parser.definition import AbstractGenericString
-from rosidl_parser.definition import AbstractNestedType
-from rosidl_parser.definition import AbstractSequence
-from rosidl_parser.definition import AbstractString
-from rosidl_parser.definition import AbstractWString
 from rosidl_parser.definition import Array
-from rosidl_parser.definition import BASIC_TYPES
 from rosidl_parser.definition import BasicType
 from rosidl_parser.definition import BoundedSequence
 from rosidl_parser.definition import BoundedString
@@ -108,9 +102,9 @@ def generate_rs(generator_arguments_file, typesupport_impls):
         'constant_value_to_rs': constant_value_to_rs,
         'value_to_rs': value_to_rs,
         'convert_camel_case_to_lower_case_underscore':
-        rosidl_pycommon.convert_camel_case_to_lower_case_underscore,
+            rosidl_pycommon.convert_camel_case_to_lower_case_underscore,
         'convert_lower_case_underscore_to_camel_case':
-        convert_lower_case_underscore_to_camel_case,
+            convert_lower_case_underscore_to_camel_case,
         'msg_specs': [],
         'srv_specs': [],
         'package_name': args['package_name'],
@@ -174,6 +168,7 @@ def generate_rs(generator_arguments_file, typesupport_impls):
 
     return 0
 
+
 def get_rs_name(name):
     keywords = [
         # strict keywords
@@ -188,6 +183,7 @@ def get_rs_name(name):
     ]
     # If the field name is a reserved keyword in Rust append an underscore
     return name if not name in keywords else name + '_'
+
 
 def escape_string(s):
     s = s.replace('\\', '\\\\')
@@ -217,17 +213,18 @@ def primitive_value_to_rs(type_, value):
         return 'true' if value else 'false'
 
     if type_.type in [
-            'byte',
-            'char',
-            'int8',
-            'uint8',
-            'int16',
-            'uint16',
-            'int32',
-            'uint32',
-            'int64',
-            'uint64',
-            'float64',
+        'byte',
+        'char',
+        'wchar',
+        'int8',
+        'uint8',
+        'int16',
+        'uint16',
+        'int32',
+        'uint32',
+        'int64',
+        'uint64',
+        'float64',
     ]:
         return str(value)
 
@@ -254,6 +251,7 @@ def constant_value_to_rs(type_, value):
         return '"%s"' % escape_string(value)
 
     assert False, "unknown constant type '%s'" % type_
+
 
 # Type hierarchy:
 # 
@@ -285,6 +283,7 @@ def pre_field_serde(type_):
 
 def make_get_idiomatic_rs_type(package_name):
     get_rmw_rs_type = make_get_rmw_rs_type(package_name)
+
     def get_idiomatic_rs_type(type_):
         if isinstance(type_, UnboundedString) or isinstance(type_, UnboundedWString):
             return 'std::string::String'
@@ -296,7 +295,9 @@ def make_get_idiomatic_rs_type(package_name):
             return '[{}; {}]'.format(get_idiomatic_rs_type(type_.value_type), type_.size)
         else:
             return get_rmw_rs_type(type_)
+
     return get_idiomatic_rs_type
+
 
 def make_get_rmw_rs_type(package_name):
     def get_rmw_rs_type(type_):
@@ -311,6 +312,8 @@ def make_get_rmw_rs_type(package_name):
                 return 'u8'
             elif type_.typename == 'char':
                 return 'u8'
+            elif type_.typename == 'wchar':
+                return 'u16'
             elif type_.typename == 'float':
                 return 'f32'
             elif type_.typename == 'double':
@@ -344,7 +347,9 @@ def make_get_rmw_rs_type(package_name):
         elif isinstance(type_, UnboundedSequence):
             return 'rosidl_runtime_rs::Sequence<{}>'.format(get_rmw_rs_type(type_.value_type))
         elif isinstance(type_, BoundedSequence):
-            return 'rosidl_runtime_rs::BoundedSequence<{}, {}>'.format(get_rmw_rs_type(type_.value_type), type_.maximum_size)
+            return 'rosidl_runtime_rs::BoundedSequence<{}, {}>'.format(get_rmw_rs_type(type_.value_type),
+                                                                       type_.maximum_size)
 
         assert False, "unknown type '%s'" % type_.typename
+
     return get_rmw_rs_type

--- a/rosidl_generator_rs/rosidl_generator_rs/__init__.py
+++ b/rosidl_generator_rs/rosidl_generator_rs/__init__.py
@@ -14,6 +14,7 @@
 
 import os
 import pathlib
+import subprocess
 
 from pathlib import Path
 
@@ -218,7 +219,6 @@ def primitive_value_to_rs(type_, value):
     if type_.type in [
             'byte',
             'char',
-            'wchar',
             'int8',
             'uint8',
             'int16',

--- a/rosidl_generator_rs/rosidl_generator_rs/__init__.py
+++ b/rosidl_generator_rs/rosidl_generator_rs/__init__.py
@@ -23,7 +23,12 @@ else:
     import rosidl_pycommon
 
 from rosidl_parser.definition import AbstractGenericString
+from rosidl_parser.definition import AbstractNestedType
+from rosidl_parser.definition import AbstractSequence
+from rosidl_parser.definition import AbstractString
+from rosidl_parser.definition import AbstractWString
 from rosidl_parser.definition import Array
+from rosidl_parser.definition import BASIC_TYPES
 from rosidl_parser.definition import BasicType
 from rosidl_parser.definition import BoundedSequence
 from rosidl_parser.definition import BoundedString


### PR DESCRIPTION
Added `wchar` support to `rosidl_runtime_rs`. 

From the [ROS 2 IDL - Interface Definition and Language Mapping](https://design.ros2.org/articles/idl_interface_definition.html) spec

> <h4 id="7414424-wide-char-type">7.4.1.4.4.2.4 Wide Char Type</h4>
> 
> 
> 
> IDL type | Value range
> -- | --
> wchar | A 16-bit wide character
> 

This maps nicely to rust's [u16](https://doc.rust-lang.org/std/primitive.u16.html) type.

You can't actually use `wchar` in a .msg file (see [humble docs for supported .msg file types](https://docs.ros.org/en/humble/Concepts/Basic/About-Interfaces.html#field-types)), but its perfectly valid and supported by [rosidl_parser](https://github.com/ros2/rosidl/blob/iron/rosidl_parser/rosidl_parser/definition.py#L43), which means its valid in a .idl file and we should support it.

Also added an example .idl file that we can generate rust code for.

Even though we can generate code for the .idl file, it does not mean that we can use all of the idl features present in the file. The commented out lines are things we don't have support for that actually break the build.

In another PR I am planning to figure out a better way to write tests besides an example package, probably something similar to `rclrs_tests`.