### PR TITLE
[docs] Add <Arc> to node field in RepublisherNode

### DIFF
--- a/docs/writing-your-first-rclrs-node.md
+++ b/docs/writing-your-first-rclrs-node.md
@@ -47,7 +47,7 @@ use std::sync::Arc;
 use std_msgs::msg::String as StringMsg;
 
 struct RepublisherNode {
-    node: rclrs::Node,
+    node: Arc<rclrs::Node>,
     _subscription: Arc<rclrs::Subscription<StringMsg>>,
     data: Option<StringMsg>,
 }
@@ -114,7 +114,7 @@ use std::sync::{Arc, Mutex};  // (1)
 use std_msgs::msg::String as StringMsg;
 
 struct RepublisherNode {
-    node: rclrs::Node,
+    node: Arc<rclrs::Node>,
     _subscription: Arc<rclrs::Subscription<StringMsg>>,
     data: Arc<Mutex<Option<StringMsg>>>,  // (2)
 }


### PR DESCRIPTION
Add the ```Arc<rclcrs::Node>``` type in the ```RepublisherNode``` in the example of the documentation. Otherwise you get this error: 

![image](https://github.com/ros2-rust/ros2_rust/assets/43600658/acc723da-54d3-421e-a54e-5bbea7e04b83)


