### PR TITLE
Remove leading underscore from private fields

### DIFF
--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -71,8 +71,8 @@ pub struct Node {
     pub(crate) guard_conditions_mtx: Mutex<Vec<Weak<GuardCondition>>>,
     pub(crate) services_mtx: Mutex<Vec<Weak<dyn ServiceBase>>>,
     pub(crate) subscriptions_mtx: Mutex<Vec<Weak<dyn SubscriptionBase>>>,
-    _time_source: TimeSource,
-    _parameter: ParameterInterface,
+    time_source: TimeSource,
+    parameter: ParameterInterface,
 }
 
 impl Eq for Node {}
@@ -102,7 +102,7 @@ impl Node {
 
     /// Returns the clock associated with this node.
     pub fn get_clock(&self) -> Clock {
-        self._time_source.get_clock()
+        self.time_source.get_clock()
     }
 
     /// Returns the name of the node.
@@ -398,16 +398,16 @@ impl Node {
         &'a self,
         name: impl Into<Arc<str>>,
     ) -> ParameterBuilder<'a, T> {
-        self._parameter.declare(name.into())
+        self.parameter.declare(name.into())
     }
 
     /// Enables usage of undeclared parameters for this node.
     ///
     /// Returns a [`Parameters`] struct that can be used to get and set all parameters.
     pub fn use_undeclared_parameters(&self) -> Parameters {
-        self._parameter.allow_undeclared();
+        self.parameter.allow_undeclared();
         Parameters {
-            interface: &self._parameter,
+            interface: &self.parameter,
         }
     }
 

--- a/rclrs/src/node/builder.rs
+++ b/rclrs/src/node/builder.rs
@@ -281,7 +281,7 @@ impl NodeBuilder {
         };
 
         let rcl_node_mtx = Arc::new(Mutex::new(rcl_node));
-        let _parameter = ParameterInterface::new(
+        let parameter = ParameterInterface::new(
             &rcl_node_mtx,
             &rcl_node_options.arguments,
             &rcl_context.global_arguments,
@@ -293,12 +293,12 @@ impl NodeBuilder {
             guard_conditions_mtx: Mutex::new(vec![]),
             services_mtx: Mutex::new(vec![]),
             subscriptions_mtx: Mutex::new(vec![]),
-            _time_source: TimeSource::builder(self.clock_type)
+            time_source: TimeSource::builder(self.clock_type)
                 .clock_qos(self.clock_qos)
                 .build(),
-            _parameter,
+            parameter,
         });
-        node._time_source.attach_node(&node);
+        node.time_source.attach_node(&node);
         Ok(node)
     }
 

--- a/rclrs/src/parameter.rs
+++ b/rclrs/src/parameter.rs
@@ -36,16 +36,16 @@ use std::sync::{
 
 #[derive(Clone, Debug)]
 struct ParameterOptionsStorage {
-    _description: Arc<str>,
-    _constraints: Arc<str>,
+    description: Arc<str>,
+    constraints: Arc<str>,
     ranges: ParameterRanges,
 }
 
 impl<T: ParameterVariant> From<ParameterOptions<T>> for ParameterOptionsStorage {
     fn from(opts: ParameterOptions<T>) -> Self {
         Self {
-            _description: opts.description,
-            _constraints: opts.constraints,
+            description: opts.description,
+            constraints: opts.constraints,
             ranges: opts.ranges.into(),
         }
     }
@@ -430,7 +430,7 @@ impl<T: ParameterVariant> TryFrom<ParameterBuilder<'_, T>> for OptionalParameter
             name: builder.name,
             value,
             ranges,
-            map: Arc::downgrade(&builder.interface._parameter_map),
+            map: Arc::downgrade(&builder.interface.parameter_map),
             _marker: Default::default(),
         })
     }
@@ -494,7 +494,7 @@ impl<'a, T: ParameterVariant + 'a> TryFrom<ParameterBuilder<'a, T>> for Mandator
             name: builder.name,
             value,
             ranges,
-            map: Arc::downgrade(&builder.interface._parameter_map),
+            map: Arc::downgrade(&builder.interface.parameter_map),
             _marker: Default::default(),
         })
     }
@@ -586,7 +586,7 @@ impl<'a, T: ParameterVariant + 'a> TryFrom<ParameterBuilder<'a, T>> for ReadOnly
         Ok(ReadOnlyParameter {
             name: builder.name,
             value,
-            map: Arc::downgrade(&builder.interface._parameter_map),
+            map: Arc::downgrade(&builder.interface.parameter_map),
             _marker: Default::default(),
         })
     }
@@ -703,7 +703,7 @@ impl<'a> Parameters<'a> {
     ///
     /// Returns `Some(T)` if a parameter of the requested type exists, `None` otherwise.
     pub fn get<T: ParameterVariant>(&self, name: &str) -> Option<T> {
-        let storage = &self.interface._parameter_map.lock().unwrap().storage;
+        let storage = &self.interface.parameter_map.lock().unwrap().storage;
         let storage = storage.get(name)?;
         match storage {
             ParameterStorage::Declared(storage) => match &storage.value {
@@ -728,7 +728,7 @@ impl<'a> Parameters<'a> {
         name: impl Into<Arc<str>>,
         value: T,
     ) -> Result<(), ParameterValueError> {
-        let mut map = self.interface._parameter_map.lock().unwrap();
+        let mut map = self.interface.parameter_map.lock().unwrap();
         let name: Arc<str> = name.into();
         match map.storage.entry(name) {
             Entry::Occupied(mut entry) => {
@@ -767,8 +767,8 @@ impl<'a> Parameters<'a> {
 }
 
 pub(crate) struct ParameterInterface {
-    _parameter_map: Arc<Mutex<ParameterMap>>,
-    _override_map: ParameterOverrideMap,
+    parameter_map: Arc<Mutex<ParameterMap>>,
+    override_map: ParameterOverrideMap,
     allow_undeclared: AtomicBool,
     // NOTE(luca-della-vedova) add a ParameterService field to this struct to add support for
     // services.
@@ -781,14 +781,14 @@ impl ParameterInterface {
         global_arguments: &rcl_arguments_t,
     ) -> Result<Self, RclrsError> {
         let rcl_node = rcl_node_mtx.lock().unwrap();
-        let _override_map = unsafe {
+        let override_map = unsafe {
             let fqn = call_string_getter_with_handle(&rcl_node, rcl_node_get_fully_qualified_name);
             resolve_parameter_overrides(&fqn, node_arguments, global_arguments)?
         };
 
         Ok(ParameterInterface {
-            _parameter_map: Default::default(),
-            _override_map,
+            parameter_map: Default::default(),
+            override_map,
             allow_undeclared: Default::default(),
         })
     }
@@ -820,7 +820,7 @@ impl ParameterInterface {
         ranges.validate()?;
         let override_value: Option<T> = if ignore_override {
             None
-        } else if let Some(override_value) = self._override_map.get(name).cloned() {
+        } else if let Some(override_value) = self.override_map.get(name).cloned() {
             Some(
                 override_value
                     .try_into()
@@ -831,7 +831,7 @@ impl ParameterInterface {
         };
 
         let prior_value =
-            if let Some(prior_value) = self._parameter_map.lock().unwrap().storage.get(name) {
+            if let Some(prior_value) = self.parameter_map.lock().unwrap().storage.get(name) {
                 match prior_value {
                     ParameterStorage::Declared(_) => return Err(DeclarationError::AlreadyDeclared),
                     ParameterStorage::Undeclared(param) => match param.clone().try_into() {
@@ -869,7 +869,7 @@ impl ParameterInterface {
         value: DeclaredValue,
         options: ParameterOptionsStorage,
     ) {
-        self._parameter_map.lock().unwrap().storage.insert(
+        self.parameter_map.lock().unwrap().storage.insert(
             name,
             ParameterStorage::Declared(DeclaredStorage {
                 options,

--- a/rclrs/src/parameter.rs
+++ b/rclrs/src/parameter.rs
@@ -36,16 +36,16 @@ use std::sync::{
 
 #[derive(Clone, Debug)]
 struct ParameterOptionsStorage {
-    description: Arc<str>,
-    constraints: Arc<str>,
+    _description: Arc<str>,
+    _constraints: Arc<str>,
     ranges: ParameterRanges,
 }
 
 impl<T: ParameterVariant> From<ParameterOptions<T>> for ParameterOptionsStorage {
     fn from(opts: ParameterOptions<T>) -> Self {
         Self {
-            description: opts.description,
-            constraints: opts.constraints,
+            _description: opts.description,
+            _constraints: opts.constraints,
             ranges: opts.ranges.into(),
         }
     }


### PR DESCRIPTION
In my previous contributions I used the convention of leading underscores for private fields of struct, however this convention is:

A) Not used anywhere else in the codebase, so it is a disconnect.
B) Actively harmful in Rust since it suppresses unused variable warnings.

This PR is just a bit of hygiene to remove that convention and conform to the normal snake_case names that are used throughout the codebase.

Note that one in particular has been left for now in storage for parameter constraints / description. The value is currently unused but will stop being so when parameter services are implemented https://github.com/ros2-rust/ros2_rust/pull/342