### PR TITLE
Add Arc::clone to the Readme tutorial to fix compile error

### DIFF
--- a/docs/writing-your-first-rclrs-node.md
+++ b/docs/writing-your-first-rclrs-node.md
@@ -212,7 +212,7 @@ fn main() -> Result<(), rclrs::RclrsError> {
             republisher_other_thread.republish()?;
         }
     });
-    rclrs::spin(republisher.node)
+    rclrs::spin(Arc::clone(&republisher.node))
 }
 ```
 


### PR DESCRIPTION
This PR fixes a compile error in the tutorial that happened because you cannot move the "node" member out of the republisher