### PR TITLE
Adding a simple helper function for converting `rclrs::Time` to a ros message

### DIFF
--- a/rclrs/Cargo.toml
+++ b/rclrs/Cargo.toml
@@ -48,5 +48,3 @@ generate_docs = ["rosidl_runtime_rs/generate_docs"]
 
 [package.metadata.docs.rs]
 features = ["generate_docs"]
-
-

--- a/rclrs/Cargo.toml
+++ b/rclrs/Cargo.toml
@@ -26,6 +26,9 @@ libloading = { version = "0.8", optional = true }
 # Needed for the Message trait, among others
 rosidl_runtime_rs = "0.4"
 
+[dependencies.builtin_interfaces]
+version = "*"
+
 [dev-dependencies]
 # Needed for e.g. writing yaml files in tests
 tempfile = "3.3.0"
@@ -45,3 +48,5 @@ generate_docs = ["rosidl_runtime_rs/generate_docs"]
 
 [package.metadata.docs.rs]
 features = ["generate_docs"]
+
+

--- a/rclrs/src/time.rs
+++ b/rclrs/src/time.rs
@@ -99,10 +99,13 @@ mod tests {
 
     #[test]
     fn test_conversion() {
+        let clock = Clock::system();
+        let t1 = clock.now();
         let time = Time {
             nsec: 1_000_000_100,
+            clock: t1.clock.clone(),
         };
-        let msg = time.to_msg().unwrap();
+        let msg = time.to_ros_msg().unwrap();
         assert_eq!(msg.nanosec, 100);
         assert_eq!(msg.sec, 1);
     }

--- a/rclrs/src/time.rs
+++ b/rclrs/src/time.rs
@@ -1,8 +1,8 @@
 use crate::rcl_bindings::*;
+use std::num::TryFromIntError;
 use std::ops::{Add, Sub};
 use std::sync::{Mutex, Weak};
 use std::time::Duration;
-use std::num::TryFromIntError;
 
 /// Struct that represents time.
 #[derive(Clone, Debug)]
@@ -12,7 +12,6 @@ pub struct Time {
     /// Weak reference to the clock that generated this time
     pub clock: Weak<Mutex<rcl_clock_t>>,
 }
-
 
 impl Time {
     /// Compares self to rhs, if they can be compared (originated from the same clock) calls f with
@@ -29,11 +28,11 @@ impl Time {
     /// Convenience function for converting time to ROS message
     pub fn to_ros_msg(&self) -> Result<builtin_interfaces::msg::Time, TryFromIntError> {
         let nanosec = self.nsec % 1_000_000_000;
-        let sec = self.nsec /  1_000_000_000;
+        let sec = self.nsec / 1_000_000_000;
 
         Ok(builtin_interfaces::msg::Time {
             nanosec: nanosec.try_into()?,
-            sec: sec.try_into()?
+            sec: sec.try_into()?,
         })
     }
 }
@@ -100,7 +99,9 @@ mod tests {
 
     #[test]
     fn test_conversion() {
-        let time = Time {nsec: 1_000_000_100};
+        let time = Time {
+            nsec: 1_000_000_100,
+        };
         let msg = time.to_msg().unwrap();
         assert_eq!(msg.nanosec, 100);
         assert_eq!(msg.sec, 1);


### PR DESCRIPTION
This commit adds a simple conversion function that converts Time to `builtin_interfaces::msg::Time` like the one in `rclpy`.