### PR TITLE
Add <Arc> to publisher field to fix the compile error

### DIFF
--- a/docs/writing-your-first-rclrs-node.md
+++ b/docs/writing-your-first-rclrs-node.md
@@ -154,7 +154,7 @@ The node still doesn't republish the received messages. First, let's add a publi
 
 ```rust
 // Add this new field to the RepublisherNode struct, after the subscription:
-publisher: rclrs::Publisher<StringMsg>,
+publisher: Arc<rclrs::Publisher<StringMsg>>,
 
 // Change the end of RepublisherNode::new() to this:
 let publisher = node.create_publisher("out_topic", rclrs::QOS_PROFILE_DEFAULT)?;


### PR DESCRIPTION
Add `Arc<>` type to the `publisher` field in `RepublisherNode` to fix the compile error:

![image](https://github.com/ros2-rust/ros2_rust/assets/13172933/ced36d60-8f75-4085-8b57-6d7b52395fcd)
