### PR TITLE
Add default implementation and builder pattern for QoS

### DIFF
--- a/rclrs/src/qos.rs
+++ b/rclrs/src/qos.rs
@@ -179,6 +179,12 @@ pub struct QoSProfile {
     pub avoid_ros_namespace_conventions: bool,
 }
 
+impl Default for QoSProfile {
+    fn default() -> Self {
+        QOS_PROFILE_DEFAULT
+    }
+}
+
 impl From<QoSProfile> for rmw_qos_profile_t {
     fn from(qos: QoSProfile) -> Self {
         Self {
@@ -196,6 +202,44 @@ impl From<QoSProfile> for rmw_qos_profile_t {
             liveliness_lease_duration: qos.liveliness_lease_duration.into(),
             avoid_ros_namespace_conventions: qos.avoid_ros_namespace_conventions,
         }
+    }
+}
+
+impl QoSProfile {
+    /// Sets the QoS profile history to [QoSHistoryPolicy::KeepLast] with the specified depth.
+    pub fn keep_last(mut self, depth: u32) -> Self {
+        self.history = QoSHistoryPolicy::KeepLast { depth };
+        self
+    }
+
+    /// Sets the QoS profile history to [QoSHistoryPolicy::KeepAll].
+    pub fn keep_all(mut self) -> Self {
+        self.history = QoSHistoryPolicy::KeepAll;
+        self
+    }
+
+    /// Sets the QoS profile reliability to [QoSReliabilityPolicy::Reliable].
+    pub fn reliable(mut self) -> Self {
+        self.reliability = QoSReliabilityPolicy::Reliable;
+        self
+    }
+
+    /// Sets the QoS profile reliability to [QoSReliabilityPolicy::BestEffort].
+    pub fn best_effort(mut self) -> Self {
+        self.reliability = QoSReliabilityPolicy::BestEffort;
+        self
+    }
+
+    /// Sets the QoS profile durability to [QoSDurabilityPolicy::Volatile].
+    pub fn volatile(mut self) -> Self {
+        self.durability = QoSDurabilityPolicy::Volatile;
+        self
+    }
+
+    /// Sets the QoS profile durability to [QoSDurabilityPolicy::TransientLocal].
+    pub fn transient_local(mut self) -> Self {
+        self.durability = QoSDurabilityPolicy::TransientLocal;
+        self
     }
 }
 

--- a/rclrs/src/qos.rs
+++ b/rclrs/src/qos.rs
@@ -179,6 +179,7 @@ pub struct QoSProfile {
     pub avoid_ros_namespace_conventions: bool,
 }
 
+/// Sets the `QoSProfile` to the RCL default.
 impl Default for QoSProfile {
     fn default() -> Self {
         QOS_PROFILE_DEFAULT

--- a/rclrs/src/qos.rs
+++ b/rclrs/src/qos.rs
@@ -241,6 +241,24 @@ impl QoSProfile {
         self.durability = QoSDurabilityPolicy::TransientLocal;
         self
     }
+
+    /// Sets the QoS profile deadline to the specified `Duration`.
+    pub fn deadline(mut self, deadline: Duration) -> Self {
+        self.deadline = QoSDuration::Custom(deadline);
+        self
+    }
+
+    /// Sets the QoS profile liveliness lease duration to the specified `Duration`.
+    pub fn liveliness_lease_duration(mut self, lease_duration: Duration) -> Self {
+        self.liveliness_lease_duration = QoSDuration::Custom(lease_duration);
+        self
+    }
+
+    /// Sets the QoS profile lifespan to the specified `Duration`.
+    pub fn lifespan(mut self, lifespan: Duration) -> Self {
+        self.lifespan = QoSDuration::Custom(lifespan);
+        self
+    }
 }
 
 impl From<QoSHistoryPolicy> for rmw_qos_history_policy_t {


### PR DESCRIPTION
This PR adds a default implementation for `QoSProfile` as well as a builder pattern based on the `rclcpp` API.
I split it into a first commit that should be fully uncontroversial and a second commit that contains the builder API for `Duration` based items, which should also be OK I believe.

I intentionally left out all the methods in the other APIs that just set a profile to the requested structure, since while in C++ people might have to do something like:

```
const auto reliability = QoSReliabilityPolicy::Reliable;
auto profile = QoSProfile::SystemDefault().reliability(reliability);
```

In Rust the API is (imho) not so necessary since they can just use struct initialization, such as:

```
let reliability = QoSReliabilityPolicy::Reliable;
let profile = QoSProfile {
   reliability,
   ..QOS_SYSTEM_DEFAULT
};
```