### PR TITLE
Declare rust_packages only when installing Rust IDL bindings

### DIFF
--- a/rosidl_generator_rs/cmake/rosidl_generator_rs_generate_interfaces.cmake
+++ b/rosidl_generator_rs/cmake/rosidl_generator_rs_generate_interfaces.cmake
@@ -115,9 +115,6 @@ file(MAKE_DIRECTORY "${_output_path}")
 
 set(_target_suffix "__rs")
 
-ament_index_register_resource("rust_packages")
-
-
 # needed to avoid multiple calls to the Rust generator trick copied from
 # https://github.com/ros2/rosidl/blob/master/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
 set(_subdir "${CMAKE_CURRENT_BINARY_DIR}/${rosidl_generate_interfaces_TARGET}${_target_suffix}")
@@ -137,6 +134,7 @@ set_property(
 
 set(_rsext_suffix "__rsext")
 if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
+  ament_index_register_resource("rust_packages")
   install(
     DIRECTORY "${_output_path}/rust"
     DESTINATION "share/${PROJECT_NAME}"


### PR DESCRIPTION
As discussed [here](https://github.com/ros2-rust/ros2_rust/issues/371#issuecomment-2008696967) there was a strange error that made it impossible to use ros2_rust in an underlay workspace. Packages that have no association to Rust were declaring themselves in the `rust_packages` ament index. This was causing downstream colcon workspaces to redirect their `.cargo/config.toml` file towards non-existent directories. When cargo is directed towards non-existent directories, it considers the situation a build error and exits immediately.

After some challenging investigation, I narrowed the problem down to this: Packages that contain **any** message definitions were invoking the `rosidl_generator_rs`'s extension to the ROS IDL generation pipeline. That extension included the line `ament_index_register_resource("rust_packages")`. For a normal message package that would be fine, but some packages have message definitions that are purely internal to the package for testing purposes and not installed (using the `SKIP_INSTALL` option of `rosidl_generate_interfaces`). Since the messages are not installed in these cases, we also do not install the Rust bindings, which makes perfect sense. However, if we declare the package under the `rust_packages` index, then colcon-ros-cargo will expect a Rust package even though one does not exist.

This PR solves the problem in an extremely simple way: The `rosidl_generator_rs` extension will only declare a package into the `rust_packages` index if the message package is being installed. I've done an A/B test on this change and confirmed that building an rclrs node in a downstream workspace is impossible without this, but works perfectly fine with the changes in this PR.