### PR TITLE
Correct rcl entity lifecycles and fix spurious test failures

### DIFF
--- a/rclrs/Cargo.toml
+++ b/rclrs/Cargo.toml
@@ -14,15 +14,21 @@ path = "src/lib.rs"
 # Please keep the list of dependencies alphabetically sorted,
 # and also state why each dependency is needed.
 [dependencies]
-# Needed for dynamically finding type support libraries 
+# Needed for dynamically finding type support libraries
 ament_rs = { version = "0.2", optional = true }
+
 # Needed for uploading documentation to docs.rs
 cfg-if = "1.0.0"
 
 # Needed for clients
 futures = "0.3"
+
+# Needed to create a global mutex for managing the lifecycles of middleware entities
+lazy_static = "1.4"
+
 # Needed for dynamic messages
 libloading = { version = "0.8", optional = true }
+
 # Needed for the Message trait, among others
 rosidl_runtime_rs = "0.4"
 

--- a/rclrs/Cargo.toml
+++ b/rclrs/Cargo.toml
@@ -23,9 +23,6 @@ cfg-if = "1.0.0"
 # Needed for clients
 futures = "0.3"
 
-# Needed to create a global mutex for managing the lifecycles of middleware entities
-lazy_static = "1.4"
-
 # Needed for dynamic messages
 libloading = { version = "0.8", optional = true }
 

--- a/rclrs/src/client.rs
+++ b/rclrs/src/client.rs
@@ -15,9 +15,9 @@ use crate::{rcl_bindings::*, NodeHandle, RclrsError, ENTITY_LIFECYCLE_MUTEX};
 // they are running in. Therefore, this type can be safely sent to another thread.
 unsafe impl Send for rcl_client_t {}
 
-/// Manage the lifecycle of an [`rcl_client_t`], including managing its dependencies
-/// on [`rcl_node_t`] and [`rcl_context_t`] by ensuring that these dependencies are
-/// [dropped after][1] the [`rcl_client_t`].
+/// Manage the lifecycle of an `rcl_client_t`, including managing its dependencies
+/// on `rcl_node_t` and `rcl_context_t` by ensuring that these dependencies are
+/// [dropped after][1] the `rcl_client_t`.
 ///
 /// [1] https://doc.rust-lang.org/reference/destructors.html
 pub struct ClientHandle {

--- a/rclrs/src/client.rs
+++ b/rclrs/src/client.rs
@@ -9,7 +9,7 @@ use rosidl_runtime_rs::Message;
 
 use crate::error::{RclReturnCode, ToResult};
 use crate::MessageCow;
-use crate::{rcl_bindings::*, RclrsError, NodeHandle, ENTITY_LIFECYCLE_MUTEX};
+use crate::{rcl_bindings::*, NodeHandle, RclrsError, ENTITY_LIFECYCLE_MUTEX};
 
 // SAFETY: The functions accessing this type, including drop(), shouldn't care about the thread
 // they are running in. Therefore, this type can be safely sent to another thread.

--- a/rclrs/src/client.rs
+++ b/rclrs/src/client.rs
@@ -19,7 +19,7 @@ unsafe impl Send for rcl_client_t {}
 /// on `rcl_node_t` and `rcl_context_t` by ensuring that these dependencies are
 /// [dropped after][1] the `rcl_client_t`.
 ///
-/// [1] https://doc.rust-lang.org/reference/destructors.html
+/// [1]: <https://doc.rust-lang.org/reference/destructors.html>
 pub struct ClientHandle {
     rcl_client: Mutex<rcl_client_t>,
     node_handle: Arc<NodeHandle>,

--- a/rclrs/src/client.rs
+++ b/rclrs/src/client.rs
@@ -99,11 +99,11 @@ where
             // The topic name and the options are copied by this function, so they can be dropped
             // afterwards.
             {
-                let mut rcl_node = node_handle.rcl_node.lock().unwrap();
+                let rcl_node = node_handle.rcl_node.lock().unwrap();
                 let _lifecycle_lock = ENTITY_LIFECYCLE_MUTEX.lock().unwrap();
                 rcl_client_init(
                     &mut rcl_client,
-                    &mut *rcl_node,
+                    &*rcl_node,
                     type_support,
                     topic_c_string.as_ptr(),
                     &client_options,

--- a/rclrs/src/context.rs
+++ b/rclrs/src/context.rs
@@ -7,14 +7,12 @@ use std::vec::Vec;
 use crate::rcl_bindings::*;
 use crate::{RclrsError, ToResult};
 
-lazy_static::lazy_static! {
-    /// This is locked whenever initializing or dropping any middleware entity
-    /// because we have found issues in RCL and some RMW implementations that
-    /// make it unsafe to simultaneously initialize and/or drop various types of
-    /// entities. It seems these C and C++ based libraries will regularly use
-    /// unprotected global variables in their object initialization and cleanup.
-    pub(crate) static ref ENTITY_LIFECYCLE_MUTEX: Mutex<()> = Mutex::new(());
-}
+/// This is locked whenever initializing or dropping any middleware entity
+/// because we have found issues in RCL and some RMW implementations that
+/// make it unsafe to simultaneously initialize and/or drop various types of
+/// entities. It seems these C and C++ based libraries will regularly use
+/// unprotected global variables in their object initialization and cleanup.
+pub(crate) static ENTITY_LIFECYCLE_MUTEX: Mutex<()> = Mutex::new(());
 
 impl Drop for rcl_context_t {
     fn drop(&mut self) {

--- a/rclrs/src/context.rs
+++ b/rclrs/src/context.rs
@@ -90,7 +90,7 @@ impl Context {
     /// assert_eq!(context.domain_id(), 5);
     /// ````
     pub fn new_with_options(
-        args: impl IntoIterator<Item=String>,
+        args: impl IntoIterator<Item = String>,
         options: InitOptions,
     ) -> Result<Self, RclrsError> {
         // SAFETY: Getting a zero-initialized value is always safe
@@ -135,7 +135,7 @@ impl Context {
         Ok(Self {
             handle: Arc::new(ContextHandle {
                 rcl_context: Mutex::new(rcl_context),
-            })
+            }),
         })
     }
 
@@ -150,7 +150,7 @@ impl Context {
         let ret = unsafe {
             rcl_context_get_domain_id(
                 &mut *self.handle.rcl_context.lock().unwrap(),
-                &mut domain_id
+                &mut domain_id,
             )
         };
 

--- a/rclrs/src/context.rs
+++ b/rclrs/src/context.rs
@@ -9,9 +9,16 @@ use crate::{RclrsError, ToResult};
 
 /// This is locked whenever initializing or dropping any middleware entity
 /// because we have found issues in RCL and some RMW implementations that
-/// make it unsafe to simultaneously initialize and/or drop various types of
-/// entities. It seems these C and C++ based libraries will regularly use
+/// make it unsafe to simultaneously initialize and/or drop middleware
+/// entities such as [`rcl_context_t`] and [`rcl_node_t`] as well middleware
+/// primitives such as [`rcl_publisher_t`], [`rcl_subscription_t`], etc.
+/// It seems these C and C++ based libraries will regularly use
 /// unprotected global variables in their object initialization and cleanup.
+///
+/// Further discussion with the RCL team may help to improve the RCL
+/// documentation to specifically call out where these risks are present. For
+/// now we lock this mutex for any RCL function that carries reasonable suspicion
+/// of a risk.
 pub(crate) static ENTITY_LIFECYCLE_MUTEX: Mutex<()> = Mutex::new(());
 
 impl Drop for rcl_context_t {

--- a/rclrs/src/context.rs
+++ b/rclrs/src/context.rs
@@ -39,7 +39,17 @@ unsafe impl Send for rcl_context_t {}
 /// - the allocator used (left as the default by `rclrs`)
 ///
 pub struct Context {
-    pub(crate) rcl_context_mtx: Arc<Mutex<rcl_context_t>>,
+    pub(crate) handle: Arc<ContextHandle>,
+}
+
+/// This struct manages the lifetime and access to the rcl context. It will also
+/// account for the lifetimes of any dependencies, if we need to add
+/// dependencies in the future (currently there are none). It is not strictly
+/// necessary to decompose `Context` and `ContextHandle` like this, but we are
+/// doing it to be consistent with the lifecycle management of other rcl
+/// bindings in this library.
+pub(crate) struct ContextHandle {
+    handle: Mutex<rcl_context_t>,
 }
 
 impl Context {

--- a/rclrs/src/context.rs
+++ b/rclrs/src/context.rs
@@ -49,7 +49,7 @@ pub struct Context {
 /// doing it to be consistent with the lifecycle management of other rcl
 /// bindings in this library.
 pub(crate) struct ContextHandle {
-    handle: Mutex<rcl_context_t>,
+    pub(crate) rcl_context: Mutex<rcl_context_t>,
 }
 
 impl Context {
@@ -109,7 +109,9 @@ impl Context {
             ret?;
         }
         Ok(Self {
-            rcl_context_mtx: Arc::new(Mutex::new(rcl_context)),
+            handle: Arc::new(ContextHandle {
+                rcl_context: Mutex::new(rcl_context),
+            })
         })
     }
 
@@ -120,7 +122,7 @@ impl Context {
     pub fn ok(&self) -> bool {
         // This will currently always return true, but once we have a signal handler, the signal
         // handler could call `rcl_shutdown()`, hence making the context invalid.
-        let rcl_context = &mut *self.rcl_context_mtx.lock().unwrap();
+        let rcl_context = &mut *self.handle.rcl_context.lock().unwrap();
         // SAFETY: No preconditions for this function.
         unsafe { rcl_context_is_valid(rcl_context) }
     }

--- a/rclrs/src/context.rs
+++ b/rclrs/src/context.rs
@@ -145,7 +145,7 @@ impl Context {
     /// It can be set through the `ROS_DOMAIN_ID` environment variable.
     ///
     /// [1]: https://docs.ros.org/en/rolling/Concepts/About-Domain-ID.html
-    pub fn domain_id(&self) -> u8 {
+    pub fn domain_id(&self) -> usize {
         let mut domain_id: usize = 0;
         let ret = unsafe {
             rcl_context_get_domain_id(
@@ -155,7 +155,7 @@ impl Context {
         };
 
         debug_assert_eq!(ret, 0);
-        domain_id as u8
+        domain_id
     }
 
     /// Checks if the context is still valid.
@@ -179,7 +179,7 @@ pub struct InitOptions {
     /// [ROS_DOMAIN_ID][1] environment variable.
     ///
     /// [1]: https://docs.ros.org/en/rolling/Concepts/Intermediate/About-Domain-ID.html#the-ros-domain-id
-    domain_id: Option<u8>,
+    domain_id: Option<usize>,
 }
 
 impl InitOptions {
@@ -189,19 +189,19 @@ impl InitOptions {
     }
 
     /// Transform an InitOptions into a new one with a certain domain_id
-    pub fn with_domain_id(mut self, domain_id: Option<u8>) -> InitOptions {
+    pub fn with_domain_id(mut self, domain_id: Option<usize>) -> InitOptions {
         self.domain_id = domain_id;
         self
     }
 
     /// Set the domain_id of an InitOptions, or reset it to the default behavior
     /// (determined by environment variables) by providing None.
-    pub fn set_domain_id(&mut self, domain_id: Option<u8>) {
+    pub fn set_domain_id(&mut self, domain_id: Option<usize>) {
         self.domain_id = domain_id;
     }
 
     /// Get the domain_id that will be provided by these InitOptions.
-    pub fn domain_id(&self) -> Option<u8> {
+    pub fn domain_id(&self) -> Option<usize> {
         self.domain_id
     }
 

--- a/rclrs/src/context.rs
+++ b/rclrs/src/context.rs
@@ -217,7 +217,7 @@ impl InitOptions {
             // other than None. When the user asks for None, that is equivalent
             // to the default value in rcl_init_options.
             if let Some(domain_id) = self.domain_id {
-                rcl_init_options_set_domain_id(&mut rcl_init_options, domain_id as usize);
+                rcl_init_options_set_domain_id(&mut rcl_init_options, domain_id);
             }
             Ok(rcl_init_options)
         }

--- a/rclrs/src/context.rs
+++ b/rclrs/src/context.rs
@@ -10,8 +10,8 @@ use crate::{RclrsError, ToResult};
 /// This is locked whenever initializing or dropping any middleware entity
 /// because we have found issues in RCL and some RMW implementations that
 /// make it unsafe to simultaneously initialize and/or drop middleware
-/// entities such as [`rcl_context_t`] and [`rcl_node_t`] as well middleware
-/// primitives such as [`rcl_publisher_t`], [`rcl_subscription_t`], etc.
+/// entities such as `rcl_context_t` and `rcl_node_t` as well middleware
+/// primitives such as `rcl_publisher_t`, `rcl_subscription_t`, etc.
 /// It seems these C and C++ based libraries will regularly use
 /// unprotected global variables in their object initialization and cleanup.
 ///
@@ -59,10 +59,10 @@ pub struct Context {
     pub(crate) handle: Arc<ContextHandle>,
 }
 
-/// This struct manages the lifetime and access to the [`rcl_context_t`]. It will also
+/// This struct manages the lifetime and access to the `rcl_context_t`. It will also
 /// account for the lifetimes of any dependencies, if we need to add
 /// dependencies in the future (currently there are none). It is not strictly
-/// necessary to decompose [`Context`] and [`ContextHandle`] like this, but we are
+/// necessary to decompose `Context` and `ContextHandle` like this, but we are
 /// doing it to be consistent with the lifecycle management of other rcl
 /// bindings in this library.
 pub(crate) struct ContextHandle {

--- a/rclrs/src/context.rs
+++ b/rclrs/src/context.rs
@@ -55,10 +55,10 @@ pub(crate) struct ContextHandle {
 impl Context {
     /// Creates a new context.
     ///
-    /// Usually, this would be called with `std::env::args()`, analogously to `rclcpp::init()`.
+    /// Usually this would be called with `std::env::args()`, analogously to `rclcpp::init()`.
     /// See also the official "Passing ROS arguments to nodes via the command-line" tutorial.
     ///
-    /// Creating a context can fail in case the args contain invalid ROS arguments.
+    /// Creating a context will fail if the args contain invalid ROS arguments.
     ///
     /// # Example
     /// ```
@@ -68,6 +68,21 @@ impl Context {
     /// assert!(Context::new(invalid_remapping).is_err());
     /// ```
     pub fn new(args: impl IntoIterator<Item = String>) -> Result<Self, RclrsError> {
+        Self::new_with_options(args, InitOptions::new())
+    }
+
+    /// Same as [`Context::new`] except you can additionally provide initialization options.
+    ///
+    /// # Example
+    /// ```
+    /// use rclrs::{Context, InitOptions};
+    /// let context = Context::new_with_options([], InitOptions::new().with_domain_id(Some(5))).unwrap();
+    /// assert_eq!(context.domain_id(), 5);
+    /// ````
+    pub fn new_with_options(
+        args: impl IntoIterator<Item=String>,
+        options: InitOptions,
+    ) -> Result<Self, RclrsError> {
         // SAFETY: Getting a zero-initialized value is always safe
         let mut rcl_context = unsafe { rcl_get_zero_initialized_context() };
         let cstring_args: Vec<CString> = args
@@ -84,11 +99,7 @@ impl Context {
         unsafe {
             // SAFETY: No preconditions for this function.
             let allocator = rcutils_get_default_allocator();
-            // SAFETY: Getting a zero-initialized value is always safe.
-            let mut rcl_init_options = rcl_get_zero_initialized_init_options();
-            // SAFETY: Passing in a zero-initialized value is expected.
-            // In the case where this returns not ok, there's nothing to clean up.
-            rcl_init_options_init(&mut rcl_init_options, allocator).ok()?;
+            let mut rcl_init_options = options.into_rcl(allocator)?;
             // SAFETY: This function does not store the ephemeral init_options and c_args
             // pointers. Passing in a zero-initialized rcl_context is expected.
             let ret = rcl_init(
@@ -115,6 +126,25 @@ impl Context {
         })
     }
 
+    /// Returns the ROS domain ID that the context is using.
+    ///
+    /// The domain ID controls which nodes can send messages to each other, see the [ROS 2 concept article][1].
+    /// It can be set through the `ROS_DOMAIN_ID` environment variable.
+    ///
+    /// [1]: https://docs.ros.org/en/rolling/Concepts/About-Domain-ID.html
+    pub fn domain_id(&self) -> u8 {
+        let mut domain_id: usize = 0;
+        let ret = unsafe {
+            rcl_context_get_domain_id(
+                &mut *self.handle.rcl_context.lock().unwrap(),
+                &mut domain_id
+            )
+        };
+
+        debug_assert_eq!(ret, 0);
+        domain_id as u8
+    }
+
     /// Checks if the context is still valid.
     ///
     /// This will return `false` when a signal has caused the context to shut down (currently
@@ -125,6 +155,59 @@ impl Context {
         let rcl_context = &mut *self.handle.rcl_context.lock().unwrap();
         // SAFETY: No preconditions for this function.
         unsafe { rcl_context_is_valid(rcl_context) }
+    }
+}
+
+/// Additional options for initializing the Context.
+#[derive(Default, Clone)]
+pub struct InitOptions {
+    /// The domain ID that should be used by the Context. Set to None to ask for
+    /// the default behavior, which is to set the domain ID according to the
+    /// [ROS_DOMAIN_ID][1] environment variable.
+    ///
+    /// [1]: https://docs.ros.org/en/rolling/Concepts/Intermediate/About-Domain-ID.html#the-ros-domain-id
+    domain_id: Option<u8>,
+}
+
+impl InitOptions {
+    /// Create a new InitOptions with all default values.
+    pub fn new() -> InitOptions {
+        Self::default()
+    }
+
+    /// Transform an InitOptions into a new one with a certain domain_id
+    pub fn with_domain_id(mut self, domain_id: Option<u8>) -> InitOptions {
+        self.domain_id = domain_id;
+        self
+    }
+
+    /// Set the domain_id of an InitOptions, or reset it to the default behavior
+    /// (determined by environment variables) by providing None.
+    pub fn set_domain_id(&mut self, domain_id: Option<u8>) {
+        self.domain_id = domain_id;
+    }
+
+    /// Get the domain_id that will be provided by these InitOptions.
+    pub fn domain_id(&self) -> Option<u8> {
+        self.domain_id
+    }
+
+    fn into_rcl(self, allocator: rcutils_allocator_s) -> Result<rcl_init_options_t, RclrsError> {
+        unsafe {
+            // SAFETY: Getting a zero-initialized value is always safe.
+            let mut rcl_init_options = rcl_get_zero_initialized_init_options();
+            // SAFETY: Passing in a zero-initialized value is expected.
+            // In the case where this returns not ok, there's nothing to clean up.
+            rcl_init_options_init(&mut rcl_init_options, allocator).ok()?;
+
+            // We only need to set the domain_id if the user asked for something
+            // other than None. When the user asks for None, that is equivalent
+            // to the default value in rcl_init_options.
+            if let Some(domain_id) = self.domain_id {
+                rcl_init_options_set_domain_id(&mut rcl_init_options, domain_id as usize);
+            }
+            return Ok(rcl_init_options);
+        }
     }
 }
 

--- a/rclrs/src/context.rs
+++ b/rclrs/src/context.rs
@@ -219,7 +219,7 @@ impl InitOptions {
             if let Some(domain_id) = self.domain_id {
                 rcl_init_options_set_domain_id(&mut rcl_init_options, domain_id as usize);
             }
-            return Ok(rcl_init_options);
+            Ok(rcl_init_options)
         }
     }
 }

--- a/rclrs/src/executor.rs
+++ b/rclrs/src/executor.rs
@@ -42,7 +42,9 @@ impl SingleThreadedExecutor {
         for node in { self.nodes_mtx.lock().unwrap() }
             .iter()
             .filter_map(Weak::upgrade)
-            .filter(|node| unsafe { rcl_context_is_valid(&*node.handle.context_handle.rcl_context.lock().unwrap()) })
+            .filter(|node| unsafe {
+                rcl_context_is_valid(&*node.handle.context_handle.rcl_context.lock().unwrap())
+            })
         {
             let wait_set = WaitSet::new_for_node(&node)?;
             let ready_entities = wait_set.wait(timeout)?;

--- a/rclrs/src/executor.rs
+++ b/rclrs/src/executor.rs
@@ -42,7 +42,7 @@ impl SingleThreadedExecutor {
         for node in { self.nodes_mtx.lock().unwrap() }
             .iter()
             .filter_map(Weak::upgrade)
-            .filter(|node| unsafe { rcl_context_is_valid(&*node.rcl_context_mtx.lock().unwrap()) })
+            .filter(|node| unsafe { rcl_context_is_valid(&*node.handle.context_handle.rcl_context.lock().unwrap()) })
         {
             let wait_set = WaitSet::new_for_node(&node)?;
             let ready_entities = wait_set.wait(timeout)?;

--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -68,9 +68,9 @@ pub struct Node {
     pub(crate) handle: Arc<NodeHandle>,
 }
 
-/// This struct manages the lifetime of an [`rcl_node_t`], and accounts for its
-/// dependency on the lifetime of its [`rcl_context_t`] by ensuring that this
-/// dependency is [dropped after][1] the [`rcl_node_t`].
+/// This struct manages the lifetime of an `rcl_node_t`, and accounts for its
+/// dependency on the lifetime of its `rcl_context_t` by ensuring that this
+/// dependency is [dropped after][1] the `rcl_node_t`.
 ///
 /// [1] https://doc.rust-lang.org/reference/destructors.html
 pub(crate) struct NodeHandle {

--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -194,7 +194,7 @@ impl Node {
         getter: unsafe extern "C" fn(*const rcl_node_t) -> *const c_char,
     ) -> String {
         let rcl_node = self.handle.rcl_node.lock().unwrap();
-        unsafe { call_string_getter_with_handle(&rcl_node, getter) }
+        unsafe { call_string_getter_with_rcl_node(&rcl_node, getter) }
     }
 
     /// Creates a [`Client`][1].
@@ -446,7 +446,7 @@ impl Node {
 // function, which is why it's not merged into Node::call_string_getter().
 // This function is unsafe since it's possible to pass in an rcl_node_t with dangling
 // pointers etc.
-pub(crate) unsafe fn call_string_getter_with_handle(
+pub(crate) unsafe fn call_string_getter_with_rcl_node(
     rcl_node: &rcl_node_t,
     getter: unsafe extern "C" fn(*const rcl_node_t) -> *const c_char,
 ) -> String {

--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -72,7 +72,7 @@ pub struct Node {
 /// dependency on the lifetime of its `rcl_context_t` by ensuring that this
 /// dependency is [dropped after][1] the `rcl_node_t`.
 ///
-/// [1] https://doc.rust-lang.org/reference/destructors.html
+/// [1]: <https://doc.rust-lang.org/reference/destructors.html>
 pub(crate) struct NodeHandle {
     pub(crate) rcl_node: Mutex<rcl_node_t>,
     pub(crate) context_handle: Arc<ContextHandle>,

--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -211,8 +211,8 @@ impl Node {
     /// [1]: crate::GuardCondition
     /// [2]: crate::spin_once
     pub fn create_guard_condition(&self) -> Arc<GuardCondition> {
-        let guard_condition = Arc::new(GuardCondition::new_with_rcl_context(
-            &mut self.handle.context_handle.rcl_context.lock().unwrap(),
+        let guard_condition = Arc::new(GuardCondition::new_with_context_handle(
+            Arc::clone(&self.handle.context_handle),
             None,
         ));
         { self.guard_conditions_mtx.lock().unwrap() }
@@ -233,8 +233,8 @@ impl Node {
     where
         F: Fn() + Send + Sync + 'static,
     {
-        let guard_condition = Arc::new(GuardCondition::new_with_rcl_context(
-            &mut self.handle.context_handle.rcl_context.lock().unwrap(),
+        let guard_condition = Arc::new(GuardCondition::new_with_context_handle(
+            Arc::clone(&self.handle.context_handle),
             Some(Box::new(callback) as Box<dyn Fn() + Send + Sync>),
         ));
         { self.guard_conditions_mtx.lock().unwrap() }

--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -13,9 +13,10 @@ pub use self::builder::*;
 pub use self::graph::*;
 use crate::rcl_bindings::*;
 use crate::{
-    Client, ClientBase, Clock, Context, ENTITY_LIFECYCLE_MUTEX, GuardCondition, ParameterBuilder, ParameterInterface,
-    ParameterVariant, Parameters, Publisher, QoSProfile, RclrsError, Service, ServiceBase,
-    Subscription, SubscriptionBase, SubscriptionCallback, TimeSource, ContextHandle,
+    Client, ClientBase, Clock, Context, ContextHandle, GuardCondition, ParameterBuilder,
+    ParameterInterface, ParameterVariant, Parameters, Publisher, QoSProfile, RclrsError, Service,
+    ServiceBase, Subscription, SubscriptionBase, SubscriptionCallback, TimeSource,
+    ENTITY_LIFECYCLE_MUTEX,
 };
 
 // SAFETY: The functions accessing this type, including drop(), shouldn't care about the thread
@@ -257,11 +258,7 @@ impl Node {
     where
         T: Message,
     {
-        let publisher = Arc::new(Publisher::<T>::new(
-            Arc::clone(&self.handle),
-            topic,
-            qos,
-        )?);
+        let publisher = Arc::new(Publisher::<T>::new(Arc::clone(&self.handle), topic, qos)?);
         Ok(publisher)
     }
 

--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -13,7 +13,7 @@ pub use self::builder::*;
 pub use self::graph::*;
 use crate::rcl_bindings::*;
 use crate::{
-    Client, ClientBase, Clock, Context, GuardCondition, ParameterBuilder, ParameterInterface,
+    Client, ClientBase, Clock, Context, ENTITY_LIFECYCLE_MUTEX, GuardCondition, ParameterBuilder, ParameterInterface,
     ParameterVariant, Parameters, Publisher, QoSProfile, RclrsError, Service, ServiceBase,
     Subscription, SubscriptionBase, SubscriptionCallback, TimeSource, ContextHandle,
 };
@@ -78,6 +78,7 @@ impl Drop for NodeHandle {
     fn drop(&mut self) {
         let _context_lock = self.context_handle.rcl_context.lock().unwrap();
         let mut rcl_node = self.rcl_node.lock().unwrap();
+        let _lifecycle_lock = ENTITY_LIFECYCLE_MUTEX.lock().unwrap();
         unsafe { rcl_node_fini(&mut *rcl_node) };
     }
 }

--- a/rclrs/src/node/builder.rs
+++ b/rclrs/src/node/builder.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::rcl_bindings::*;
 use crate::{
-    ClockType, Context, ContextHandle, Node, NodeHandle, ParameterInterface, QoSProfile, RclrsError, TimeSource, ToResult,
+    ClockType, Context, ContextHandle, ENTITY_LIFECYCLE_MUTEX, Node, NodeHandle, ParameterInterface, QoSProfile, RclrsError, TimeSource, ToResult,
     QOS_PROFILE_CLOCK,
 };
 
@@ -270,6 +270,7 @@ impl NodeBuilder {
             // The strings and node options are copied by this function, so we don't need
             // to keep them alive.
             // The rcl_context has to be kept alive because it is co-owned by the node.
+            let _lifecycle_lock = ENTITY_LIFECYCLE_MUTEX.lock().unwrap();
             rcl_node_init(
                 &mut rcl_node,
                 node_name.as_ptr(),

--- a/rclrs/src/node/builder.rs
+++ b/rclrs/src/node/builder.rs
@@ -266,10 +266,12 @@ impl NodeBuilder {
         // SAFETY: Getting a zero-initialized value is always safe.
         let mut rcl_node = unsafe { rcl_get_zero_initialized_node() };
         unsafe {
-            // SAFETY: The rcl_node is zero-initialized as expected by this function.
-            // The strings and node options are copied by this function, so we don't need
-            // to keep them alive.
-            // The rcl_context has to be kept alive because it is co-owned by the node.
+            // SAFETY:
+            // * The rcl_node is zero-initialized as mandated by this function.
+            // * The strings and node options are copied by this function, so we don't need to keep them alive.
+            // * The rcl_context is kept alive by the ContextHandle because it is a dependency of the node.
+            // * The entity lifecycle mutex is locked to protect against the risk of
+            //   global variables in the rmw implementation being unsafely modified during cleanup.
             let _lifecycle_lock = ENTITY_LIFECYCLE_MUTEX.lock().unwrap();
             rcl_node_init(
                 &mut rcl_node,

--- a/rclrs/src/node/builder.rs
+++ b/rclrs/src/node/builder.rs
@@ -288,7 +288,7 @@ impl NodeBuilder {
         let parameter = {
             let rcl_node = handle.rcl_node.lock().unwrap();
             ParameterInterface::new(
-                &*rcl_node,
+                &rcl_node,
                 &rcl_node_options.arguments,
                 &rcl_context.global_arguments,
             )?

--- a/rclrs/src/node/builder.rs
+++ b/rclrs/src/node/builder.rs
@@ -3,8 +3,8 @@ use std::sync::{Arc, Mutex};
 
 use crate::rcl_bindings::*;
 use crate::{
-    ClockType, Context, ContextHandle, ENTITY_LIFECYCLE_MUTEX, Node, NodeHandle, ParameterInterface, QoSProfile, RclrsError, TimeSource, ToResult,
-    QOS_PROFILE_CLOCK,
+    ClockType, Context, ContextHandle, Node, NodeHandle, ParameterInterface, QoSProfile,
+    RclrsError, TimeSource, ToResult, ENTITY_LIFECYCLE_MUTEX, QOS_PROFILE_CLOCK,
 };
 
 /// A builder for creating a [`Node`][1].

--- a/rclrs/src/node/builder.rs
+++ b/rclrs/src/node/builder.rs
@@ -284,11 +284,14 @@ impl NodeBuilder {
             rcl_node: Mutex::new(rcl_node),
             context_handle: Arc::clone(&self.context),
         });
-        let parameter = ParameterInterface::new(
-            &*handle.rcl_node.lock().unwrap(),
-            &rcl_node_options.arguments,
-            &rcl_context.global_arguments,
-        )?;
+        let parameter = {
+            let rcl_node = handle.rcl_node.lock().unwrap();
+            ParameterInterface::new(
+                &*rcl_node,
+                &rcl_node_options.arguments,
+                &rcl_context.global_arguments,
+            )?
+        };
         let node = Arc::new(Node {
             handle,
             clients_mtx: Mutex::new(vec![]),

--- a/rclrs/src/node/graph.rs
+++ b/rclrs/src/node/graph.rs
@@ -459,8 +459,24 @@ mod tests {
 
     #[test]
     fn test_graph_empty() {
+        let domain_id: usize = std::env::var("ROS_DOMAIN_ID")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .map(|value| {
+                if value == 99 {
+                    // The default domain ID for this application is 99, which
+                    // conflicts with our arbitrarily chosen default for the
+                    // empty graph test. Therefore we will set the empty graph
+                    // test domain ID to 98 instead.
+                    98
+                } else {
+                    99
+                }
+            })
+            .unwrap_or(99);
+
         let context =
-            Context::new_with_options([], InitOptions::new().with_domain_id(Some(99))).unwrap();
+            Context::new_with_options([], InitOptions::new().with_domain_id(Some(domain_id))).unwrap();
         let node_name = "test_publisher_names_and_types";
         let node = Node::new(&context, node_name).unwrap();
         // Test that the graph has no publishers

--- a/rclrs/src/node/graph.rs
+++ b/rclrs/src/node/graph.rs
@@ -462,7 +462,7 @@ mod tests {
         let domain_id: usize = std::env::var("ROS_DOMAIN_ID")
             .ok()
             .and_then(|value| value.parse().ok())
-            .map(|value| {
+            .map(|value: usize| {
                 if value == 99 {
                     // The default domain ID for this application is 99, which
                     // conflicts with our arbitrarily chosen default for the
@@ -476,7 +476,8 @@ mod tests {
             .unwrap_or(99);
 
         let context =
-            Context::new_with_options([], InitOptions::new().with_domain_id(Some(domain_id))).unwrap();
+            Context::new_with_options([], InitOptions::new().with_domain_id(Some(domain_id)))
+                .unwrap();
         let node_name = "test_publisher_names_and_types";
         let node = Node::new(&context, node_name).unwrap();
         // Test that the graph has no publishers

--- a/rclrs/src/node/graph.rs
+++ b/rclrs/src/node/graph.rs
@@ -137,8 +137,9 @@ impl Node {
 
         // SAFETY: rcl_names_and_types is zero-initialized as expected by this call
         unsafe {
+            let rcl_node = self.handle.rcl_node.lock().unwrap();
             rcl_get_topic_names_and_types(
-                &*self.handle.rcl_node.lock().unwrap(),
+                &*rcl_node,
                 &mut rcutils_get_default_allocator(),
                 false,
                 &mut rcl_names_and_types,
@@ -166,8 +167,9 @@ impl Node {
 
         // SAFETY: node_names and node_namespaces are zero-initialized as expected by this call.
         unsafe {
+            let rcl_node = self.handle.rcl_node.lock().unwrap();
             rcl_get_node_names(
-                &*self.handle.rcl_node.lock().unwrap(),
+                &*rcl_node,
                 rcutils_get_default_allocator(),
                 &mut rcl_names,
                 &mut rcl_namespaces,
@@ -213,8 +215,9 @@ impl Node {
 
         // SAFETY: The node_names, namespaces, and enclaves are zero-initialized as expected by this call.
         unsafe {
+            let rcl_node = self.handle.rcl_node.lock().unwrap();
             rcl_get_node_names_with_enclaves(
-                &*self.handle.rcl_node.lock().unwrap(),
+                &*rcl_node,
                 rcutils_get_default_allocator(),
                 &mut rcl_names,
                 &mut rcl_namespaces,
@@ -262,8 +265,9 @@ impl Node {
 
         // SAFETY: The topic_name string was correctly allocated previously
         unsafe {
+            let rcl_node = self.handle.rcl_node.lock().unwrap();
             rcl_count_publishers(
-                &*self.handle.rcl_node.lock().unwrap(),
+                &*rcl_node,
                 topic_name.as_ptr(),
                 &mut count,
             )
@@ -282,8 +286,9 @@ impl Node {
 
         // SAFETY: The topic_name string was correctly allocated previously
         unsafe {
+            let rcl_node = self.handle.rcl_node.lock().unwrap();
             rcl_count_subscribers(
-                &*self.handle.rcl_node.lock().unwrap(),
+                &*rcl_node,
                 topic_name.as_ptr(),
                 &mut count,
             )
@@ -336,8 +341,9 @@ impl Node {
 
         // SAFETY: node_name and node_namespace have been zero-initialized.
         unsafe {
+            let rcl_node = self.handle.rcl_node.lock().unwrap();
             getter(
-                &*self.handle.rcl_node.lock().unwrap(),
+                &*rcl_node,
                 &mut rcutils_get_default_allocator(),
                 node_name.as_ptr(),
                 node_namespace.as_ptr(),
@@ -371,8 +377,9 @@ impl Node {
 
         // SAFETY: topic has been zero-initialized
         unsafe {
+            let rcl_node = self.handle.rcl_node.lock().unwrap();
             getter(
-                &*self.handle.rcl_node.lock().unwrap(),
+                &*rcl_node,
                 &mut rcutils_get_default_allocator(),
                 topic.as_ptr(),
                 false,
@@ -458,14 +465,16 @@ fn convert_names_and_types(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Context;
+    use crate::{Context, InitOptions};
 
     #[test]
     fn test_graph_empty() {
-        let context = Context::new([]).unwrap();
+        let context = Context::new_with_options(
+            [],
+            InitOptions::new().with_domain_id(Some(99))
+        ).unwrap();
         let node_name = "test_publisher_names_and_types";
         let node = Node::new(&context, node_name).unwrap();
-
         // Test that the graph has no publishers
         let names_and_topics = node
             .get_publisher_names_and_types_by_node(node_name, "")

--- a/rclrs/src/node/graph.rs
+++ b/rclrs/src/node/graph.rs
@@ -138,7 +138,7 @@ impl Node {
         // SAFETY: rcl_names_and_types is zero-initialized as expected by this call
         unsafe {
             rcl_get_topic_names_and_types(
-                &*self.rcl_node_mtx.lock().unwrap(),
+                &*self.handle.rcl_node.lock().unwrap(),
                 &mut rcutils_get_default_allocator(),
                 false,
                 &mut rcl_names_and_types,
@@ -167,7 +167,7 @@ impl Node {
         // SAFETY: node_names and node_namespaces are zero-initialized as expected by this call.
         unsafe {
             rcl_get_node_names(
-                &*self.rcl_node_mtx.lock().unwrap(),
+                &*self.handle.rcl_node.lock().unwrap(),
                 rcutils_get_default_allocator(),
                 &mut rcl_names,
                 &mut rcl_namespaces,
@@ -214,7 +214,7 @@ impl Node {
         // SAFETY: The node_names, namespaces, and enclaves are zero-initialized as expected by this call.
         unsafe {
             rcl_get_node_names_with_enclaves(
-                &*self.rcl_node_mtx.lock().unwrap(),
+                &*self.handle.rcl_node.lock().unwrap(),
                 rcutils_get_default_allocator(),
                 &mut rcl_names,
                 &mut rcl_namespaces,
@@ -263,7 +263,7 @@ impl Node {
         // SAFETY: The topic_name string was correctly allocated previously
         unsafe {
             rcl_count_publishers(
-                &*self.rcl_node_mtx.lock().unwrap(),
+                &*self.handle.rcl_node.lock().unwrap(),
                 topic_name.as_ptr(),
                 &mut count,
             )
@@ -283,7 +283,7 @@ impl Node {
         // SAFETY: The topic_name string was correctly allocated previously
         unsafe {
             rcl_count_subscribers(
-                &*self.rcl_node_mtx.lock().unwrap(),
+                &*self.handle.rcl_node.lock().unwrap(),
                 topic_name.as_ptr(),
                 &mut count,
             )
@@ -337,7 +337,7 @@ impl Node {
         // SAFETY: node_name and node_namespace have been zero-initialized.
         unsafe {
             getter(
-                &*self.rcl_node_mtx.lock().unwrap(),
+                &*self.handle.rcl_node.lock().unwrap(),
                 &mut rcutils_get_default_allocator(),
                 node_name.as_ptr(),
                 node_namespace.as_ptr(),
@@ -372,7 +372,7 @@ impl Node {
         // SAFETY: topic has been zero-initialized
         unsafe {
             getter(
-                &*self.rcl_node_mtx.lock().unwrap(),
+                &*self.handle.rcl_node.lock().unwrap(),
                 &mut rcutils_get_default_allocator(),
                 topic.as_ptr(),
                 false,

--- a/rclrs/src/node/graph.rs
+++ b/rclrs/src/node/graph.rs
@@ -266,12 +266,7 @@ impl Node {
         // SAFETY: The topic_name string was correctly allocated previously
         unsafe {
             let rcl_node = self.handle.rcl_node.lock().unwrap();
-            rcl_count_publishers(
-                &*rcl_node,
-                topic_name.as_ptr(),
-                &mut count,
-            )
-            .ok()?
+            rcl_count_publishers(&*rcl_node, topic_name.as_ptr(), &mut count).ok()?
         };
         Ok(count)
     }
@@ -287,12 +282,7 @@ impl Node {
         // SAFETY: The topic_name string was correctly allocated previously
         unsafe {
             let rcl_node = self.handle.rcl_node.lock().unwrap();
-            rcl_count_subscribers(
-                &*rcl_node,
-                topic_name.as_ptr(),
-                &mut count,
-            )
-            .ok()?
+            rcl_count_subscribers(&*rcl_node, topic_name.as_ptr(), &mut count).ok()?
         };
         Ok(count)
     }
@@ -469,10 +459,8 @@ mod tests {
 
     #[test]
     fn test_graph_empty() {
-        let context = Context::new_with_options(
-            [],
-            InitOptions::new().with_domain_id(Some(99))
-        ).unwrap();
+        let context =
+            Context::new_with_options([], InitOptions::new().with_domain_id(Some(99))).unwrap();
         let node_name = "test_publisher_names_and_types";
         let node = Node::new(&context, node_name).unwrap();
         // Test that the graph has no publishers

--- a/rclrs/src/parameter.rs
+++ b/rclrs/src/parameter.rs
@@ -5,7 +5,7 @@ pub(crate) use override_map::*;
 pub use value::*;
 
 use crate::rcl_bindings::*;
-use crate::{call_string_getter_with_handle, RclrsError};
+use crate::{call_string_getter_with_rcl_node, RclrsError};
 use std::collections::{btree_map::Entry, BTreeMap};
 use std::fmt::Debug;
 use std::marker::PhantomData;
@@ -781,7 +781,7 @@ impl ParameterInterface {
         global_arguments: &rcl_arguments_t,
     ) -> Result<Self, RclrsError> {
         let override_map = unsafe {
-            let fqn = call_string_getter_with_handle(rcl_node, rcl_node_get_fully_qualified_name);
+            let fqn = call_string_getter_with_rcl_node(rcl_node, rcl_node_get_fully_qualified_name);
             resolve_parameter_overrides(&fqn, node_arguments, global_arguments)?
         };
 

--- a/rclrs/src/parameter.rs
+++ b/rclrs/src/parameter.rs
@@ -776,13 +776,12 @@ pub(crate) struct ParameterInterface {
 
 impl ParameterInterface {
     pub(crate) fn new(
-        rcl_node_mtx: &Arc<Mutex<rcl_node_t>>,
+        rcl_node: &rcl_node_t,
         node_arguments: &rcl_arguments_t,
         global_arguments: &rcl_arguments_t,
     ) -> Result<Self, RclrsError> {
-        let rcl_node = rcl_node_mtx.lock().unwrap();
         let override_map = unsafe {
-            let fqn = call_string_getter_with_handle(&rcl_node, rcl_node_get_fully_qualified_name);
+            let fqn = call_string_getter_with_handle(rcl_node, rcl_node_get_fully_qualified_name);
             resolve_parameter_overrides(&fqn, node_arguments, global_arguments)?
         };
 

--- a/rclrs/src/parameter/value.rs
+++ b/rclrs/src/parameter/value.rs
@@ -433,7 +433,7 @@ mod tests {
             let mut rcl_params = std::ptr::null_mut();
             unsafe {
                 rcl_arguments_get_param_overrides(
-                    &ctx.rcl_context_mtx.lock().unwrap().global_arguments,
+                    &ctx.handle.rcl_context.lock().unwrap().global_arguments,
                     &mut rcl_params,
                 )
                 .ok()?;

--- a/rclrs/src/publisher.rs
+++ b/rclrs/src/publisher.rs
@@ -29,10 +29,7 @@ impl Drop for PublisherHandle {
             // SAFETY: No preconditions for this function (besides the arguments being valid).
             let mut rcl_node = self.node_handle.rcl_node.lock().unwrap();
             let _lifecycle_lock = ENTITY_LIFECYCLE_MUTEX.lock().unwrap();
-            rcl_publisher_fini(
-                self.rcl_publisher.get_mut().unwrap(),
-                &mut *rcl_node,
-            );
+            rcl_publisher_fini(self.rcl_publisher.get_mut().unwrap(), &mut *rcl_node);
         }
     }
 }
@@ -116,7 +113,7 @@ where
             handle: PublisherHandle {
                 rcl_publisher: Mutex::new(rcl_publisher),
                 node_handle,
-            }
+            },
         })
     }
 

--- a/rclrs/src/publisher.rs
+++ b/rclrs/src/publisher.rs
@@ -9,6 +9,7 @@ use rosidl_runtime_rs::{Message, RmwMessage};
 use crate::error::{RclrsError, ToResult};
 use crate::qos::QoSProfile;
 use crate::rcl_bindings::*;
+use crate::NodeHandle;
 
 mod loaned_message;
 pub use loaned_message::*;
@@ -16,6 +17,11 @@ pub use loaned_message::*;
 // SAFETY: The functions accessing this type, including drop(), shouldn't care about the thread
 // they are running in. Therefore, this type can be safely sent to another thread.
 unsafe impl Send for rcl_publisher_t {}
+
+struct PublisherHandle {
+    rcl_publisher: Mutex<rcl_publisher_t>,
+    node_handle: Arc<NodeHandle>,
+}
 
 /// Struct for sending messages of type `T`.
 ///
@@ -31,12 +37,11 @@ pub struct Publisher<T>
 where
     T: Message,
 {
-    rcl_publisher_mtx: Mutex<rcl_publisher_t>,
-    rcl_node_mtx: Arc<Mutex<rcl_node_t>>,
     // The data pointed to by type_support_ptr has static lifetime;
     // it is global data in the type support library.
     type_support_ptr: *const rosidl_message_type_support_t,
     message: PhantomData<T>,
+    handle: PublisherHandle,
 }
 
 impl<T> Drop for Publisher<T>
@@ -47,8 +52,8 @@ where
         unsafe {
             // SAFETY: No preconditions for this function (besides the arguments being valid).
             rcl_publisher_fini(
-                self.rcl_publisher_mtx.get_mut().unwrap(),
-                &mut *self.rcl_node_mtx.lock().unwrap(),
+                self.handle.rcl_publisher.get_mut().unwrap(),
+                &mut *self.handle.node_handle.rcl_node.lock().unwrap(),
             );
         }
     }
@@ -68,8 +73,8 @@ where
     /// Creates a new `Publisher`.
     ///
     /// Node and namespace changes are always applied _before_ topic remapping.
-    pub fn new(
-        rcl_node_mtx: Arc<Mutex<rcl_node_t>>,
+    pub(crate) fn new(
+        node_handle: Arc<NodeHandle>,
         topic: &str,
         qos: QoSProfile,
     ) -> Result<Self, RclrsError>
@@ -96,7 +101,7 @@ where
             // TODO: type support?
             rcl_publisher_init(
                 &mut rcl_publisher,
-                &*rcl_node_mtx.lock().unwrap(),
+                &*node_handle.rcl_node.lock().unwrap(),
                 type_support_ptr,
                 topic_c_string.as_ptr(),
                 &publisher_options,
@@ -105,10 +110,12 @@ where
         }
 
         Ok(Self {
-            rcl_publisher_mtx: Mutex::new(rcl_publisher),
-            rcl_node_mtx,
             type_support_ptr,
             message: PhantomData,
+            handle: PublisherHandle {
+                rcl_publisher: Mutex::new(rcl_publisher),
+                node_handle,
+            }
         })
     }
 
@@ -121,7 +128,7 @@ where
         // The unsafe variables created get converted to safe types before being returned
         unsafe {
             let raw_topic_pointer =
-                rcl_publisher_get_topic_name(&*self.rcl_publisher_mtx.lock().unwrap());
+                rcl_publisher_get_topic_name(&*self.handle.rcl_publisher.lock().unwrap());
             CStr::from_ptr(raw_topic_pointer)
                 .to_string_lossy()
                 .into_owned()
@@ -146,7 +153,7 @@ where
     /// [1]: https://github.com/ros2/ros2/issues/255
     pub fn publish<'a, M: MessageCow<'a, T>>(&self, message: M) -> Result<(), RclrsError> {
         let rmw_message = T::into_rmw_message(message.into_cow());
-        let rcl_publisher = &mut *self.rcl_publisher_mtx.lock().unwrap();
+        let rcl_publisher = &mut *self.handle.rcl_publisher.lock().unwrap();
         unsafe {
             // SAFETY: The message type is guaranteed to match the publisher type by the type system.
             // The message does not need to be valid beyond the duration of this function call.
@@ -200,7 +207,7 @@ where
         unsafe {
             // SAFETY: msg_ptr contains a null ptr as expected by this function.
             rcl_borrow_loaned_message(
-                &*self.rcl_publisher_mtx.lock().unwrap(),
+                &*self.handle.rcl_publisher.lock().unwrap(),
                 self.type_support_ptr,
                 &mut msg_ptr,
             )

--- a/rclrs/src/publisher.rs
+++ b/rclrs/src/publisher.rs
@@ -18,9 +18,9 @@ pub use loaned_message::*;
 // they are running in. Therefore, this type can be safely sent to another thread.
 unsafe impl Send for rcl_publisher_t {}
 
-/// Manage the lifecycle of an [`rcl_publisher_t`], including managing its dependencies
-/// on [`rcl_node_t`] and [`rcl_context_t`] by ensuring that these dependencies are
-/// [dropped after][1] the [`rcl_publisher_t`].
+/// Manage the lifecycle of an `rcl_publisher_t`, including managing its dependencies
+/// on `rcl_node_t` and `rcl_context_t` by ensuring that these dependencies are
+/// [dropped after][1] the `rcl_publisher_t`.
 ///
 /// [1] https://doc.rust-lang.org/reference/destructors.html
 struct PublisherHandle {

--- a/rclrs/src/publisher.rs
+++ b/rclrs/src/publisher.rs
@@ -22,7 +22,7 @@ unsafe impl Send for rcl_publisher_t {}
 /// on `rcl_node_t` and `rcl_context_t` by ensuring that these dependencies are
 /// [dropped after][1] the `rcl_publisher_t`.
 ///
-/// [1] https://doc.rust-lang.org/reference/destructors.html
+/// [1]: <https://doc.rust-lang.org/reference/destructors.html>
 struct PublisherHandle {
     rcl_publisher: Mutex<rcl_publisher_t>,
     node_handle: Arc<NodeHandle>,

--- a/rclrs/src/publisher.rs
+++ b/rclrs/src/publisher.rs
@@ -9,7 +9,7 @@ use rosidl_runtime_rs::{Message, RmwMessage};
 use crate::error::{RclrsError, ToResult};
 use crate::qos::QoSProfile;
 use crate::rcl_bindings::*;
-use crate::NodeHandle;
+use crate::{NodeHandle, ENTITY_LIFECYCLE_MUTEX};
 
 mod loaned_message;
 pub use loaned_message::*;
@@ -28,6 +28,7 @@ impl Drop for PublisherHandle {
         unsafe {
             // SAFETY: No preconditions for this function (besides the arguments being valid).
             let mut rcl_node = self.node_handle.rcl_node.lock().unwrap();
+            let _lifecycle_lock = ENTITY_LIFECYCLE_MUTEX.lock().unwrap();
             rcl_publisher_fini(
                 self.rcl_publisher.get_mut().unwrap(),
                 &mut *rcl_node,
@@ -98,6 +99,7 @@ where
             // afterwards.
             // TODO: type support?
             let rcl_node = node_handle.rcl_node.lock().unwrap();
+            let _lifecycle_lock = ENTITY_LIFECYCLE_MUTEX.lock().unwrap();
             rcl_publisher_init(
                 &mut rcl_publisher,
                 &*rcl_node,

--- a/rclrs/src/publisher/loaned_message.rs
+++ b/rclrs/src/publisher/loaned_message.rs
@@ -55,7 +55,7 @@ where
             unsafe {
                 // SAFETY: These two pointers are valid, and the msg_ptr is not used afterwards.
                 rcl_return_loaned_message_from_publisher(
-                    &*self.publisher.rcl_publisher_mtx.lock().unwrap(),
+                    &*self.publisher.handle.rcl_publisher.lock().unwrap(),
                     self.msg_ptr as *mut _,
                 )
                 .ok()
@@ -80,7 +80,7 @@ where
         unsafe {
             // SAFETY: These two pointers are valid, and the msg_ptr is not used afterwards.
             rcl_publish_loaned_message(
-                &*self.publisher.rcl_publisher_mtx.lock().unwrap(),
+                &*self.publisher.handle.rcl_publisher.lock().unwrap(),
                 self.msg_ptr as *mut _,
                 std::ptr::null_mut(),
             )

--- a/rclrs/src/service.rs
+++ b/rclrs/src/service.rs
@@ -13,9 +13,9 @@ use crate::{NodeHandle, ENTITY_LIFECYCLE_MUTEX};
 // they are running in. Therefore, this type can be safely sent to another thread.
 unsafe impl Send for rcl_service_t {}
 
-/// Manage the lifecycle of an [`rcl_service_t`], including managing its dependencies
-/// on [`rcl_node_t`] and [`rcl_context_t`] by ensuring that these dependencies are
-/// [dropped after][1] the [`rcl_service_t`].
+/// Manage the lifecycle of an `rcl_service_t`, including managing its dependencies
+/// on `rcl_node_t` and `rcl_context_t` by ensuring that these dependencies are
+/// [dropped after][1] the `rcl_service_t`.
 ///
 /// [1] https://doc.rust-lang.org/reference/destructors.html
 pub struct ServiceHandle {

--- a/rclrs/src/service.rs
+++ b/rclrs/src/service.rs
@@ -17,7 +17,7 @@ unsafe impl Send for rcl_service_t {}
 /// on `rcl_node_t` and `rcl_context_t` by ensuring that these dependencies are
 /// [dropped after][1] the `rcl_service_t`.
 ///
-/// [1] https://doc.rust-lang.org/reference/destructors.html
+/// [1]: <https://doc.rust-lang.org/reference/destructors.html>
 pub struct ServiceHandle {
     rcl_service: Mutex<rcl_service_t>,
     node_handle: Arc<NodeHandle>,

--- a/rclrs/src/subscription.rs
+++ b/rclrs/src/subscription.rs
@@ -8,7 +8,7 @@ use rosidl_runtime_rs::{Message, RmwMessage};
 
 use crate::error::{RclReturnCode, ToResult};
 use crate::qos::QoSProfile;
-use crate::{rcl_bindings::*, RclrsError, NodeHandle, ENTITY_LIFECYCLE_MUTEX};
+use crate::{rcl_bindings::*, NodeHandle, RclrsError, ENTITY_LIFECYCLE_MUTEX};
 
 mod callback;
 mod message_info;

--- a/rclrs/src/subscription.rs
+++ b/rclrs/src/subscription.rs
@@ -8,7 +8,7 @@ use rosidl_runtime_rs::{Message, RmwMessage};
 
 use crate::error::{RclReturnCode, ToResult};
 use crate::qos::QoSProfile;
-use crate::{rcl_bindings::*, RclrsError, NodeHandle};
+use crate::{rcl_bindings::*, RclrsError, NodeHandle, ENTITY_LIFECYCLE_MUTEX};
 
 mod callback;
 mod message_info;
@@ -38,6 +38,7 @@ impl Drop for SubscriptionHandle {
     fn drop(&mut self) {
         let rcl_subscription = self.rcl_subscription.get_mut().unwrap();
         let mut rcl_node = self.node_handle.rcl_node.lock().unwrap();
+        let _lifecycle_lock = ENTITY_LIFECYCLE_MUTEX.lock().unwrap();
         // SAFETY: No preconditions for this function (besides the arguments being valid).
         unsafe {
             rcl_subscription_fini(rcl_subscription, &mut *rcl_node);
@@ -114,6 +115,7 @@ where
             // afterwards.
             // TODO: type support?
             let rcl_node = node_handle.rcl_node.lock().unwrap();
+            let _lifecycle_lock = ENTITY_LIFECYCLE_MUTEX.lock().unwrap();
             rcl_subscription_init(
                 &mut rcl_subscription,
                 &*rcl_node,

--- a/rclrs/src/subscription.rs
+++ b/rclrs/src/subscription.rs
@@ -21,7 +21,11 @@ pub use readonly_loaned_message::*;
 // they are running in. Therefore, this type can be safely sent to another thread.
 unsafe impl Send for rcl_subscription_t {}
 
-/// Internal struct used by subscriptions.
+/// Manage the lifecycle of an [`rcl_subscription_t`], including managing its dependencies
+/// on [`rcl_node_t`] and [`rcl_context_t`] by ensuring that these dependencies are
+/// [dropped after][1] the [`rcl_subscription_t`].
+///
+/// [1] https://doc.rust-lang.org/reference/destructors.html
 pub struct SubscriptionHandle {
     rcl_subscription: Mutex<rcl_subscription_t>,
     node_handle: Arc<NodeHandle>,
@@ -39,7 +43,8 @@ impl Drop for SubscriptionHandle {
         let rcl_subscription = self.rcl_subscription.get_mut().unwrap();
         let mut rcl_node = self.node_handle.rcl_node.lock().unwrap();
         let _lifecycle_lock = ENTITY_LIFECYCLE_MUTEX.lock().unwrap();
-        // SAFETY: No preconditions for this function (besides the arguments being valid).
+        // SAFETY: The entity lifecycle mutex is locked to protect against the risk of
+        // global variables in the rmw implementation being unsafely modified during cleanup.
         unsafe {
             rcl_subscription_fini(rcl_subscription, &mut *rcl_node);
         }
@@ -108,22 +113,26 @@ where
         // SAFETY: No preconditions for this function.
         let mut subscription_options = unsafe { rcl_subscription_get_default_options() };
         subscription_options.qos = qos.into();
-        unsafe {
-            // SAFETY: The rcl_subscription is zero-initialized as expected by this function.
-            // The rcl_node is kept alive because it is co-owned by the subscription.
-            // The topic name and the options are copied by this function, so they can be dropped
-            // afterwards.
-            // TODO: type support?
+
+        {
             let rcl_node = node_handle.rcl_node.lock().unwrap();
             let _lifecycle_lock = ENTITY_LIFECYCLE_MUTEX.lock().unwrap();
-            rcl_subscription_init(
-                &mut rcl_subscription,
-                &*rcl_node,
-                type_support,
-                topic_c_string.as_ptr(),
-                &subscription_options,
-            )
-            .ok()?;
+            unsafe {
+                // SAFETY:
+                // * The rcl_subscription is zero-initialized as mandated by this function.
+                // * The rcl_node is kept alive by the NodeHandle because it is a dependency of the subscription.
+                // * The topic name and the options are copied by this function, so they can be dropped afterwards.
+                // * The entity lifecycle mutex is locked to protect against the risk of global
+                //   variables in the rmw implementation being unsafely modified during cleanup.
+                rcl_subscription_init(
+                    &mut rcl_subscription,
+                    &*rcl_node,
+                    type_support,
+                    topic_c_string.as_ptr(),
+                    &subscription_options,
+                )
+                .ok()?;
+            }
         }
 
         let handle = Arc::new(SubscriptionHandle {

--- a/rclrs/src/subscription.rs
+++ b/rclrs/src/subscription.rs
@@ -25,7 +25,7 @@ unsafe impl Send for rcl_subscription_t {}
 /// on `rcl_node_t` and `rcl_context_t` by ensuring that these dependencies are
 /// [dropped after][1] the `rcl_subscription_t`.
 ///
-/// [1] https://doc.rust-lang.org/reference/destructors.html
+/// [1]: <https://doc.rust-lang.org/reference/destructors.html>
 pub struct SubscriptionHandle {
     rcl_subscription: Mutex<rcl_subscription_t>,
     node_handle: Arc<NodeHandle>,

--- a/rclrs/src/subscription.rs
+++ b/rclrs/src/subscription.rs
@@ -21,9 +21,9 @@ pub use readonly_loaned_message::*;
 // they are running in. Therefore, this type can be safely sent to another thread.
 unsafe impl Send for rcl_subscription_t {}
 
-/// Manage the lifecycle of an [`rcl_subscription_t`], including managing its dependencies
-/// on [`rcl_node_t`] and [`rcl_context_t`] by ensuring that these dependencies are
-/// [dropped after][1] the [`rcl_subscription_t`].
+/// Manage the lifecycle of an `rcl_subscription_t`, including managing its dependencies
+/// on `rcl_node_t` and `rcl_context_t` by ensuring that these dependencies are
+/// [dropped after][1] the `rcl_subscription_t`.
 ///
 /// [1] https://doc.rust-lang.org/reference/destructors.html
 pub struct SubscriptionHandle {

--- a/rclrs/src/wait.rs
+++ b/rclrs/src/wait.rs
@@ -28,9 +28,9 @@ mod guard_condition;
 use exclusivity_guard::*;
 pub use guard_condition::*;
 
-/// Manage the lifecycle of an [`rcl_wait_set_t`], including managing its dependency
-/// on [`rcl_context_t`] by ensuring that this dependency is [dropped after][1] the
-/// [`rcl_wait_set_t`].
+/// Manage the lifecycle of an `rcl_wait_set_t`, including managing its dependency
+/// on `rcl_context_t` by ensuring that this dependency is [dropped after][1] the
+/// `rcl_wait_set_t`.
 ///
 /// [1] https://doc.rust-lang.org/reference/destructors.html
 struct WaitSetHandle {

--- a/rclrs/src/wait.rs
+++ b/rclrs/src/wait.rs
@@ -32,7 +32,7 @@ pub use guard_condition::*;
 /// on `rcl_context_t` by ensuring that this dependency is [dropped after][1] the
 /// `rcl_wait_set_t`.
 ///
-/// [1] https://doc.rust-lang.org/reference/destructors.html
+/// [1]: <https://doc.rust-lang.org/reference/destructors.html>
 struct WaitSetHandle {
     rcl_wait_set: rcl_wait_set_t,
     // Used to ensure the context is alive while the wait set is alive.

--- a/rclrs/src/wait.rs
+++ b/rclrs/src/wait.rs
@@ -15,24 +15,27 @@
 // DISTRIBUTION A. Approved for public release; distribution unlimited.
 // OPSEC #4584.
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 use std::vec::Vec;
 
 use crate::error::{to_rclrs_result, RclReturnCode, RclrsError, ToResult};
 use crate::rcl_bindings::*;
-use crate::{ClientBase, Context, Node, ServiceBase, SubscriptionBase};
+use crate::{ClientBase, Context, Node, ServiceBase, SubscriptionBase, ContextHandle};
 
 mod exclusivity_guard;
 mod guard_condition;
 use exclusivity_guard::*;
 pub use guard_condition::*;
 
-/// A struct for waiting on subscriptions and other waitable entities to become ready.
-pub struct WaitSet {
+struct WaitSetHandle {
     rcl_wait_set: rcl_wait_set_t,
     // Used to ensure the context is alive while the wait set is alive.
-    _rcl_context_mtx: Arc<Mutex<rcl_context_t>>,
+    _rcl_context_mtx: Arc<ContextHandle>,
+}
+
+/// A struct for waiting on subscriptions and other waitable entities to become ready.
+pub struct WaitSet {
     // The subscriptions that are currently registered in the wait set.
     // This correspondence is an invariant that must be maintained by all functions,
     // even in the error case.
@@ -41,6 +44,7 @@ pub struct WaitSet {
     // The guard conditions that are currently registered in the wait set.
     guard_conditions: Vec<ExclusivityGuard<Arc<GuardCondition>>>,
     services: Vec<ExclusivityGuard<Arc<dyn ServiceBase>>>,
+    handle: WaitSetHandle,
 }
 
 /// A list of entities that are ready, returned by [`WaitSet::wait`].
@@ -101,19 +105,21 @@ impl WaitSet {
                 number_of_clients,
                 number_of_services,
                 number_of_events,
-                &mut *context.rcl_context_mtx.lock().unwrap(),
+                &mut *context.handle.rcl_context.lock().unwrap(),
                 rcutils_get_default_allocator(),
             )
             .ok()?;
             rcl_wait_set
         };
         Ok(Self {
-            rcl_wait_set,
-            _rcl_context_mtx: context.rcl_context_mtx.clone(),
             subscriptions: Vec::new(),
             guard_conditions: Vec::new(),
             clients: Vec::new(),
             services: Vec::new(),
+            handle: WaitSetHandle {
+                rcl_wait_set,
+                _rcl_context_mtx: Arc::clone(&context.handle),
+            },
         })
     }
 
@@ -126,7 +132,7 @@ impl WaitSet {
         let live_guard_conditions = node.live_guard_conditions();
         let live_services = node.live_services();
         let ctx = Context {
-            rcl_context_mtx: node.rcl_context_mtx.clone(),
+            handle: Arc::clone(&node.handle.context_handle),
         };
         let mut wait_set = WaitSet::new(
             live_subscriptions.len(),
@@ -169,7 +175,7 @@ impl WaitSet {
         // valid, which it always is in our case. Hence, only debug_assert instead of returning
         // Result.
         // SAFETY: No preconditions for this function (besides passing in a valid wait set).
-        let ret = unsafe { rcl_wait_set_clear(&mut self.rcl_wait_set) };
+        let ret = unsafe { rcl_wait_set_clear(&mut self.handle.rcl_wait_set) };
         debug_assert_eq!(ret, 0);
     }
 
@@ -196,7 +202,7 @@ impl WaitSet {
             // for as long as the wait set exists, because it's stored in self.subscriptions.
             // Passing in a null pointer for the third argument is explicitly allowed.
             rcl_wait_set_add_subscription(
-                &mut self.rcl_wait_set,
+                &mut self.handle.rcl_wait_set,
                 &*subscription.handle().lock(),
                 std::ptr::null_mut(),
             )
@@ -228,7 +234,7 @@ impl WaitSet {
         unsafe {
             // SAFETY: Safe if the wait set and guard condition are initialized
             rcl_wait_set_add_guard_condition(
-                &mut self.rcl_wait_set,
+                &mut self.handle.rcl_wait_set,
                 &*guard_condition.rcl_guard_condition.lock().unwrap(),
                 std::ptr::null_mut(),
             )
@@ -258,7 +264,7 @@ impl WaitSet {
             // for as long as the wait set exists, because it's stored in self.clients.
             // Passing in a null pointer for the third argument is explicitly allowed.
             rcl_wait_set_add_client(
-                &mut self.rcl_wait_set,
+                &mut self.handle.rcl_wait_set,
                 &*client.handle().lock() as *const _,
                 core::ptr::null_mut(),
             )
@@ -288,7 +294,7 @@ impl WaitSet {
             // for as long as the wait set exists, because it's stored in self.services.
             // Passing in a null pointer for the third argument is explicitly allowed.
             rcl_wait_set_add_service(
-                &mut self.rcl_wait_set,
+                &mut self.handle.rcl_wait_set,
                 &*service.handle().lock() as *const _,
                 core::ptr::null_mut(),
             )
@@ -337,7 +343,7 @@ impl WaitSet {
         // We cannot currently guarantee that the wait sets may not share content, but it is
         // mentioned in the doc comment for `add_subscription`.
         // Also, the rcl_wait_set is obviously valid.
-        match unsafe { rcl_wait(&mut self.rcl_wait_set, timeout_ns) }.ok() {
+        match unsafe { rcl_wait(&mut self.handle.rcl_wait_set, timeout_ns) }.ok() {
             Ok(_) => (),
             Err(error) => match error {
                 RclrsError::RclError { code, msg } => match code {
@@ -357,7 +363,7 @@ impl WaitSet {
             // SAFETY: The `subscriptions` entry is an array of pointers, and this dereferencing is
             // equivalent to
             // https://github.com/ros2/rcl/blob/35a31b00a12f259d492bf53c0701003bd7f1745c/rcl/include/rcl/wait.h#L419
-            let wait_set_entry = unsafe { *self.rcl_wait_set.subscriptions.add(i) };
+            let wait_set_entry = unsafe { *self.handle.rcl_wait_set.subscriptions.add(i) };
             if !wait_set_entry.is_null() {
                 ready_entities
                     .subscriptions
@@ -369,7 +375,7 @@ impl WaitSet {
             // SAFETY: The `clients` entry is an array of pointers, and this dereferencing is
             // equivalent to
             // https://github.com/ros2/rcl/blob/35a31b00a12f259d492bf53c0701003bd7f1745c/rcl/include/rcl/wait.h#L419
-            let wait_set_entry = unsafe { *self.rcl_wait_set.clients.add(i) };
+            let wait_set_entry = unsafe { *self.handle.rcl_wait_set.clients.add(i) };
             if !wait_set_entry.is_null() {
                 ready_entities.clients.push(Arc::clone(&client.waitable));
             }
@@ -379,7 +385,7 @@ impl WaitSet {
             // SAFETY: The `clients` entry is an array of pointers, and this dereferencing is
             // equivalent to
             // https://github.com/ros2/rcl/blob/35a31b00a12f259d492bf53c0701003bd7f1745c/rcl/include/rcl/wait.h#L419
-            let wait_set_entry = unsafe { *self.rcl_wait_set.guard_conditions.add(i) };
+            let wait_set_entry = unsafe { *self.handle.rcl_wait_set.guard_conditions.add(i) };
             if !wait_set_entry.is_null() {
                 ready_entities
                     .guard_conditions
@@ -391,7 +397,7 @@ impl WaitSet {
             // SAFETY: The `services` entry is an array of pointers, and this dereferencing is
             // equivalent to
             // https://github.com/ros2/rcl/blob/35a31b00a12f259d492bf53c0701003bd7f1745c/rcl/include/rcl/wait.h#L419
-            let wait_set_entry = unsafe { *self.rcl_wait_set.services.add(i) };
+            let wait_set_entry = unsafe { *self.handle.rcl_wait_set.services.add(i) };
             if !wait_set_entry.is_null() {
                 ready_entities.services.push(Arc::clone(&service.waitable));
             }

--- a/rclrs/src/wait.rs
+++ b/rclrs/src/wait.rs
@@ -31,7 +31,8 @@ pub use guard_condition::*;
 struct WaitSetHandle {
     rcl_wait_set: rcl_wait_set_t,
     // Used to ensure the context is alive while the wait set is alive.
-    _rcl_context_mtx: Arc<ContextHandle>,
+    #[allow(dead_code)]
+    context_handle: Arc<ContextHandle>,
 }
 
 /// A struct for waiting on subscriptions and other waitable entities to become ready.
@@ -118,7 +119,7 @@ impl WaitSet {
             services: Vec::new(),
             handle: WaitSetHandle {
                 rcl_wait_set,
-                _rcl_context_mtx: Arc::clone(&context.handle),
+                context_handle: Arc::clone(&context.handle),
             },
         })
     }
@@ -235,7 +236,7 @@ impl WaitSet {
             // SAFETY: Safe if the wait set and guard condition are initialized
             rcl_wait_set_add_guard_condition(
                 &mut self.handle.rcl_wait_set,
-                &*guard_condition.rcl_guard_condition.lock().unwrap(),
+                &*guard_condition.handle.rcl_guard_condition.lock().unwrap(),
                 std::ptr::null_mut(),
             )
             .ok()?;

--- a/rclrs/src/wait.rs
+++ b/rclrs/src/wait.rs
@@ -28,6 +28,11 @@ mod guard_condition;
 use exclusivity_guard::*;
 pub use guard_condition::*;
 
+/// Manage the lifecycle of an [`rcl_wait_set_t`], including managing its dependency
+/// on [`rcl_context_t`] by ensuring that this dependency is [dropped after][1] the
+/// [`rcl_wait_set_t`].
+///
+/// [1] https://doc.rust-lang.org/reference/destructors.html
 struct WaitSetHandle {
     rcl_wait_set: rcl_wait_set_t,
     // Used to ensure the context is alive while the wait set is alive.

--- a/rclrs/src/wait.rs
+++ b/rclrs/src/wait.rs
@@ -96,6 +96,7 @@ impl WaitSet {
         let rcl_wait_set = unsafe {
             // SAFETY: Getting a zero-initialized value is always safe
             let mut rcl_wait_set = rcl_get_zero_initialized_wait_set();
+            let mut rcl_context = context.handle.rcl_context.lock().unwrap();
             // SAFETY: We're passing in a zero-initialized wait set and a valid context.
             // There are no other preconditions.
             rcl_wait_set_init(
@@ -106,7 +107,7 @@ impl WaitSet {
                 number_of_clients,
                 number_of_services,
                 number_of_events,
-                &mut *context.handle.rcl_context.lock().unwrap(),
+                &mut *rcl_context,
                 rcutils_get_default_allocator(),
             )
             .ok()?;

--- a/rclrs/src/wait.rs
+++ b/rclrs/src/wait.rs
@@ -21,7 +21,7 @@ use std::vec::Vec;
 
 use crate::error::{to_rclrs_result, RclReturnCode, RclrsError, ToResult};
 use crate::rcl_bindings::*;
-use crate::{ClientBase, Context, Node, ServiceBase, SubscriptionBase, ContextHandle};
+use crate::{ClientBase, Context, ContextHandle, Node, ServiceBase, SubscriptionBase};
 
 mod exclusivity_guard;
 mod guard_condition;

--- a/rclrs/src/wait/guard_condition.rs
+++ b/rclrs/src/wait/guard_condition.rs
@@ -80,7 +80,7 @@ unsafe impl Send for rcl_guard_condition_t {}
 impl GuardCondition {
     /// Creates a new guard condition with no callback.
     pub fn new(context: &Context) -> Self {
-        Self::new_with_rcl_context(&mut context.rcl_context_mtx.lock().unwrap(), None)
+        Self::new_with_rcl_context(&mut context.handle.rcl_context.lock().unwrap(), None)
     }
 
     /// Creates a new guard condition with a callback.
@@ -89,7 +89,7 @@ impl GuardCondition {
         F: Fn() + Send + Sync + 'static,
     {
         Self::new_with_rcl_context(
-            &mut context.rcl_context_mtx.lock().unwrap(),
+            &mut context.handle.rcl_context.lock().unwrap(),
             Some(Box::new(callback) as Box<dyn Fn() + Send + Sync>),
         )
     }

--- a/rclrs/src/wait/guard_condition.rs
+++ b/rclrs/src/wait/guard_condition.rs
@@ -52,9 +52,9 @@ pub struct GuardCondition {
     pub(crate) in_use_by_wait_set: Arc<AtomicBool>,
 }
 
-/// Manage the lifecycle of an [`rcl_guard_condition_t`], including managing its dependency
-/// on [`rcl_context_t`] by ensuring that this dependency is [dropped after][1] the
-/// [`rcl_guard_condition_t`].
+/// Manage the lifecycle of an `rcl_guard_condition_t`, including managing its dependency
+/// on `rcl_context_t` by ensuring that this dependency is [dropped after][1] the
+/// `rcl_guard_condition_t`.
 ///
 /// [1] https://doc.rust-lang.org/reference/destructors.html
 pub(crate) struct GuardConditionHandle {

--- a/rclrs/src/wait/guard_condition.rs
+++ b/rclrs/src/wait/guard_condition.rs
@@ -1,7 +1,7 @@
 use std::sync::{atomic::AtomicBool, Arc, Mutex};
 
 use crate::rcl_bindings::*;
-use crate::{Context, RclrsError, ToResult};
+use crate::{Context, ContextHandle, RclrsError, ToResult};
 
 /// A waitable entity used for waking up a wait set manually.
 ///
@@ -45,18 +45,25 @@ use crate::{Context, RclrsError, ToResult};
 /// ```
 pub struct GuardCondition {
     /// The rcl_guard_condition_t that this struct encapsulates.
-    pub(crate) rcl_guard_condition: Mutex<rcl_guard_condition_t>,
+    pub(crate) handle: GuardConditionHandle,
     /// An optional callback to call when this guard condition is triggered.
     callback: Option<Box<dyn Fn() + Send + Sync>>,
     /// A flag to indicate if this guard condition has already been assigned to a wait set.
     pub(crate) in_use_by_wait_set: Arc<AtomicBool>,
 }
 
+pub(crate) struct GuardConditionHandle {
+    pub(crate) rcl_guard_condition: Mutex<rcl_guard_condition_t>,
+    /// Keep the context alive for the whole lifecycle of the guard condition
+    #[allow(dead_code)]
+    pub(crate) context_handle: Arc<ContextHandle>,
+}
+
 impl Drop for GuardCondition {
     fn drop(&mut self) {
         unsafe {
             // SAFETY: No precondition for this function (besides passing in a valid guard condition)
-            rcl_guard_condition_fini(&mut *self.rcl_guard_condition.lock().unwrap());
+            rcl_guard_condition_fini(&mut *self.handle.rcl_guard_condition.lock().unwrap());
         }
     }
 }
@@ -66,8 +73,8 @@ impl PartialEq for GuardCondition {
         // Because GuardCondition controls the creation of the rcl_guard_condition, each unique GuardCondition should have a unique
         // rcl_guard_condition. Thus comparing equality of this member should be enough.
         std::ptr::eq(
-            &self.rcl_guard_condition.lock().unwrap().impl_,
-            &other.rcl_guard_condition.lock().unwrap().impl_,
+            &self.handle.rcl_guard_condition.lock().unwrap().impl_,
+            &other.handle.rcl_guard_condition.lock().unwrap().impl_,
         )
     }
 }
@@ -80,7 +87,7 @@ unsafe impl Send for rcl_guard_condition_t {}
 impl GuardCondition {
     /// Creates a new guard condition with no callback.
     pub fn new(context: &Context) -> Self {
-        Self::new_with_rcl_context(&mut context.handle.rcl_context.lock().unwrap(), None)
+        Self::new_with_context_handle(Arc::clone(&context.handle), None)
     }
 
     /// Creates a new guard condition with a callback.
@@ -88,8 +95,8 @@ impl GuardCondition {
     where
         F: Fn() + Send + Sync + 'static,
     {
-        Self::new_with_rcl_context(
-            &mut context.handle.rcl_context.lock().unwrap(),
+        Self::new_with_context_handle(
+            Arc::clone(&context.handle),
             Some(Box::new(callback) as Box<dyn Fn() + Send + Sync>),
         )
     }
@@ -98,23 +105,31 @@ impl GuardCondition {
     /// Note this function enables calling `Node::create_guard_condition`[1] without providing the Context separately
     ///
     /// [1]: Node::create_guard_condition
-    pub(crate) fn new_with_rcl_context(
-        context: &mut rcl_context_t,
+    pub(crate) fn new_with_context_handle(
+        context_handle: Arc<ContextHandle>,
         callback: Option<Box<dyn Fn() + Send + Sync>>,
     ) -> Self {
-        // SAFETY: Getting a zero initialized value is always safe
-        let mut guard_condition = unsafe { rcl_get_zero_initialized_guard_condition() };
-        unsafe {
-            // SAFETY: The context must be valid, and the guard condition must be zero-initialized
-            rcl_guard_condition_init(
-                &mut guard_condition,
-                context,
-                rcl_guard_condition_get_default_options(),
-            );
-        }
+        let rcl_guard_condition = {
+            let mut rcl_context = context_handle.rcl_context.lock().unwrap();
+            // SAFETY: Getting a zero initialized value is always safe
+            let mut guard_condition = unsafe { rcl_get_zero_initialized_guard_condition() };
+            unsafe {
+                // SAFETY: The context must be valid, and the guard condition must be zero-initialized
+                rcl_guard_condition_init(
+                    &mut guard_condition,
+                    &mut *rcl_context,
+                    rcl_guard_condition_get_default_options(),
+                );
+            }
+
+            Mutex::new(guard_condition)
+        };
 
         Self {
-            rcl_guard_condition: Mutex::new(guard_condition),
+            handle: GuardConditionHandle {
+                rcl_guard_condition,
+                context_handle,
+            },
             callback,
             in_use_by_wait_set: Arc::new(AtomicBool::new(false)),
         }
@@ -124,7 +139,7 @@ impl GuardCondition {
     pub fn trigger(&self) -> Result<(), RclrsError> {
         unsafe {
             // SAFETY: The rcl_guard_condition_t is valid.
-            rcl_trigger_guard_condition(&mut *self.rcl_guard_condition.lock().unwrap()).ok()?;
+            rcl_trigger_guard_condition(&mut *self.handle.rcl_guard_condition.lock().unwrap()).ok()?;
         }
         if let Some(callback) = &self.callback {
             callback();

--- a/rclrs/src/wait/guard_condition.rs
+++ b/rclrs/src/wait/guard_condition.rs
@@ -110,9 +110,9 @@ impl GuardCondition {
         callback: Option<Box<dyn Fn() + Send + Sync>>,
     ) -> Self {
         let rcl_guard_condition = {
-            let mut rcl_context = context_handle.rcl_context.lock().unwrap();
             // SAFETY: Getting a zero initialized value is always safe
             let mut guard_condition = unsafe { rcl_get_zero_initialized_guard_condition() };
+            let mut rcl_context = context_handle.rcl_context.lock().unwrap();
             unsafe {
                 // SAFETY: The context must be valid, and the guard condition must be zero-initialized
                 rcl_guard_condition_init(

--- a/rclrs/src/wait/guard_condition.rs
+++ b/rclrs/src/wait/guard_condition.rs
@@ -56,7 +56,7 @@ pub struct GuardCondition {
 /// on `rcl_context_t` by ensuring that this dependency is [dropped after][1] the
 /// `rcl_guard_condition_t`.
 ///
-/// [1] https://doc.rust-lang.org/reference/destructors.html
+/// [1]: <https://doc.rust-lang.org/reference/destructors.html>
 pub(crate) struct GuardConditionHandle {
     pub(crate) rcl_guard_condition: Mutex<rcl_guard_condition_t>,
     /// Keep the context alive for the whole lifecycle of the guard condition

--- a/rclrs/src/wait/guard_condition.rs
+++ b/rclrs/src/wait/guard_condition.rs
@@ -139,7 +139,8 @@ impl GuardCondition {
     pub fn trigger(&self) -> Result<(), RclrsError> {
         unsafe {
             // SAFETY: The rcl_guard_condition_t is valid.
-            rcl_trigger_guard_condition(&mut *self.handle.rcl_guard_condition.lock().unwrap()).ok()?;
+            rcl_trigger_guard_condition(&mut *self.handle.rcl_guard_condition.lock().unwrap())
+                .ok()?;
         }
         if let Some(callback) = &self.callback {
             callback();

--- a/rclrs/src/wait/guard_condition.rs
+++ b/rclrs/src/wait/guard_condition.rs
@@ -52,6 +52,11 @@ pub struct GuardCondition {
     pub(crate) in_use_by_wait_set: Arc<AtomicBool>,
 }
 
+/// Manage the lifecycle of an [`rcl_guard_condition_t`], including managing its dependency
+/// on [`rcl_context_t`] by ensuring that this dependency is [dropped after][1] the
+/// [`rcl_guard_condition_t`].
+///
+/// [1] https://doc.rust-lang.org/reference/destructors.html
 pub(crate) struct GuardConditionHandle {
     pub(crate) rcl_guard_condition: Mutex<rcl_guard_condition_t>,
     /// Keep the context alive for the whole lifecycle of the guard condition


### PR DESCRIPTION
For some time now we've noticed spurious segmentation faults and other test failures in CI. This PR aims to eliminate those entirely. I'll break down the problems we observed, followed by how they are being solved by this PR.

## Segmentation Faults

Our initial suspicion was that the segmentation faults were being caused by flaws in the drop order of various rcl entities (e.g. `rcl_context_t`, `rcl_node_t`, `rcl_publisher_t`, etc). This suspicion had a lot of merit since rcl specifies that all nodes and middleware primitives must be cleaned up (`fini`ed) before the `rcl_context_t` that they came  from gets `fini`ed. However, the way the rcl objects' lifecycles were being managed, if a `Node` struct gets dropped before its associated primitives (`Subscription`, `Publisher`, `Service`, `Client`) are dropped, then their `rcl_context_t` will get dropped while the `rcl_node_t` and various primitive rcl objects are still alive. This violates the contract that rcl stipulates and seemed like a very reasonable explanation for spurious segfaults.

### Initial solution

To address this, I introduced a `[_]Handle` struct specifically to manage the lifecycle of each rcl binding object that gets used by rclrs. For example we now have `ContextHandle`, `NodeHandle,` `PublisherHandle`, etc. We already had a `SubscriptionHandle` which served a similar purpose, and now all the other middleware entity types have a similar handle for themselves. The handle has two roles:
1. Ensure that the rcl object that it's responsible for is dropped correctly by implementing the `Drop` trait such that it cleans up the rcl object correctly.
2. Ensure that any lifecycle dependencies (e.g. primitives must not outlive their nodes, and nodes must not outlive their contexts) are guaranteed by the `[_]Handle` struct via RAII.

Applying this pattern consistently to all types in rclrs provides us with a sound and easily maintained way to ensure that we're always respecting the documented lifecycle contracts of rcl. If our initial suspicion about drop order flaws were correct, this would completely resolve the segmentation faults that we were experiencing. So with bated breath I ran the tests through an aggressive loop and ...it still segfaulted....

### The actual cause

While the `Initial Solution` was a worthwhile and legitimate thing to fix, it ultimately turned out to not be the cause of the segfaults we were observing (although it does fix other segfaults that could have happened in other scenarios). Ultimately the conclusive cause of the segfaults was this:

#### rcutils and (much more so) FastDDS perform unprotected mutations to global variables inside of a variety of entity initialization and cleanup functions.

rcutils has [some ongoing efforts](https://github.com/ros2/rcutils/pull/427) to weed out its use of unprotected mutations to global variables, but (1) the direction of those efforts is controversial, so there's no telling when they'll be merged, if ever, and (2) the vast vast majority of segmentation faults are originating in FastDDS, which suggests they are making far more extensive use of global variables and might not be likely to change that aspect of their implementation any time soon. Taking all of that into account, I am left to conclude that we must accommodate the assumption that **all calls** to rcl entity initialization or cleanup functions may be unsafe to run concurrently no matter their arguments nor their relationship to each other.

To deal with this, I've introduced a global (but thread-safe) static `ENTITY_LIFECYCLE_MUTEX` which must be locked while any entity initialization or cleanup function is running. This ensures that no matter what unprotected global variables might be getting modified by rcutils or the rmw implementation, there will not be any data races or race conditions between those calls.

Since initialization and cleanup are both extremely low-frequency occurrences and also do not block for any substantial amount of time, I think it is reasonable to have a single global lock for them. The alternative, which is to risk segmentation faults depending on the choice of rmw implementation and the mood that rcutils happens to be in, is something I would consider unacceptable.

## Empty Graph Tests

Besides segmentation faults, we also observed sporadic failures in the `test_graph_empty` test case. This is easily explained by two facts:
1. `cargo test` by default will run as many tests at once as possible, according to the number of threads available on the current system
2. `test_graph_empty` assumes that the system's node graph will be empty because there are no nodes, topics, etc being constructed within the scope of the test

The assumption made by (2) is trivially violated by (1) if `test_graph_empty` ever happens to be run at the same time as any other test that does happen to create nodes or middleware primitives.

Prior to this PR, the only way to change the domain ID of a context programmatically within an `rclrs` application was to set the environment variable `ROS_DOMAIN_ID` using `std::env::set_var`. That would not help in this case because changing the environment variable anywhere within the application would modify it across all new contexts within the application, and all the tests being run in parallel are all being run within the same application.

To solve this, I've introduced an API for providing an `InitOptions` struct while creating a new `Context`. The `InitOptions` struct is the rclrs equivalent to `rcl_init_options_t`, which allows users to specify a domain ID for the context that may be different than what is specified by the `ROS_DOMAIN_ID` environment variable. Taking advantage of this, we can set the domain ID of the context used by `test_graph_empty` to be something different from the rest of the tests.

~~I've arbitrarily chosen `99`, but that means tests may fail if the system running the tests happens to have its `ROS_DOMAIN_ID` set to 99. We could consider putting in a check and remedy for this if anyone is concerned about making sure our tests have absolutely no possible edge cases.~~ Edit: If the `ROS_DOMAIN_ID` environment variable is unset or set to anything besides `99`, then `test_graph_empty` will use 99 as its domain ID. But if `ROS_DOMAIN_ID` happens to be set to `99` then we will use 98 for the domain ID of `test_graph_empty` to avoid conflicts with any other tests that may run simultaneously.