### PR TITLE
Fix panic on sequence_init() when size is 0

### DIFF
--- a/rosidl_runtime_rs/src/sequence.rs
+++ b/rosidl_runtime_rs/src/sequence.rs
@@ -510,8 +510,10 @@ macro_rules! impl_sequence_alloc_for_primitive_type {
                 unsafe {
                     // This allocates space and sets seq.size and seq.capacity to size
                     let ret = $init_func(seq as *mut _, size);
-                    // Zero memory, since it will be uninitialized if there is no default value
-                    std::ptr::write_bytes(seq.data, 0u8, size);
+                    if !seq.data.is_null() {
+                        // Zero memory, since it will be uninitialized if there is no default value
+                        std::ptr::write_bytes(seq.data, 0u8, size);
+                    }
                     ret
                 }
             }


### PR DESCRIPTION
resolves: #406

In Rust 1.78, a panic occurs when publishing sequence-type messages containing array types, which could be fixed by adding null pointer handling.
