### PR TITLE
Add in missing nullptr check when calling `std::slice::from_raw_parts`

### DIFF
--- a/rosidl_runtime_rs/src/sequence.rs
+++ b/rosidl_runtime_rs/src/sequence.rs
@@ -261,18 +261,26 @@ where
     ///
     /// Equivalent to `&seq[..]`.
     pub fn as_slice(&self) -> &[T] {
-        // SAFETY: self.data points to self.size consecutive, initialized elements and
-        // isn't modified externally.
-        unsafe { std::slice::from_raw_parts(self.data, self.size) }
+        if self.data.is_null() {
+            &[]
+        } else {
+            // SAFETY: self.data is not null and points to self.size consecutive,
+            // initialized elements and isn't modified externally.
+            unsafe { std::slice::from_raw_parts(self.data, self.size) }
+        }
     }
 
     /// Extracts a mutable slice containing the entire sequence.
     ///
     /// Equivalent to `&mut seq[..]`.
     pub fn as_mut_slice(&mut self) -> &mut [T] {
-        // SAFETY: self.data points to self.size consecutive, initialized elements and
-        // isn't modified externally.
-        unsafe { std::slice::from_raw_parts_mut(self.data, self.size) }
+        if self.data.is_null() {
+            &mut []
+        } else {
+            // SAFETY: self.data is not null and points to self.size consecutive,
+            // initialized elements and isn't modified externally.
+            unsafe { std::slice::from_raw_parts_mut(self.data, self.size) }
+        }
     }
 }
 


### PR DESCRIPTION
Seems like back in #407 we added a conditional to not call [write_bytes()](https://doc.rust-lang.org/core/ptr/fn.write_bytes.html) if the internal data buffer of a Sequence was a nullptr. 

It is true that it is unsafe to pass a nullptr to `write_bytes` 
> the pointer must be non-null and properly aligned.

But this breaks our Sequence abstraction because now an empty sequence has a nullptr for its buffer. So later, when we may call [from_raw_parts()](https://doc.rust-lang.org/std/slice/fn.from_raw_parts.html#safety), we panic if our Sequence is empty.

> data must be non-null and aligned even for zero-length slices.

So this PR is a small hack for #411, but doesn't fundamentally address the issue. 

---

Taking a deeper look at the BoundedSequence and  Sequence structs, I think we should refactor them to use something like [RawVec](https://doc.rust-lang.org/stable/src/alloc/raw_vec.rs.html#69) (The RawVec impl in the std lib actually uses [Unique](https://doc.rust-lang.org/stable/src/core/ptr/unique.rs.html#36) which is currently unstable :disappointed: ). We know the type that a Sequence or BoundedSequence is constructed with, so there should be no reason our internal buffer isn't non-zero and aligned. 

`Vec::<i32>::default().is_empty()` doesn't panic so `Sequence::<i32>::default().is_empty()` shouldn't panic.