### PR TITLE
Wrap slice::from_raw_parts to be compatible with rcl

### DIFF
--- a/rclrs/src/node/graph.rs
+++ b/rclrs/src/node/graph.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::HashMap,
     ffi::{CStr, CString},
-    slice,
 };
 
 use crate::{rcl_bindings::*, Node, RclrsError, ToResult};
@@ -182,8 +181,8 @@ impl Node {
         // namespaces are populated with valid data
         let (names_slice, namespaces_slice) = unsafe {
             (
-                slice::from_raw_parts(rcl_names.data, rcl_names.size),
-                slice::from_raw_parts(rcl_namespaces.data, rcl_namespaces.size),
+                rcl_from_raw_parts(rcl_names.data, rcl_names.size),
+                rcl_from_raw_parts(rcl_namespaces.data, rcl_namespaces.size),
             )
         };
 
@@ -230,9 +229,9 @@ impl Node {
         // SAFETY: The previous function successfully returned, so the arrays are valid
         let (names_slice, namespaces_slice, enclaves_slice) = unsafe {
             (
-                slice::from_raw_parts(rcl_names.data, rcl_names.size),
-                slice::from_raw_parts(rcl_namespaces.data, rcl_namespaces.size),
-                slice::from_raw_parts(rcl_enclaves.data, rcl_enclaves.size),
+                rcl_from_raw_parts(rcl_names.data, rcl_names.size),
+                rcl_from_raw_parts(rcl_namespaces.data, rcl_namespaces.size),
+                rcl_from_raw_parts(rcl_enclaves.data, rcl_enclaves.size),
             )
         };
 
@@ -379,9 +378,9 @@ impl Node {
             .ok()?;
         }
 
-        // SAFETY: The previous call returned successfully, so the slice is valid
+        // SAFETY: The previous call returned successfully, so the data is valid
         let topic_endpoint_infos_slice = unsafe {
-            slice::from_raw_parts(rcl_publishers_info.info_array, rcl_publishers_info.size)
+            rcl_from_raw_parts(rcl_publishers_info.info_array, rcl_publishers_info.size)
         };
 
         // SAFETY: Because the rcl call returned successfully, each element of the slice points
@@ -422,7 +421,7 @@ fn convert_names_and_types(
 
     // SAFETY: Safe if the rcl_names_and_types arg has been initialized by the caller
     let name_slice = unsafe {
-        slice::from_raw_parts(
+        rcl_from_raw_parts(
             rcl_names_and_types.names.data,
             rcl_names_and_types.names.size,
         )
@@ -438,7 +437,7 @@ fn convert_names_and_types(
         // SAFETY: Safe as long as rcl_names_and_types was populated by the caller
         let types: Vec<String> = unsafe {
             let p = rcl_names_and_types.types.add(idx);
-            slice::from_raw_parts((*p).data, (*p).size)
+            rcl_from_raw_parts((*p).data, (*p).size)
                 .iter()
                 .map(|s| {
                     let cstr = CStr::from_ptr(*s);

--- a/rclrs/src/node/graph.rs
+++ b/rclrs/src/node/graph.rs
@@ -379,9 +379,8 @@ impl Node {
         }
 
         // SAFETY: The previous call returned successfully, so the data is valid
-        let topic_endpoint_infos_slice = unsafe {
-            rcl_from_raw_parts(rcl_publishers_info.info_array, rcl_publishers_info.size)
-        };
+        let topic_endpoint_infos_slice =
+            unsafe { rcl_from_raw_parts(rcl_publishers_info.info_array, rcl_publishers_info.size) };
 
         // SAFETY: Because the rcl call returned successfully, each element of the slice points
         // to a valid topic_endpoint_info object, which contains valid C strings

--- a/rclrs/src/parameter/override_map.rs
+++ b/rclrs/src/parameter/override_map.rs
@@ -49,9 +49,9 @@ impl RclParamsIter<'_> {
             }
         } else {
             let node_name_ptrs =
-                std::slice::from_raw_parts((*rcl_params).node_names, (*rcl_params).num_nodes);
+                rcl_from_raw_parts((*rcl_params).node_names, (*rcl_params).num_nodes);
             let rcl_node_params =
-                std::slice::from_raw_parts((*rcl_params).params, (*rcl_params).num_nodes);
+                rcl_from_raw_parts((*rcl_params).params, (*rcl_params).num_nodes);
             Self {
                 node_name_ptrs,
                 rcl_node_params,
@@ -83,8 +83,8 @@ impl<'a> RclNodeParamsIter<'a> {
     // sizes or dangling pointers.
     pub unsafe fn new(rcl_node_params: &'a rcl_node_params_t) -> Self {
         let param_name_ptrs =
-            std::slice::from_raw_parts(rcl_node_params.parameter_names, rcl_node_params.num_params);
-        let rcl_variants = std::slice::from_raw_parts(
+            rcl_from_raw_parts(rcl_node_params.parameter_names, rcl_node_params.num_params);
+        let rcl_variants = rcl_from_raw_parts(
             rcl_node_params.parameter_values,
             rcl_node_params.num_params,
         );

--- a/rclrs/src/parameter/override_map.rs
+++ b/rclrs/src/parameter/override_map.rs
@@ -50,8 +50,7 @@ impl RclParamsIter<'_> {
         } else {
             let node_name_ptrs =
                 rcl_from_raw_parts((*rcl_params).node_names, (*rcl_params).num_nodes);
-            let rcl_node_params =
-                rcl_from_raw_parts((*rcl_params).params, (*rcl_params).num_nodes);
+            let rcl_node_params = rcl_from_raw_parts((*rcl_params).params, (*rcl_params).num_nodes);
             Self {
                 node_name_ptrs,
                 rcl_node_params,
@@ -84,10 +83,8 @@ impl<'a> RclNodeParamsIter<'a> {
     pub unsafe fn new(rcl_node_params: &'a rcl_node_params_t) -> Self {
         let param_name_ptrs =
             rcl_from_raw_parts(rcl_node_params.parameter_names, rcl_node_params.num_params);
-        let rcl_variants = rcl_from_raw_parts(
-            rcl_node_params.parameter_values,
-            rcl_node_params.num_params,
-        );
+        let rcl_variants =
+            rcl_from_raw_parts(rcl_node_params.parameter_values, rcl_node_params.num_params);
         Self {
             param_name_ptrs,
             rcl_variants,

--- a/rclrs/src/parameter/value.rs
+++ b/rclrs/src/parameter/value.rs
@@ -460,25 +460,25 @@ impl ParameterValue {
             ParameterValue::String(s.into())
         } else if !var.byte_array_value.is_null() {
             let rcl_byte_array = &*var.byte_array_value;
-            let slice = std::slice::from_raw_parts(rcl_byte_array.values, rcl_byte_array.size);
+            let slice = rcl_from_raw_parts(rcl_byte_array.values, rcl_byte_array.size);
             ParameterValue::ByteArray(slice.into())
         } else if !var.bool_array_value.is_null() {
             let rcl_bool_array = &*var.bool_array_value;
-            let slice = std::slice::from_raw_parts(rcl_bool_array.values, rcl_bool_array.size);
+            let slice = rcl_from_raw_parts(rcl_bool_array.values, rcl_bool_array.size);
             ParameterValue::BoolArray(slice.into())
         } else if !var.integer_array_value.is_null() {
             let rcl_integer_array = &*var.integer_array_value;
             let slice =
-                std::slice::from_raw_parts(rcl_integer_array.values, rcl_integer_array.size);
+                rcl_from_raw_parts(rcl_integer_array.values, rcl_integer_array.size);
             ParameterValue::IntegerArray(slice.into())
         } else if !var.double_array_value.is_null() {
             let rcl_double_array = &*var.double_array_value;
-            let slice = std::slice::from_raw_parts(rcl_double_array.values, rcl_double_array.size);
+            let slice = rcl_from_raw_parts(rcl_double_array.values, rcl_double_array.size);
             ParameterValue::DoubleArray(slice.into())
         } else if !var.string_array_value.is_null() {
             let rcutils_string_array = &*var.string_array_value;
             let slice =
-                std::slice::from_raw_parts(rcutils_string_array.data, rcutils_string_array.size);
+                rcl_from_raw_parts(rcutils_string_array.data, rcutils_string_array.size);
             let strings = slice
                 .iter()
                 .map(|&ptr| {

--- a/rclrs/src/parameter/value.rs
+++ b/rclrs/src/parameter/value.rs
@@ -468,8 +468,7 @@ impl ParameterValue {
             ParameterValue::BoolArray(slice.into())
         } else if !var.integer_array_value.is_null() {
             let rcl_integer_array = &*var.integer_array_value;
-            let slice =
-                rcl_from_raw_parts(rcl_integer_array.values, rcl_integer_array.size);
+            let slice = rcl_from_raw_parts(rcl_integer_array.values, rcl_integer_array.size);
             ParameterValue::IntegerArray(slice.into())
         } else if !var.double_array_value.is_null() {
             let rcl_double_array = &*var.double_array_value;
@@ -477,8 +476,7 @@ impl ParameterValue {
             ParameterValue::DoubleArray(slice.into())
         } else if !var.string_array_value.is_null() {
             let rcutils_string_array = &*var.string_array_value;
-            let slice =
-                rcl_from_raw_parts(rcutils_string_array.data, rcutils_string_array.size);
+            let slice = rcl_from_raw_parts(rcutils_string_array.data, rcutils_string_array.size);
             let strings = slice
                 .iter()
                 .map(|&ptr| {

--- a/rclrs/src/rcl_bindings.rs
+++ b/rclrs/src/rcl_bindings.rs
@@ -148,3 +148,25 @@ cfg_if::cfg_if! {
         pub const RMW_GID_STORAGE_SIZE: usize = rmw_gid_storage_size_constant;
     }
 }
+
+/// Wrapper around [`std::slice::from_raw_parts`] that accommodates the rcl
+/// convention of providing a null pointer to represent empty arrays. This
+/// violates the safety requirements of [`std::slice::from_raw_parts`].
+///
+/// # Safety
+///
+/// Behavior is undefined in all the same scenarios as [`slice::from_raw_parts`]
+/// (see its safety section) except that null pointers are allowed and will
+/// return a slice to an empty array.
+pub(crate) unsafe fn rcl_from_raw_parts<'a, T>(data: *const T, len: usize) -> &'a [T] {
+    if data.is_null() {
+        &[]
+    } else {
+        // SAFETY: The user of this function is instructed to abide by all the
+        // safety requirements of slice::from_raw_parts except for null pointer
+        // values, which are checked above.
+        unsafe {
+            std::slice::from_raw_parts(data, len)
+        }
+    }
+}

--- a/rclrs/src/rcl_bindings.rs
+++ b/rclrs/src/rcl_bindings.rs
@@ -165,8 +165,6 @@ pub(crate) unsafe fn rcl_from_raw_parts<'a, T>(data: *const T, len: usize) -> &'
         // SAFETY: The user of this function is instructed to abide by all the
         // safety requirements of slice::from_raw_parts except for null pointer
         // values, which are checked above.
-        unsafe {
-            std::slice::from_raw_parts(data, len)
-        }
+        unsafe { std::slice::from_raw_parts(data, len) }
     }
 }


### PR DESCRIPTION
Similar to #416, there are numerous places within rclrs that are at risk of runtime panics because `std::slice::from_raw_parts` may panic when it receives null pointer values. In particular I got this panic while running `cargo test` on rclrs:

```
unsafe precondition(s) violated: slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`
stack backtrace:
   0: rust_begin_unwind
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/std/src/panicking.rs:652:5
   1: core::panicking::panic_nounwind_fmt::runtime
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/core/src/panicking.rs:110:18
   2: core::panicking::panic_nounwind_fmt
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/core/src/panicking.rs:120:5
   3: core::panicking::panic_nounwind
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/core/src/panicking.rs:219:5
   4: core::slice::raw::from_raw_parts::precondition_check
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/core/src/ub_checks.rs:68:21
   5: core::slice::raw::from_raw_parts
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/core/src/ub_checks.rs:75:17
   6: rclrs::node::graph::convert_names_and_types
             at ./src/node/graph.rs:425:9
   7: rclrs::node::graph::<impl rclrs::node::Node>::get_names_and_types_by_node
             at ./src/node/graph.rs:345:12
   8: rclrs::node::graph::<impl rclrs::node::Node>::get_publisher_names_and_types_by_node
             at ./src/node/graph.rs:86:9
   9: rclrs::node::graph::tests::test_graph_empty
             at ./src/node/graph.rs:493:32
  10: rclrs::node::graph::tests::test_graph_empty::{{closure}}
             at ./src/node/graph.rs:462:26
  11: core::ops::function::FnOnce::call_once
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/core/src/ops/function.rs:250:5
  12: core::ops::function::FnOnce::call_once
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
thread caused non-unwinding panic. aborting.
```

This PR adds a new internal function `rcl_from_raw_parts` which wraps `std::slice::from_raw_parts` so that it's compatible with rcl's practice of returning null pointers to represent empty arrays. Then we replace every call to `std::slice::from_raw_parts` with `rcl_from_raw_parts`.