### PR TITLE
Use latest stable Rust CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,7 +51,7 @@ jobs:
         use-ros2-testing: ${{ matrix.ros_distribution == 'rolling' }}
 
     - name: Setup Rust
-      uses: dtolnay/rust-toolchain@1.74.0
+      uses: dtolnay/rust-toolchain@stable
       with:
         components: clippy, rustfmt
 


### PR DESCRIPTION
This PR will test whether using the latest stable version of Rust will result in cause CI to fail as suspected in https://github.com/ros2-rust/ros2_rust/pull/419#issuecomment-2391502532