### PR TITLE
Add a .repos file for jazzy

### DIFF
--- a/ros2_rust_jazzy.repos
+++ b/ros2_rust_jazzy.repos
@@ -1,0 +1,29 @@
+repositories:
+  ros2/common_interfaces:
+    type: git
+    url: https://github.com/ros2/common_interfaces.git
+    version: jazzy
+  ros2/example_interfaces:
+    type: git
+    url: https://github.com/ros2/example_interfaces.git
+    version: jazzy
+  ros2/rcl_interfaces:
+    type: git
+    url: https://github.com/ros2/rcl_interfaces.git
+    version: jazzy
+  ros2/test_interface_files:
+    type: git
+    url: https://github.com/ros2/test_interface_files.git
+    version: jazzy
+  ros2/rosidl_core:
+    type: git
+    url: https://github.com/ros2/rosidl_core.git
+    version: jazzy
+  ros2/rosidl_defaults:
+    type: git
+    url: https://github.com/ros2/rosidl_defaults.git
+    version: jazzy
+  ros2/unique_identifier_msgs:
+    type: git
+    url: https://github.com/ros2/unique_identifier_msgs.git
+    version: jazzy


### PR DESCRIPTION
To address #424 this PR adds a .repos file for jazzy.

The new repos file is exactly the same as the file for rolling, but the branches have been switched to jazzy. I used this on 24.04 with the jazzy distro sourced and the build and test went fine.