### PR TITLE
API Changes: execution structure, options pattern, and arcs

### DIFF
--- a/examples/message_demo/Cargo.toml
+++ b/examples/message_demo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "examples_rclrs_message_demo"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Nikolai Morin <nnmmgit@gmail.com>"]
 edition = "2021"
 
@@ -12,7 +12,7 @@ path = "src/message_demo.rs"
 anyhow = {version = "1", features = ["backtrace"]}
 
 [dependencies.rclrs]
-version = "0.4"
+version = "0.5"
 
 [dependencies.rosidl_runtime_rs]
 version = "0.4"

--- a/examples/message_demo/src/message_demo.rs
+++ b/examples/message_demo/src/message_demo.rs
@@ -141,8 +141,10 @@ fn demonstrate_pubsub() -> Result<(), Error> {
     let mut executor = rclrs::Context::default_from_env()?.create_basic_executor();
     let node = executor.create_node("message_demo")?;
 
-    let idiomatic_publisher = node.create_publisher::<rclrs_example_msgs::msg::VariousTypes>("topic")?;
-    let direct_publisher = node.create_publisher::<rclrs_example_msgs::msg::rmw::VariousTypes>("topic")?;
+    let idiomatic_publisher =
+        node.create_publisher::<rclrs_example_msgs::msg::VariousTypes>("topic")?;
+    let direct_publisher =
+        node.create_publisher::<rclrs_example_msgs::msg::rmw::VariousTypes>("topic")?;
 
     let _idiomatic_subscription = node
         .create_subscription::<rclrs_example_msgs::msg::VariousTypes, _>(

--- a/examples/message_demo/src/message_demo.rs
+++ b/examples/message_demo/src/message_demo.rs
@@ -141,14 +141,8 @@ fn demonstrate_pubsub() -> Result<(), Error> {
     let mut executor = rclrs::Context::default_from_env()?.create_basic_executor();
     let node = executor.create_node("message_demo")?;
 
-    let idiomatic_publisher = node.create_publisher::<rclrs_example_msgs::msg::VariousTypes>(
-        "topic",
-        rclrs::QOS_PROFILE_DEFAULT,
-    )?;
-    let direct_publisher = node.create_publisher::<rclrs_example_msgs::msg::rmw::VariousTypes>(
-        "topic",
-        rclrs::QOS_PROFILE_DEFAULT,
-    )?;
+    let idiomatic_publisher = node.create_publisher::<rclrs_example_msgs::msg::VariousTypes>("topic")?;
+    let direct_publisher = node.create_publisher::<rclrs_example_msgs::msg::rmw::VariousTypes>("topic")?;
 
     let _idiomatic_subscription = node
         .create_subscription::<rclrs_example_msgs::msg::VariousTypes, _>(

--- a/examples/message_demo/src/message_demo.rs
+++ b/examples/message_demo/src/message_demo.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryInto, env, sync::Arc};
+use std::convert::TryInto;
 
 use anyhow::{Error, Result};
 use rosidl_runtime_rs::{seq, BoundedSequence, Message, Sequence};
@@ -138,8 +138,8 @@ fn demonstrate_sequences() {
 fn demonstrate_pubsub() -> Result<(), Error> {
     println!("================== Interoperability demo ==================");
     // Demonstrate interoperability between idiomatic and RMW-native message types
-    let context = rclrs::Context::new(env::args())?;
-    let node = rclrs::create_node(&context, "message_demo")?;
+    let mut executor = rclrs::Context::default_from_env()?.create_basic_executor();
+    let node = executor.create_node("message_demo")?;
 
     let idiomatic_publisher = node.create_publisher::<rclrs_example_msgs::msg::VariousTypes>(
         "topic",
@@ -166,10 +166,10 @@ fn demonstrate_pubsub() -> Result<(), Error> {
         )?;
     println!("Sending idiomatic message.");
     idiomatic_publisher.publish(rclrs_example_msgs::msg::VariousTypes::default())?;
-    rclrs::spin_once(Arc::clone(&node), None)?;
+    executor.spin(rclrs::SpinOptions::spin_once())?;
     println!("Sending RMW-native message.");
     direct_publisher.publish(rclrs_example_msgs::msg::rmw::VariousTypes::default())?;
-    rclrs::spin_once(Arc::clone(&node), None)?;
+    executor.spin(rclrs::SpinOptions::spin_once())?;
 
     Ok(())
 }

--- a/examples/message_demo/src/message_demo.rs
+++ b/examples/message_demo/src/message_demo.rs
@@ -153,13 +153,11 @@ fn demonstrate_pubsub() -> Result<(), Error> {
     let _idiomatic_subscription = node
         .create_subscription::<rclrs_example_msgs::msg::VariousTypes, _>(
             "topic",
-            rclrs::QOS_PROFILE_DEFAULT,
             move |_msg: rclrs_example_msgs::msg::VariousTypes| println!("Got idiomatic message!"),
         )?;
     let _direct_subscription = node
         .create_subscription::<rclrs_example_msgs::msg::rmw::VariousTypes, _>(
             "topic",
-            rclrs::QOS_PROFILE_DEFAULT,
             move |_msg: rclrs_example_msgs::msg::rmw::VariousTypes| {
                 println!("Got RMW-native message!")
             },

--- a/examples/minimal_client_service/Cargo.toml
+++ b/examples/minimal_client_service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "examples_rclrs_minimal_client_service"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Esteve Fernandez <esteve@apache.org>"]
 edition = "2021"
 
@@ -21,7 +21,7 @@ anyhow = {version = "1", features = ["backtrace"]}
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time"] }
 
 [dependencies.rclrs]
-version = "0.4"
+version = "0.5"
 
 [dependencies.rosidl_runtime_rs]
 version = "0.4"

--- a/examples/minimal_client_service/src/minimal_client.rs
+++ b/examples/minimal_client_service/src/minimal_client.rs
@@ -1,11 +1,9 @@
-use std::env;
-
 use anyhow::{Error, Result};
 
 fn main() -> Result<(), Error> {
-    let context = rclrs::Context::new(env::args())?;
+    let mut executor = rclrs::Context::default_from_env()?.create_basic_executor();
 
-    let node = rclrs::create_node(&context, "minimal_client")?;
+    let node = executor.create_node("minimal_client")?;
 
     let client = node.create_client::<example_interfaces::srv::AddTwoInts>("add_two_ints")?;
 
@@ -30,5 +28,5 @@ fn main() -> Result<(), Error> {
     std::thread::sleep(std::time::Duration::from_millis(500));
 
     println!("Waiting for response");
-    rclrs::spin(node).map_err(|err| err.into())
+    executor.spin(rclrs::SpinOptions::default()).map_err(|err| err.into())
 }

--- a/examples/minimal_client_service/src/minimal_client.rs
+++ b/examples/minimal_client_service/src/minimal_client.rs
@@ -28,5 +28,7 @@ fn main() -> Result<(), Error> {
     std::thread::sleep(std::time::Duration::from_millis(500));
 
     println!("Waiting for response");
-    executor.spin(rclrs::SpinOptions::default()).map_err(|err| err.into())
+    executor
+        .spin(rclrs::SpinOptions::default())
+        .map_err(|err| err.into())
 }

--- a/examples/minimal_client_service/src/minimal_client_async.rs
+++ b/examples/minimal_client_service/src/minimal_client_async.rs
@@ -20,7 +20,8 @@ async fn main() -> Result<(), Error> {
 
     println!("Waiting for response");
 
-    let rclrs_spin = tokio::task::spawn_blocking(move || executor.spin(rclrs::SpinOptions::default()));
+    let rclrs_spin =
+        tokio::task::spawn_blocking(move || executor.spin(rclrs::SpinOptions::default()));
 
     let response = future.await?;
     println!(

--- a/examples/minimal_client_service/src/minimal_client_async.rs
+++ b/examples/minimal_client_service/src/minimal_client_async.rs
@@ -1,12 +1,10 @@
-use std::env;
-
 use anyhow::{Error, Result};
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    let context = rclrs::Context::new(env::args())?;
+    let mut executor = rclrs::Context::default_from_env()?.create_basic_executor();
 
-    let node = rclrs::create_node(&context, "minimal_client")?;
+    let node = executor.create_node("minimal_client")?;
 
     let client = node.create_client::<example_interfaces::srv::AddTwoInts>("add_two_ints")?;
 
@@ -22,7 +20,7 @@ async fn main() -> Result<(), Error> {
 
     println!("Waiting for response");
 
-    let rclrs_spin = tokio::task::spawn_blocking(move || rclrs::spin(node));
+    let rclrs_spin = tokio::task::spawn_blocking(move || executor.spin(rclrs::SpinOptions::default()));
 
     let response = future.await?;
     println!(

--- a/examples/minimal_client_service/src/minimal_service.rs
+++ b/examples/minimal_client_service/src/minimal_service.rs
@@ -19,5 +19,7 @@ fn main() -> Result<(), Error> {
         .create_service::<example_interfaces::srv::AddTwoInts, _>("add_two_ints", handle_service)?;
 
     println!("Starting server");
-    executor.spin(rclrs::SpinOptions::default()).map_err(|err| err.into())
+    executor
+        .spin(rclrs::SpinOptions::default())
+        .map_err(|err| err.into())
 }

--- a/examples/minimal_client_service/src/minimal_service.rs
+++ b/examples/minimal_client_service/src/minimal_service.rs
@@ -1,5 +1,3 @@
-use std::env;
-
 use anyhow::{Error, Result};
 
 fn handle_service(
@@ -13,13 +11,13 @@ fn handle_service(
 }
 
 fn main() -> Result<(), Error> {
-    let context = rclrs::Context::new(env::args())?;
+    let mut executor = rclrs::Context::default_from_env()?.create_basic_executor();
 
-    let node = rclrs::create_node(&context, "minimal_service")?;
+    let node = executor.create_node("minimal_service")?;
 
     let _server = node
         .create_service::<example_interfaces::srv::AddTwoInts, _>("add_two_ints", handle_service)?;
 
     println!("Starting server");
-    rclrs::spin(node).map_err(|err| err.into())
+    executor.spin(rclrs::SpinOptions::default()).map_err(|err| err.into())
 }

--- a/examples/minimal_pub_sub/Cargo.toml
+++ b/examples/minimal_pub_sub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "examples_rclrs_minimal_pub_sub"
-version = "0.4.1"
+version = "0.5.0"
 # This project is not military-sponsored, Jacob's employment contract just requires him to use this email address
 authors = ["Esteve Fernandez <esteve@apache.org>", "Nikolai Morin <nnmmgit@gmail.com>", "Jacob Hassold <jacob.a.hassold.civ@army.mil>"]
 edition = "2021"
@@ -29,7 +29,7 @@ path = "src/zero_copy_publisher.rs"
 anyhow = {version = "1", features = ["backtrace"]}
 
 [dependencies.rclrs]
-version = "0.4"
+version = "0.5"
 
 [dependencies.rosidl_runtime_rs]
 version = "0.4"

--- a/examples/minimal_pub_sub/src/minimal_publisher.rs
+++ b/examples/minimal_pub_sub/src/minimal_publisher.rs
@@ -1,11 +1,10 @@
-use std::env;
-
 use anyhow::{Error, Result};
 
 fn main() -> Result<(), Error> {
-    let context = rclrs::Context::new(env::args())?;
+    let context = rclrs::Context::default_from_env()?;
+    let executor = context.create_basic_executor();
 
-    let node = rclrs::create_node(&context, "minimal_publisher")?;
+    let node = executor.create_node("minimal_publisher")?;
 
     let publisher =
         node.create_publisher::<std_msgs::msg::String>("topic", rclrs::QOS_PROFILE_DEFAULT)?;

--- a/examples/minimal_pub_sub/src/minimal_publisher.rs
+++ b/examples/minimal_pub_sub/src/minimal_publisher.rs
@@ -6,8 +6,7 @@ fn main() -> Result<(), Error> {
 
     let node = executor.create_node("minimal_publisher")?;
 
-    let publisher =
-        node.create_publisher::<std_msgs::msg::String>("topic", rclrs::QOS_PROFILE_DEFAULT)?;
+    let publisher = node.create_publisher::<std_msgs::msg::String>("topic")?;
 
     let mut message = std_msgs::msg::String::default();
 

--- a/examples/minimal_pub_sub/src/minimal_subscriber.rs
+++ b/examples/minimal_pub_sub/src/minimal_subscriber.rs
@@ -17,5 +17,7 @@ fn main() -> Result<(), Error> {
         },
     )?;
 
-    executor.spin(rclrs::SpinOptions::default()).map_err(|err| err.into())
+    executor
+        .spin(rclrs::SpinOptions::default())
+        .map_err(|err| err.into())
 }

--- a/examples/minimal_pub_sub/src/minimal_subscriber.rs
+++ b/examples/minimal_pub_sub/src/minimal_subscriber.rs
@@ -10,7 +10,6 @@ fn main() -> Result<(), Error> {
 
     let _subscription = node.create_subscription::<std_msgs::msg::String, _>(
         "topic",
-        rclrs::QOS_PROFILE_DEFAULT,
         move |msg: std_msgs::msg::String| {
             num_messages += 1;
             println!("I heard: '{}'", msg.data);

--- a/examples/minimal_pub_sub/src/minimal_subscriber.rs
+++ b/examples/minimal_pub_sub/src/minimal_subscriber.rs
@@ -1,11 +1,10 @@
-use std::env;
-
 use anyhow::{Error, Result};
 
 fn main() -> Result<(), Error> {
-    let context = rclrs::Context::new(env::args())?;
+    let context = rclrs::Context::default_from_env()?;
+    let mut executor = context.create_basic_executor();
 
-    let node = rclrs::create_node(&context, "minimal_subscriber")?;
+    let node = executor.create_node("minimal_subscriber")?;
 
     let mut num_messages: usize = 0;
 
@@ -19,5 +18,5 @@ fn main() -> Result<(), Error> {
         },
     )?;
 
-    rclrs::spin(node).map_err(|err| err.into())
+    executor.spin(rclrs::SpinOptions::default()).map_err(|err| err.into())
 }

--- a/examples/minimal_pub_sub/src/minimal_two_nodes.rs
+++ b/examples/minimal_pub_sub/src/minimal_two_nodes.rs
@@ -12,7 +12,11 @@ struct MinimalSubscriber {
 }
 
 impl MinimalSubscriber {
-    pub fn new(executor: &rclrs::Executor, name: &str, topic: &str) -> Result<Arc<Self>, rclrs::RclrsError> {
+    pub fn new(
+        executor: &rclrs::Executor,
+        name: &str,
+        topic: &str,
+    ) -> Result<Arc<Self>, rclrs::RclrsError> {
         let node = executor.create_node(name)?;
         let minimal_subscriber = Arc::new(MinimalSubscriber {
             num_messages: 0.into(),
@@ -48,8 +52,10 @@ fn main() -> Result<(), Error> {
     let mut executor = rclrs::Context::default_from_env()?.create_basic_executor();
     let publisher_node = executor.create_node("minimal_publisher")?;
 
-    let _subscriber_node_one = MinimalSubscriber::new(&executor, "minimal_subscriber_one", "topic")?;
-    let _subscriber_node_two = MinimalSubscriber::new(&executor, "minimal_subscriber_two", "topic")?;
+    let _subscriber_node_one =
+        MinimalSubscriber::new(&executor, "minimal_subscriber_one", "topic")?;
+    let _subscriber_node_two =
+        MinimalSubscriber::new(&executor, "minimal_subscriber_two", "topic")?;
 
     let publisher = publisher_node.create_publisher::<std_msgs::msg::String>("topic")?;
 
@@ -65,5 +71,7 @@ fn main() -> Result<(), Error> {
         }
     });
 
-    executor.spin(rclrs::SpinOptions::default()).map_err(|err| err.into())
+    executor
+        .spin(rclrs::SpinOptions::default())
+        .map_err(|err| err.into())
 }

--- a/examples/minimal_pub_sub/src/minimal_two_nodes.rs
+++ b/examples/minimal_pub_sub/src/minimal_two_nodes.rs
@@ -1,23 +1,19 @@
-use std::{
-    env,
-    sync::{
-        atomic::{AtomicU32, Ordering},
-        Arc, Mutex,
-    },
+use std::sync::{
+    atomic::{AtomicU32, Ordering},
+    Arc, Mutex,
 };
 
 use anyhow::{Error, Result};
 
 struct MinimalSubscriber {
     num_messages: AtomicU32,
-    node: Arc<rclrs::Node>,
+    node: rclrs::Node,
     subscription: Mutex<Option<Arc<rclrs::Subscription<std_msgs::msg::String>>>>,
 }
 
 impl MinimalSubscriber {
-    pub fn new(name: &str, topic: &str) -> Result<Arc<Self>, rclrs::RclrsError> {
-        let context = rclrs::Context::new(env::args())?;
-        let node = rclrs::create_node(&context, name)?;
+    pub fn new(executor: &rclrs::Executor, name: &str, topic: &str) -> Result<Arc<Self>, rclrs::RclrsError> {
+        let node = executor.create_node(name)?;
         let minimal_subscriber = Arc::new(MinimalSubscriber {
             num_messages: 0.into(),
             node,
@@ -50,11 +46,11 @@ impl MinimalSubscriber {
 }
 
 fn main() -> Result<(), Error> {
-    let publisher_context = rclrs::Context::new(env::args())?;
-    let publisher_node = rclrs::create_node(&publisher_context, "minimal_publisher")?;
+    let mut executor = rclrs::Context::default_from_env()?.create_basic_executor();
+    let publisher_node = executor.create_node("minimal_publisher")?;
 
-    let subscriber_node_one = MinimalSubscriber::new("minimal_subscriber_one", "topic")?;
-    let subscriber_node_two = MinimalSubscriber::new("minimal_subscriber_two", "topic")?;
+    let _subscriber_node_one = MinimalSubscriber::new(&executor, "minimal_subscriber_one", "topic")?;
+    let _subscriber_node_two = MinimalSubscriber::new(&executor, "minimal_subscriber_two", "topic")?;
 
     let publisher = publisher_node
         .create_publisher::<std_msgs::msg::String>("topic", rclrs::QOS_PROFILE_DEFAULT)?;
@@ -71,11 +67,5 @@ fn main() -> Result<(), Error> {
         }
     });
 
-    let executor = rclrs::SingleThreadedExecutor::new();
-
-    executor.add_node(&publisher_node)?;
-    executor.add_node(&subscriber_node_one.node)?;
-    executor.add_node(&subscriber_node_two.node)?;
-
-    executor.spin().map_err(|err| err.into())
+    executor.spin(rclrs::SpinOptions::default()).map_err(|err| err.into())
 }

--- a/examples/minimal_pub_sub/src/minimal_two_nodes.rs
+++ b/examples/minimal_pub_sub/src/minimal_two_nodes.rs
@@ -51,8 +51,7 @@ fn main() -> Result<(), Error> {
     let _subscriber_node_one = MinimalSubscriber::new(&executor, "minimal_subscriber_one", "topic")?;
     let _subscriber_node_two = MinimalSubscriber::new(&executor, "minimal_subscriber_two", "topic")?;
 
-    let publisher = publisher_node
-        .create_publisher::<std_msgs::msg::String>("topic", rclrs::QOS_PROFILE_DEFAULT)?;
+    let publisher = publisher_node.create_publisher::<std_msgs::msg::String>("topic")?;
 
     std::thread::spawn(move || -> Result<(), rclrs::RclrsError> {
         let mut message = std_msgs::msg::String::default();

--- a/examples/minimal_pub_sub/src/minimal_two_nodes.rs
+++ b/examples/minimal_pub_sub/src/minimal_two_nodes.rs
@@ -25,7 +25,6 @@ impl MinimalSubscriber {
             .node
             .create_subscription::<std_msgs::msg::String, _>(
                 topic,
-                rclrs::QOS_PROFILE_DEFAULT,
                 move |msg: std_msgs::msg::String| {
                     minimal_subscriber_aux.callback(msg);
                 },

--- a/examples/minimal_pub_sub/src/minimal_two_nodes.rs
+++ b/examples/minimal_pub_sub/src/minimal_two_nodes.rs
@@ -8,7 +8,7 @@ use anyhow::{Error, Result};
 struct MinimalSubscriber {
     num_messages: AtomicU32,
     node: rclrs::Node,
-    subscription: Mutex<Option<Arc<rclrs::Subscription<std_msgs::msg::String>>>>,
+    subscription: Mutex<Option<rclrs::Subscription<std_msgs::msg::String>>>,
 }
 
 impl MinimalSubscriber {

--- a/examples/minimal_pub_sub/src/zero_copy_publisher.rs
+++ b/examples/minimal_pub_sub/src/zero_copy_publisher.rs
@@ -1,11 +1,10 @@
-use std::env;
-
 use anyhow::{Error, Result};
 
 fn main() -> Result<(), Error> {
-    let context = rclrs::Context::new(env::args())?;
+    let context = rclrs::Context::default_from_env()?;
+    let executor = context.create_basic_executor();
 
-    let node = rclrs::create_node(&context, "minimal_publisher")?;
+    let node = executor.create_node("minimal_publisher")?;
 
     let publisher =
         node.create_publisher::<std_msgs::msg::rmw::UInt32>("topic", rclrs::QOS_PROFILE_DEFAULT)?;

--- a/examples/minimal_pub_sub/src/zero_copy_publisher.rs
+++ b/examples/minimal_pub_sub/src/zero_copy_publisher.rs
@@ -6,8 +6,7 @@ fn main() -> Result<(), Error> {
 
     let node = executor.create_node("minimal_publisher")?;
 
-    let publisher =
-        node.create_publisher::<std_msgs::msg::rmw::UInt32>("topic", rclrs::QOS_PROFILE_DEFAULT)?;
+    let publisher = node.create_publisher::<std_msgs::msg::rmw::UInt32>("topic")?;
 
     let mut publish_count: u32 = 1;
 

--- a/examples/minimal_pub_sub/src/zero_copy_subscriber.rs
+++ b/examples/minimal_pub_sub/src/zero_copy_subscriber.rs
@@ -9,7 +9,6 @@ fn main() -> Result<(), Error> {
 
     let _subscription = node.create_subscription::<std_msgs::msg::UInt32, _>(
         "topic",
-        rclrs::QOS_PROFILE_DEFAULT,
         move |msg: rclrs::ReadOnlyLoanedMessage<'_, std_msgs::msg::UInt32>| {
             num_messages += 1;
             println!("I heard: '{}'", msg.data);

--- a/examples/minimal_pub_sub/src/zero_copy_subscriber.rs
+++ b/examples/minimal_pub_sub/src/zero_copy_subscriber.rs
@@ -1,11 +1,9 @@
-use std::env;
-
 use anyhow::{Error, Result};
 
 fn main() -> Result<(), Error> {
-    let context = rclrs::Context::new(env::args())?;
+    let mut executor = rclrs::Context::default_from_env()?.create_basic_executor();
 
-    let node = rclrs::create_node(&context, "minimal_subscriber")?;
+    let node = executor.create_node("minimal_subscriber")?;
 
     let mut num_messages: usize = 0;
 
@@ -19,5 +17,5 @@ fn main() -> Result<(), Error> {
         },
     )?;
 
-    rclrs::spin(node).map_err(|err| err.into())
+    executor.spin(rclrs::SpinOptions::default()).map_err(|err| err.into())
 }

--- a/examples/minimal_pub_sub/src/zero_copy_subscriber.rs
+++ b/examples/minimal_pub_sub/src/zero_copy_subscriber.rs
@@ -16,5 +16,7 @@ fn main() -> Result<(), Error> {
         },
     )?;
 
-    executor.spin(rclrs::SpinOptions::default()).map_err(|err| err.into())
+    executor
+        .spin(rclrs::SpinOptions::default())
+        .map_err(|err| err.into())
 }

--- a/examples/rust_pubsub/src/simple_publisher.rs
+++ b/examples/rust_pubsub/src/simple_publisher.rs
@@ -3,7 +3,7 @@ use std::{sync::Arc, thread, time::Duration};
 use std_msgs::msg::String as StringMsg;
 
 struct SimplePublisher {
-    publisher: Arc<Publisher<StringMsg>>,
+    publisher: Publisher<StringMsg>,
 }
 
 impl SimplePublisher {

--- a/examples/rust_pubsub/src/simple_publisher.rs
+++ b/examples/rust_pubsub/src/simple_publisher.rs
@@ -1,4 +1,4 @@
-use rclrs::{Context, Executor, Publisher, RclrsError, SpinOptions, QOS_PROFILE_DEFAULT};
+use rclrs::{Context, Executor, Publisher, RclrsError, SpinOptions};
 use std::{sync::Arc, thread, time::Duration};
 use std_msgs::msg::String as StringMsg;
 
@@ -9,9 +9,7 @@ struct SimplePublisher {
 impl SimplePublisher {
     fn new(executor: &Executor) -> Result<Self, RclrsError> {
         let node = executor.create_node("simple_publisher").unwrap();
-        let publisher = node
-            .create_publisher("publish_hello", QOS_PROFILE_DEFAULT)
-            .unwrap();
+        let publisher = node.create_publisher("publish_hello").unwrap();
         Ok(Self { publisher })
     }
 

--- a/examples/rust_pubsub/src/simple_publisher.rs
+++ b/examples/rust_pubsub/src/simple_publisher.rs
@@ -1,36 +1,37 @@
-use rclrs::{create_node, Context, Node, Publisher, RclrsError, QOS_PROFILE_DEFAULT};
+use rclrs::{Context, Executor, Publisher, RclrsError, SpinOptions, QOS_PROFILE_DEFAULT};
 use std::{sync::Arc, thread, time::Duration};
 use std_msgs::msg::String as StringMsg;
-struct SimplePublisherNode {
-    node: Arc<Node>,
-    _publisher: Arc<Publisher<StringMsg>>,
+
+struct SimplePublisher {
+    publisher: Arc<Publisher<StringMsg>>,
 }
-impl SimplePublisherNode {
-    fn new(context: &Context) -> Result<Self, RclrsError> {
-        let node = create_node(context, "simple_publisher").unwrap();
-        let _publisher = node
+
+impl SimplePublisher {
+    fn new(executor: &Executor) -> Result<Self, RclrsError> {
+        let node = executor.create_node("simple_publisher").unwrap();
+        let publisher = node
             .create_publisher("publish_hello", QOS_PROFILE_DEFAULT)
             .unwrap();
-        Ok(Self { node, _publisher })
+        Ok(Self { publisher })
     }
 
     fn publish_data(&self, increment: i32) -> Result<i32, RclrsError> {
         let msg: StringMsg = StringMsg {
             data: format!("Hello World {}", increment),
         };
-        self._publisher.publish(msg).unwrap();
+        self.publisher.publish(msg).unwrap();
         Ok(increment + 1_i32)
     }
 }
 
 fn main() -> Result<(), RclrsError> {
-    let context = Context::new(std::env::args()).unwrap();
-    let publisher = Arc::new(SimplePublisherNode::new(&context).unwrap());
+    let mut executor = Context::default_from_env().unwrap().create_basic_executor();
+    let publisher = Arc::new(SimplePublisher::new(&executor).unwrap());
     let publisher_other_thread = Arc::clone(&publisher);
     let mut count: i32 = 0;
     thread::spawn(move || loop {
         thread::sleep(Duration::from_millis(1000));
         count = publisher_other_thread.publish_data(count).unwrap();
     });
-    rclrs::spin(publisher.node.clone())
+    executor.spin(SpinOptions::default())
 }

--- a/examples/rust_pubsub/src/simple_subscriber.rs
+++ b/examples/rust_pubsub/src/simple_subscriber.rs
@@ -1,19 +1,19 @@
-use rclrs::{create_node, Context, Node, RclrsError, Subscription, QOS_PROFILE_DEFAULT};
+use rclrs::{Context, Executor, RclrsError, SpinOptions, Subscription, QOS_PROFILE_DEFAULT};
 use std::{
-    env,
     sync::{Arc, Mutex},
     thread,
     time::Duration,
 };
 use std_msgs::msg::String as StringMsg;
+
 pub struct SimpleSubscriptionNode {
-    node: Arc<Node>,
     _subscriber: Arc<Subscription<StringMsg>>,
     data: Arc<Mutex<Option<StringMsg>>>,
 }
+
 impl SimpleSubscriptionNode {
-    fn new(context: &Context) -> Result<Self, RclrsError> {
-        let node = create_node(context, "simple_subscription").unwrap();
+    fn new(executor: &Executor) -> Result<Self, RclrsError> {
+        let node = executor.create_node("simple_subscription").unwrap();
         let data: Arc<Mutex<Option<StringMsg>>> = Arc::new(Mutex::new(None));
         let data_mut: Arc<Mutex<Option<StringMsg>>> = Arc::clone(&data);
         let _subscriber = node
@@ -26,7 +26,6 @@ impl SimpleSubscriptionNode {
             )
             .unwrap();
         Ok(Self {
-            node,
             _subscriber,
             data,
         })
@@ -41,12 +40,12 @@ impl SimpleSubscriptionNode {
     }
 }
 fn main() -> Result<(), RclrsError> {
-    let context = Context::new(env::args()).unwrap();
-    let subscription = Arc::new(SimpleSubscriptionNode::new(&context).unwrap());
+    let mut executor = Context::default_from_env().unwrap().create_basic_executor();
+    let subscription = Arc::new(SimpleSubscriptionNode::new(&executor).unwrap());
     let subscription_other_thread = Arc::clone(&subscription);
     thread::spawn(move || loop {
         thread::sleep(Duration::from_millis(1000));
         subscription_other_thread.data_callback().unwrap()
     });
-    rclrs::spin(subscription.node.clone())
+    executor.spin(SpinOptions::default())
 }

--- a/examples/rust_pubsub/src/simple_subscriber.rs
+++ b/examples/rust_pubsub/src/simple_subscriber.rs
@@ -17,17 +17,11 @@ impl SimpleSubscriptionNode {
         let data: Arc<Mutex<Option<StringMsg>>> = Arc::new(Mutex::new(None));
         let data_mut: Arc<Mutex<Option<StringMsg>>> = Arc::clone(&data);
         let _subscriber = node
-            .create_subscription::<StringMsg, _>(
-                "publish_hello",
-                move |msg: StringMsg| {
-                    *data_mut.lock().unwrap() = Some(msg);
-                },
-            )
+            .create_subscription::<StringMsg, _>("publish_hello", move |msg: StringMsg| {
+                *data_mut.lock().unwrap() = Some(msg);
+            })
             .unwrap();
-        Ok(Self {
-            _subscriber,
-            data,
-        })
+        Ok(Self { _subscriber, data })
     }
     fn data_callback(&self) -> Result<(), RclrsError> {
         if let Some(data) = self.data.lock().unwrap().as_ref() {

--- a/examples/rust_pubsub/src/simple_subscriber.rs
+++ b/examples/rust_pubsub/src/simple_subscriber.rs
@@ -7,7 +7,7 @@ use std::{
 use std_msgs::msg::String as StringMsg;
 
 pub struct SimpleSubscriptionNode {
-    _subscriber: Arc<Subscription<StringMsg>>,
+    _subscriber: Subscription<StringMsg>,
     data: Arc<Mutex<Option<StringMsg>>>,
 }
 

--- a/examples/rust_pubsub/src/simple_subscriber.rs
+++ b/examples/rust_pubsub/src/simple_subscriber.rs
@@ -1,4 +1,4 @@
-use rclrs::{Context, Executor, RclrsError, SpinOptions, Subscription, QOS_PROFILE_DEFAULT};
+use rclrs::{Context, Executor, RclrsError, SpinOptions, Subscription};
 use std::{
     sync::{Arc, Mutex},
     thread,
@@ -19,7 +19,6 @@ impl SimpleSubscriptionNode {
         let _subscriber = node
             .create_subscription::<StringMsg, _>(
                 "publish_hello",
-                QOS_PROFILE_DEFAULT,
                 move |msg: StringMsg| {
                     *data_mut.lock().unwrap() = Some(msg);
                 },

--- a/rclrs/Cargo.toml
+++ b/rclrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rclrs"
-version = "0.4.1"
+version = "0.5.0"
 # This project is not military-sponsored, Jacob's employment contract just requires him to use this email address
 authors = ["Esteve Fernandez <esteve@apache.org>", "Nikolai Morin <nnmmgit@gmail.com>", "Jacob Hassold <jacob.a.hassold.civ@army.mil>"]
 edition = "2021"

--- a/rclrs/src/client.rs
+++ b/rclrs/src/client.rs
@@ -11,7 +11,7 @@ use rosidl_runtime_rs::Message;
 use crate::{
     error::{RclReturnCode, ToResult},
     rcl_bindings::*,
-    IntoPrimitiveOptions, MessageCow, NodeHandle, RclrsError, ENTITY_LIFECYCLE_MUTEX, QoSProfile,
+    IntoPrimitiveOptions, MessageCow, NodeHandle, QoSProfile, RclrsError, ENTITY_LIFECYCLE_MUTEX,
 };
 
 // SAFETY: The functions accessing this type, including drop(), shouldn't care about the thread
@@ -97,10 +97,11 @@ where
         let mut rcl_client = unsafe { rcl_get_zero_initialized_client() };
         let type_support = <T as rosidl_runtime_rs::Service>::get_type_support()
             as *const rosidl_service_type_support_t;
-        let topic_c_string = CString::new(service_name).map_err(|err| RclrsError::StringContainsNul {
-            err,
-            s: service_name.into(),
-        })?;
+        let topic_c_string =
+            CString::new(service_name).map_err(|err| RclrsError::StringContainsNul {
+                err,
+                s: service_name.into(),
+            })?;
 
         // SAFETY: No preconditions for this function.
         let mut client_options = unsafe { rcl_client_get_default_options() };
@@ -296,7 +297,10 @@ pub struct ClientOptions<'a> {
 impl<'a> ClientOptions<'a> {
     /// Initialize a new [`ClientOptions`] with default settings.
     pub fn new(service_name: &'a str) -> Self {
-        Self { service_name, qos: QoSProfile::services_default() }
+        Self {
+            service_name,
+            qos: QoSProfile::services_default(),
+        }
     }
 }
 

--- a/rclrs/src/client.rs
+++ b/rclrs/src/client.rs
@@ -11,7 +11,7 @@ use rosidl_runtime_rs::Message;
 use crate::{
     error::{RclReturnCode, ToResult},
     rcl_bindings::*,
-    MessageCow, NodeHandle, RclrsError, ENTITY_LIFECYCLE_MUTEX,
+    IntoPrimitiveOptions, MessageCow, NodeHandle, RclrsError, ENTITY_LIFECYCLE_MUTEX, QoSProfile,
 };
 
 // SAFETY: The functions accessing this type, including drop(), shouldn't care about the thread
@@ -83,23 +83,28 @@ where
     T: rosidl_runtime_rs::Service,
 {
     /// Creates a new client.
-    pub(crate) fn new(node_handle: Arc<NodeHandle>, topic: &str) -> Result<Self, RclrsError>
+    pub(crate) fn new<'a>(
+        node_handle: Arc<NodeHandle>,
+        options: impl Into<ClientOptions<'a>>,
+    ) -> Result<Self, RclrsError>
     // This uses pub(crate) visibility to avoid instantiating this struct outside
     // [`Node::create_client`], see the struct's documentation for the rationale
     where
         T: rosidl_runtime_rs::Service,
     {
+        let ClientOptions { service_name, qos } = options.into();
         // SAFETY: Getting a zero-initialized value is always safe.
         let mut rcl_client = unsafe { rcl_get_zero_initialized_client() };
         let type_support = <T as rosidl_runtime_rs::Service>::get_type_support()
             as *const rosidl_service_type_support_t;
-        let topic_c_string = CString::new(topic).map_err(|err| RclrsError::StringContainsNul {
+        let topic_c_string = CString::new(service_name).map_err(|err| RclrsError::StringContainsNul {
             err,
-            s: topic.into(),
+            s: service_name.into(),
         })?;
 
         // SAFETY: No preconditions for this function.
-        let client_options = unsafe { rcl_client_get_default_options() };
+        let mut client_options = unsafe { rcl_client_get_default_options() };
+        client_options.qos = qos.into();
 
         {
             let rcl_node = node_handle.rcl_node.lock().unwrap();
@@ -272,6 +277,28 @@ where
         }
         .ok()?;
         Ok(is_ready)
+    }
+}
+
+/// `ClientOptions` are used by [`Node::create_client`][1] to initialize a
+/// [`Client`] for a service.
+///
+/// [1]: crate::NodeState::create_client
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct ClientOptions<'a> {
+    /// The name of the service that this client will send requests to
+    pub service_name: &'a str,
+    /// The quality of the service profile for this client
+    pub qos: QoSProfile,
+}
+
+impl<'a, T: IntoPrimitiveOptions<'a>> From<T> for ClientOptions<'a> {
+    fn from(value: T) -> Self {
+        let options = value.into_primitive_options();
+        let mut qos = QoSProfile::services_default();
+        options.apply(&mut qos);
+        Self { service_name: options.name, qos }
     }
 }
 

--- a/rclrs/src/client.rs
+++ b/rclrs/src/client.rs
@@ -67,7 +67,7 @@ type RequestId = i64;
 /// The only available way to instantiate clients is via [`Node::create_client`][1], this is to
 /// ensure that [`Node`][2]s can track all the clients that have been created.
 ///
-/// [1]: crate::Node::create_client
+/// [1]: crate::NodeState::create_client
 /// [2]: crate::Node
 pub struct Client<T>
 where

--- a/rclrs/src/client.rs
+++ b/rclrs/src/client.rs
@@ -293,12 +293,19 @@ pub struct ClientOptions<'a> {
     pub qos: QoSProfile,
 }
 
+impl<'a> ClientOptions<'a> {
+    /// Initialize a new [`ClientOptions`] with default settings.
+    pub fn new(service_name: &'a str) -> Self {
+        Self { service_name, qos: QoSProfile::services_default() }
+    }
+}
+
 impl<'a, T: IntoPrimitiveOptions<'a>> From<T> for ClientOptions<'a> {
     fn from(value: T) -> Self {
-        let options = value.into_primitive_options();
-        let mut qos = QoSProfile::services_default();
-        options.apply(&mut qos);
-        Self { service_name: options.name, qos }
+        let primitive = value.into_primitive_options();
+        let mut options = Self::new(primitive.name);
+        primitive.apply(&mut options.qos);
+        options
     }
 }
 

--- a/rclrs/src/context.rs
+++ b/rclrs/src/context.rs
@@ -82,13 +82,13 @@ impl Context {
     /// Creates a new context.
     ///
     /// * `args` - A sequence of strings that resembles command line arguments
-    /// that users can pass into a ROS executable. See [the official tutorial][1]
-    /// to know what these arguments may look like. To simply pass in the arguments
-    /// that the user has provided from the command line, call [`Self::from_env`]
-    /// or [`Self::default_from_env`] instead.
+    ///   that users can pass into a ROS executable. See [the official tutorial][1]
+    ///   to know what these arguments may look like. To simply pass in the arguments
+    ///   that the user has provided from the command line, call [`Self::from_env`]
+    ///   or [`Self::default_from_env`] instead.
     ///
     /// * `options` - Additional options that your application can use to override
-    /// settings that would otherwise be determined by the environment.
+    ///   settings that would otherwise be determined by the environment.
     ///
     /// Creating a context will fail if `args` contains invalid ROS arguments.
     ///

--- a/rclrs/src/context.rs
+++ b/rclrs/src/context.rs
@@ -6,7 +6,7 @@ use std::{
     vec::Vec,
 };
 
-use crate::{rcl_bindings::*, RclrsError, ToResult, Executor};
+use crate::{rcl_bindings::*, Executor, RclrsError, ToResult};
 
 /// This is locked whenever initializing or dropping any middleware entity
 /// because we have found issues in RCL and some RMW implementations that
@@ -74,8 +74,7 @@ impl Default for Context {
     fn default() -> Self {
         // SAFETY: It should always be valid to instantiate a context with no
         // arguments, no parameters, no options, etc.
-        Self::new([], InitOptions::default())
-        .expect("Failed to instantiate a default context")
+        Self::new([], InitOptions::default()).expect("Failed to instantiate a default context")
     }
 }
 

--- a/rclrs/src/context.rs
+++ b/rclrs/src/context.rs
@@ -6,7 +6,7 @@ use std::{
     vec::Vec,
 };
 
-use crate::{rcl_bindings::*, RclrsError, ToResult};
+use crate::{rcl_bindings::*, RclrsError, ToResult, Executor};
 
 /// This is locked whenever initializing or dropping any middleware entity
 /// because we have found issues in RCL and some RMW implementations that
@@ -70,34 +70,41 @@ pub(crate) struct ContextHandle {
     pub(crate) rcl_context: Mutex<rcl_context_t>,
 }
 
+impl Default for Context {
+    fn default() -> Self {
+        // SAFETY: It should always be valid to instantiate a context with no
+        // arguments, no parameters, no options, etc.
+        Self::new([], InitOptions::default())
+        .expect("Failed to instantiate a default context")
+    }
+}
+
 impl Context {
     /// Creates a new context.
     ///
-    /// Usually this would be called with `std::env::args()`, analogously to `rclcpp::init()`.
-    /// See also the official "Passing ROS arguments to nodes via the command-line" tutorial.
+    /// * `args` - A sequence of strings that resembles command line arguments
+    /// that users can pass into a ROS executable. See [the official tutorial][1]
+    /// to know what these arguments may look like. To simply pass in the arguments
+    /// that the user has provided from the command line, call [`Self::from_env`]
+    /// or [`Self::default_from_env`] instead.
     ///
-    /// Creating a context will fail if the args contain invalid ROS arguments.
+    /// * `options` - Additional options that your application can use to override
+    /// settings that would otherwise be determined by the environment.
     ///
-    /// # Example
-    /// ```
-    /// # use rclrs::Context;
-    /// assert!(Context::new([]).is_ok());
-    /// let invalid_remapping = ["--ros-args", "-r", ":=:*/]"].map(String::from);
-    /// assert!(Context::new(invalid_remapping).is_err());
-    /// ```
-    pub fn new(args: impl IntoIterator<Item = String>) -> Result<Self, RclrsError> {
-        Self::new_with_options(args, InitOptions::new())
-    }
-
-    /// Same as [`Context::new`] except you can additionally provide initialization options.
+    /// Creating a context will fail if `args` contains invalid ROS arguments.
     ///
     /// # Example
     /// ```
     /// use rclrs::{Context, InitOptions};
-    /// let context = Context::new_with_options([], InitOptions::new().with_domain_id(Some(5))).unwrap();
+    /// let context = Context::new(
+    ///     std::env::args(),
+    ///     InitOptions::new().with_domain_id(Some(5)),
+    /// ).unwrap();
     /// assert_eq!(context.domain_id(), 5);
-    /// ````
-    pub fn new_with_options(
+    /// ```
+    ///
+    /// [1]: https://docs.ros.org/en/rolling/How-To-Guides/Node-arguments.html
+    pub fn new(
         args: impl IntoIterator<Item = String>,
         options: InitOptions,
     ) -> Result<Self, RclrsError> {
@@ -148,6 +155,23 @@ impl Context {
                 rcl_context: Mutex::new(rcl_context),
             }),
         })
+    }
+
+    /// Same as [`Self::new`] but [`std::env::args`] is automatically passed in
+    /// for `args`.
+    pub fn from_env(options: InitOptions) -> Result<Self, RclrsError> {
+        Self::new(std::env::args(), options)
+    }
+
+    /// Same as [`Self::from_env`] but the default [`InitOptions`] is passed in
+    /// for `options`.
+    pub fn default_from_env() -> Result<Self, RclrsError> {
+        Self::new(std::env::args(), InitOptions::default())
+    }
+
+    /// Create a basic executor that comes built into rclrs.
+    pub fn create_basic_executor(&self) -> Executor {
+        Executor::new(Arc::clone(&self.handle))
     }
 
     /// Returns the ROS domain ID that the context is using.
@@ -250,14 +274,14 @@ mod tests {
     #[test]
     fn test_create_context() -> Result<(), RclrsError> {
         // If the context fails to be created, this will cause a panic
-        let _ = Context::new(vec![])?;
+        let _ = Context::new(vec![], InitOptions::default())?;
         Ok(())
     }
 
     #[test]
     fn test_context_ok() -> Result<(), RclrsError> {
         // If the context fails to be created, this will cause a panic
-        let created_context = Context::new(vec![]).unwrap();
+        let created_context = Context::new(vec![], InitOptions::default()).unwrap();
         assert!(created_context.ok());
 
         Ok(())

--- a/rclrs/src/error.rs
+++ b/rclrs/src/error.rs
@@ -352,3 +352,24 @@ impl ToResult for rcl_ret_t {
         to_rclrs_result(*self)
     }
 }
+
+/// A helper trait to disregard timeouts as not an error.
+pub trait RclrsErrorFilter {
+    /// If the result was a timeout error, change it to `Ok(())`.
+    fn timeout_ok(self) -> Result<(), RclrsError>;
+}
+
+impl RclrsErrorFilter for Result<(), RclrsError> {
+    fn timeout_ok(self) -> Result<(), RclrsError> {
+        match self {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                if matches!(err, RclrsError::RclError { code: RclReturnCode::Timeout, .. }) {
+                    return Ok(());
+                }
+
+                Err(err)
+            }
+        }
+    }
+}

--- a/rclrs/src/error.rs
+++ b/rclrs/src/error.rs
@@ -364,7 +364,13 @@ impl RclrsErrorFilter for Result<(), RclrsError> {
         match self {
             Ok(()) => Ok(()),
             Err(err) => {
-                if matches!(err, RclrsError::RclError { code: RclReturnCode::Timeout, .. }) {
+                if matches!(
+                    err,
+                    RclrsError::RclError {
+                        code: RclReturnCode::Timeout,
+                        ..
+                    }
+                ) {
                     return Ok(());
                 }
 

--- a/rclrs/src/executor.rs
+++ b/rclrs/src/executor.rs
@@ -1,16 +1,16 @@
 use crate::{
     rcl_bindings::rcl_context_is_valid,
-    Node, RclrsError, WaitSet, ContextHandle, NodeOptions, WeakNode,
+    Node, NodeState, RclrsError, WaitSet, ContextHandle, NodeOptions,
 };
 use std::{
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, Weak},
     time::Duration,
 };
 
 /// Single-threaded executor implementation.
 pub struct Executor {
     context: Arc<ContextHandle>,
-    nodes_mtx: Mutex<Vec<WeakNode>>,
+    nodes_mtx: Mutex<Vec<Weak<NodeState>>>,
 }
 
 impl Executor {
@@ -21,7 +21,7 @@ impl Executor {
     ) -> Result<Node, RclrsError> {
         let options: NodeOptions = options.into();
         let node = options.build(&self.context)?;
-        self.nodes_mtx.lock().unwrap().push(node.downgrade());
+        self.nodes_mtx.lock().unwrap().push(Arc::downgrade(&node));
         Ok(node)
     }
 
@@ -55,7 +55,7 @@ impl Executor {
     fn spin_once(&self, timeout: Option<Duration>) -> Result<(), RclrsError> {
         for node in { self.nodes_mtx.lock().unwrap() }
             .iter()
-            .filter_map(WeakNode::upgrade)
+            .filter_map(Weak::upgrade)
             .filter(|node| unsafe {
                 rcl_context_is_valid(&*node.handle.context_handle.rcl_context.lock().unwrap())
             })

--- a/rclrs/src/executor.rs
+++ b/rclrs/src/executor.rs
@@ -1,48 +1,61 @@
-use crate::{rcl_bindings::rcl_context_is_valid, Node, RclReturnCode, RclrsError, WaitSet};
+use crate::{
+    rcl_bindings::rcl_context_is_valid,
+    Node, RclrsError, WaitSet, ContextHandle, NodeOptions, WeakNode,
+};
 use std::{
-    sync::{Arc, Mutex, Weak},
+    sync::{Arc, Mutex},
     time::Duration,
 };
 
 /// Single-threaded executor implementation.
-pub struct SingleThreadedExecutor {
-    nodes_mtx: Mutex<Vec<Weak<Node>>>,
+pub struct Executor {
+    context: Arc<ContextHandle>,
+    nodes_mtx: Mutex<Vec<WeakNode>>,
 }
 
-impl Default for SingleThreadedExecutor {
-    fn default() -> Self {
-        Self::new()
+impl Executor {
+    /// Create a [`Node`] that will run on this Executor.
+    pub fn create_node(
+        &self,
+        options: impl Into<NodeOptions>,
+    ) -> Result<Node, RclrsError> {
+        let options: NodeOptions = options.into();
+        let node = options.build(&self.context)?;
+        self.nodes_mtx.lock().unwrap().push(node.downgrade());
+        Ok(node)
     }
-}
 
-impl SingleThreadedExecutor {
-    /// Creates a new executor.
-    pub fn new() -> Self {
-        SingleThreadedExecutor {
-            nodes_mtx: Mutex::new(Vec::new()),
+    /// Spin the Executor. The current thread will be blocked until the Executor
+    /// stops spinning.
+    ///
+    /// [`SpinOptions`] can be used to automatically stop the spinning when
+    /// certain conditions are met. Use `SpinOptions::default()` to allow the
+    /// Executor to keep spinning indefinitely.
+    pub fn spin(&mut self, options: SpinOptions) -> Result<(), RclrsError> {
+        loop {
+            if self.nodes_mtx.lock().unwrap().is_empty() {
+                // Nothing to spin for, so just quit here
+                return Ok(());
+            }
+
+            self.spin_once(options.timeout)?;
+
+            if options.only_next_available_work {
+                // We were only suppposed to spin once, so quit here
+                return Ok(());
+            }
+
+            std::thread::yield_now();
         }
-    }
-
-    /// Add a node to the executor.
-    pub fn add_node(&self, node: &Arc<Node>) -> Result<(), RclrsError> {
-        { self.nodes_mtx.lock().unwrap() }.push(Arc::downgrade(node));
-        Ok(())
-    }
-
-    /// Remove a node from the executor.
-    pub fn remove_node(&self, node: Arc<Node>) -> Result<(), RclrsError> {
-        { self.nodes_mtx.lock().unwrap() }
-            .retain(|n| !n.upgrade().map(|n| Arc::ptr_eq(&n, &node)).unwrap_or(false));
-        Ok(())
     }
 
     /// Polls the nodes for new messages and executes the corresponding callbacks.
     ///
     /// This function additionally checks that the context is still valid.
-    pub fn spin_once(&self, timeout: Option<Duration>) -> Result<(), RclrsError> {
+    fn spin_once(&self, timeout: Option<Duration>) -> Result<(), RclrsError> {
         for node in { self.nodes_mtx.lock().unwrap() }
             .iter()
-            .filter_map(Weak::upgrade)
+            .filter_map(WeakNode::upgrade)
             .filter(|node| unsafe {
                 rcl_context_is_valid(&*node.handle.context_handle.rcl_context.lock().unwrap())
             })
@@ -66,19 +79,51 @@ impl SingleThreadedExecutor {
         Ok(())
     }
 
-    /// Convenience function for calling [`SingleThreadedExecutor::spin_once`] in a loop.
-    pub fn spin(&self) -> Result<(), RclrsError> {
-        while !{ self.nodes_mtx.lock().unwrap() }.is_empty() {
-            match self.spin_once(None) {
-                Ok(_)
-                | Err(RclrsError::RclError {
-                    code: RclReturnCode::Timeout,
-                    ..
-                }) => std::thread::yield_now(),
-                error => return error,
-            }
+    /// Used by [`Context`] to create the `Executor`. Users cannot call this
+    /// function.
+    pub(crate) fn new(context: Arc<ContextHandle>) -> Self {
+        Self {
+            context,
+            nodes_mtx: Mutex::new(Vec::new()),
         }
+    }
+}
 
-        Ok(())
+/// A bundle of optional conditions that a user may want to impose on how long
+/// an executor spins for.
+///
+/// By default the executor will be allowed to spin indefinitely.
+#[non_exhaustive]
+#[derive(Default)]
+pub struct SpinOptions {
+    /// Only perform the next available work. This is similar to spin_once in
+    /// rclcpp and rclpy.
+    ///
+    /// To only process work that is immediately available without waiting at all,
+    /// set a timeout of zero.
+    pub only_next_available_work: bool,
+    /// Stop waiting after this duration of time has passed. Use `Some(0)` to not
+    /// wait any amount of time. Use `None` to wait an infinite amount of time.
+    pub timeout: Option<Duration>,
+}
+
+impl SpinOptions {
+    /// Use default spin options.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Behave like spin_once in rclcpp and rclpy.
+    pub fn spin_once() -> Self {
+        Self {
+            only_next_available_work: true,
+            ..Default::default()
+        }
+    }
+
+    /// Stop spinning once this durtion of time is reached.
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = Some(timeout);
+        self
     }
 }

--- a/rclrs/src/executor.rs
+++ b/rclrs/src/executor.rs
@@ -1,6 +1,6 @@
 use crate::{
-    rcl_bindings::rcl_context_is_valid,
-    Node, NodeState, RclrsError, WaitSet, ContextHandle, NodeOptions,
+    rcl_bindings::rcl_context_is_valid, ContextHandle, Node, NodeOptions, NodeState, RclrsError,
+    WaitSet,
 };
 use std::{
     sync::{Arc, Mutex, Weak},
@@ -15,10 +15,7 @@ pub struct Executor {
 
 impl Executor {
     /// Create a [`Node`] that will run on this Executor.
-    pub fn create_node(
-        &self,
-        options: impl Into<NodeOptions>,
-    ) -> Result<Node, RclrsError> {
+    pub fn create_node(&self, options: impl Into<NodeOptions>) -> Result<Node, RclrsError> {
         let options: NodeOptions = options.into();
         let node = options.build(&self.context)?;
         self.nodes_mtx.lock().unwrap().push(Arc::downgrade(&node));

--- a/rclrs/src/lib.rs
+++ b/rclrs/src/lib.rs
@@ -30,8 +30,6 @@ mod rcl_bindings;
 #[cfg(feature = "dyn_msg")]
 pub mod dynamic_message;
 
-use std::{sync::Arc, time::Duration};
-
 pub use arguments::*;
 pub use client::*;
 pub use clock::*;
@@ -48,66 +46,3 @@ pub use subscription::*;
 pub use time::*;
 use time_source::*;
 pub use wait::*;
-
-/// Polls the node for new messages and executes the corresponding callbacks.
-///
-/// See [`WaitSet::wait`] for the meaning of the `timeout` parameter.
-///
-/// This may under some circumstances return
-/// [`SubscriptionTakeFailed`][1], [`ClientTakeFailed`][1], [`ServiceTakeFailed`][1] when the wait
-/// set spuriously wakes up.
-/// This can usually be ignored.
-///
-/// [1]: crate::RclReturnCode
-pub fn spin_once(node: Arc<Node>, timeout: Option<Duration>) -> Result<(), RclrsError> {
-    let executor = SingleThreadedExecutor::new();
-    executor.add_node(&node)?;
-    executor.spin_once(timeout)
-}
-
-/// Convenience function for calling [`spin_once`] in a loop.
-pub fn spin(node: Arc<Node>) -> Result<(), RclrsError> {
-    let executor = SingleThreadedExecutor::new();
-    executor.add_node(&node)?;
-    executor.spin()
-}
-
-/// Creates a new node in the empty namespace.
-///
-/// Convenience function equivalent to [`Node::new`][1].
-/// Please see that function's documentation.
-///
-/// [1]: crate::Node::new
-///
-/// # Example
-/// ```
-/// # use rclrs::{Context, RclrsError};
-/// let ctx = Context::new([])?;
-/// let node = rclrs::create_node(&ctx, "my_node");
-/// assert!(node.is_ok());
-/// # Ok::<(), RclrsError>(())
-/// ```
-pub fn create_node(context: &Context, node_name: &str) -> Result<Arc<Node>, RclrsError> {
-    Node::new(context, node_name)
-}
-
-/// Creates a [`NodeBuilder`].
-///
-/// Convenience function equivalent to [`NodeBuilder::new()`][1] and [`Node::builder()`][2].
-/// Please see that function's documentation.
-///
-/// [1]: crate::NodeBuilder::new
-/// [2]: crate::Node::builder
-///
-/// # Example
-/// ```
-/// # use rclrs::{Context, RclrsError};
-/// let context = Context::new([])?;
-/// let node_builder = rclrs::create_node_builder(&context, "my_node");
-/// let node = node_builder.build()?;
-/// assert_eq!(node.name(), "my_node");
-/// # Ok::<(), RclrsError>(())
-/// ```
-pub fn create_node_builder(context: &Context, node_name: &str) -> NodeBuilder {
-    Node::builder(context, node_name)
-}

--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -20,10 +20,10 @@ use rosidl_runtime_rs::Message;
 
 use crate::{
     rcl_bindings::*, Client, ClientBase, ClientOptions, Clock, ContextHandle, GuardCondition,
-    ParameterBuilder, ParameterInterface, ParameterVariant, Parameters, Publisher, PublisherOptions,
-    PublisherState, RclrsError, Service, ServiceBase, ServiceOptions, ServiceState, Subscription,
-    SubscriptionBase, SubscriptionCallback, SubscriptionOptions, SubscriptionState, TimeSource,
-    ENTITY_LIFECYCLE_MUTEX,
+    ParameterBuilder, ParameterInterface, ParameterVariant, Parameters, Publisher,
+    PublisherOptions, PublisherState, RclrsError, Service, ServiceBase, ServiceOptions,
+    ServiceState, Subscription, SubscriptionBase, SubscriptionCallback, SubscriptionOptions,
+    SubscriptionState, TimeSource, ENTITY_LIFECYCLE_MUTEX,
 };
 
 // SAFETY: The functions accessing this type, including drop(), shouldn't care about the thread
@@ -611,7 +611,7 @@ pub(crate) unsafe fn call_string_getter_with_rcl_node(
 
 #[cfg(test)]
 mod tests {
-    use crate::{*, test_helpers::*};
+    use crate::{test_helpers::*, *};
 
     #[test]
     fn traits() {
@@ -629,10 +629,9 @@ mod tests {
             "graph_test_topic_3",
             |_msg: msg::Defaults| {},
         )?;
-        let _node_2_empty_subscription = graph.node2.create_subscription::<msg::Empty, _>(
-            "graph_test_topic_1",
-            |_msg: msg::Empty| {},
-        )?;
+        let _node_2_empty_subscription = graph
+            .node2
+            .create_subscription::<msg::Empty, _>("graph_test_topic_1", |_msg: msg::Empty| {})?;
         let _node_2_basic_types_subscription =
             graph.node2.create_subscription::<msg::BasicTypes, _>(
                 "graph_test_topic_2",

--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -1,5 +1,12 @@
-mod node_options;
 mod graph;
+pub use graph::*;
+
+mod node_options;
+pub use node_options::*;
+
+mod primitive_options;
+pub use primitive_options::*;
+
 use std::{
     cmp::PartialEq,
     ffi::CStr,
@@ -11,12 +18,11 @@ use std::{
 
 use rosidl_runtime_rs::Message;
 
-pub use self::{graph::*, node_options::*};
 use crate::{
     rcl_bindings::*, Client, ClientBase, Clock, ContextHandle, GuardCondition,
     ParameterBuilder, ParameterInterface, ParameterVariant, Parameters, Publisher, QoSProfile,
     RclrsError, Service, ServiceBase, Subscription, SubscriptionBase, SubscriptionCallback,
-    TimeSource, ENTITY_LIFECYCLE_MUTEX,
+    SubscriptionOptions, TimeSource, ENTITY_LIFECYCLE_MUTEX,
 };
 
 // SAFETY: The functions accessing this type, including drop(), shouldn't care about the thread
@@ -302,12 +308,49 @@ impl NodeState {
 
     /// Creates a [`Subscription`][1].
     ///
+    /// Pass in only the topic name for the `options` argument to use all default subscription options:
+    /// ```
+    /// # use rclrs::*;
+    /// # let executor = Context::default().create_basic_executor();
+    /// # let node = executor.create_node("my_node").unwrap();
+    /// let subscription = node.create_subscription(
+    ///     "my_subscription",
+    ///     |_msg: test_msgs::msg::Empty| {
+    ///         println!("Received message!");
+    ///     },
+    /// );
+    /// ```
+    ///
+    /// Take advantage of [`IntoPrimitiveOptions`] to easily build up the
+    /// subscription options:
+    ///
+    /// ```
+    /// # use rclrs::*;
+    /// # let executor = Context::default().create_basic_executor();
+    /// # let node = executor.create_node("my_node").unwrap();
+    /// let subscription = node.create_subscription(
+    ///     "my_subscription"
+    ///     .keep_last(100)
+    ///     .transient_local(),
+    ///     |_msg: test_msgs::msg::Empty| {
+    ///         println!("Received message!");
+    ///     },
+    /// );
+    ///
+    /// let reliable_subscription = node.create_subscription(
+    ///     "my_reliable_subscription"
+    ///     .reliable(),
+    ///     |_msg: test_msgs::msg::Empty| {
+    ///         println!("Received message!");
+    ///     },
+    /// );
+    /// ```
+    ///
     /// [1]: crate::Subscription
     // TODO: make subscription's lifetime depend on node's lifetime
-    pub fn create_subscription<T, Args>(
+    pub fn create_subscription<'a, T, Args>(
         &self,
-        topic: &str,
-        qos: QoSProfile,
+        options: impl Into<SubscriptionOptions<'a>>,
         callback: impl SubscriptionCallback<T, Args>,
     ) -> Result<Arc<Subscription<T>>, RclrsError>
     where
@@ -315,8 +358,7 @@ impl NodeState {
     {
         let subscription = Arc::new(Subscription::<T>::new(
             Arc::clone(&self.handle),
-            topic,
-            qos,
+            options,
             callback,
         )?);
         { self.subscriptions_mtx.lock() }
@@ -452,8 +494,7 @@ pub(crate) unsafe fn call_string_getter_with_rcl_node(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::test_helpers::*;
+    use crate::{*, test_helpers::*};
 
     #[test]
     fn traits() {
@@ -463,25 +504,21 @@ mod tests {
 
     #[test]
     fn test_topic_names_and_types() -> Result<(), RclrsError> {
-        use crate::QOS_PROFILE_SYSTEM_DEFAULT;
         use test_msgs::msg;
 
         let graph = construct_test_graph("test_topics_graph")?;
 
         let _node_1_defaults_subscription = graph.node1.create_subscription::<msg::Defaults, _>(
             "graph_test_topic_3",
-            QOS_PROFILE_SYSTEM_DEFAULT,
             |_msg: msg::Defaults| {},
         )?;
         let _node_2_empty_subscription = graph.node2.create_subscription::<msg::Empty, _>(
             "graph_test_topic_1",
-            QOS_PROFILE_SYSTEM_DEFAULT,
             |_msg: msg::Empty| {},
         )?;
         let _node_2_basic_types_subscription =
             graph.node2.create_subscription::<msg::BasicTypes, _>(
                 "graph_test_topic_2",
-                QOS_PROFILE_SYSTEM_DEFAULT,
                 |_msg: msg::BasicTypes| {},
             )?;
 

--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -269,8 +269,39 @@ impl NodeState {
 
     /// Creates a [`Publisher`][1].
     ///
+    /// Pass in only the topic name for the `options` argument to use all default publisher options:
+    /// ```
+    /// # use rclrs::*;
+    /// # let executor = Context::default().create_basic_executor();
+    /// # let node = executor.create_node("my_node").unwrap();
+    /// let publisher = node.create_publisher::<test_msgs::msg::Empty>(
+    ///     "my_topic"
+    /// )
+    /// .unwrap();
+    /// ```
+    ///
+    /// Take advantage of the [`IntoPrimitiveOptions`] API to easily build up the
+    /// publisher options:
+    ///
+    /// ```
+    /// # use rclrs::*;
+    /// # let executor = Context::default().create_basic_executor();
+    /// # let node = executor.create_node("my_node").unwrap();
+    /// let publisher = node.create_publisher::<test_msgs::msg::Empty>(
+    ///     "my_topic"
+    ///     .keep_last(100)
+    ///     .transient_local()
+    /// )
+    /// .unwrap();
+    ///
+    /// let reliable_publisher = node.create_publisher::<test_msgs::msg::Empty>(
+    ///     "my_topic"
+    ///     .reliable()
+    /// )
+    /// .unwrap();
+    /// ```
+    ///
     /// [1]: crate::Publisher
-    // TODO: make publisher's lifetime depend on node's lifetime
     pub fn create_publisher<'a, T>(
         &self,
         options: impl Into<PublisherOptions<'a>>,
@@ -295,7 +326,8 @@ impl NodeState {
     ///         println!("Received request!");
     ///         test_msgs::srv::Empty_Response::default()
     ///     },
-    /// );
+    /// )
+    /// .unwrap();
     /// ```
     ///
     /// Take advantage of the [`IntoPrimitiveOptions`] API to easily build up the
@@ -313,7 +345,8 @@ impl NodeState {
     ///         println!("Received request!");
     ///         test_msgs::srv::Empty_Response::default()
     ///     },
-    /// );
+    /// )
+    /// .unwrap();
     /// ```
     ///
     /// Any quality of service options that you explicitly specify will override
@@ -356,7 +389,8 @@ impl NodeState {
     ///     |_msg: test_msgs::msg::Empty| {
     ///         println!("Received message!");
     ///     },
-    /// );
+    /// )
+    /// .unwrap();
     /// ```
     ///
     /// Take advantage of the [`IntoPrimitiveOptions`] API to easily build up the
@@ -373,7 +407,8 @@ impl NodeState {
     ///     |_msg: test_msgs::msg::Empty| {
     ///         println!("Received message!");
     ///     },
-    /// );
+    /// )
+    /// .unwrap();
     ///
     /// let reliable_subscription = node.create_subscription(
     ///     "my_reliable_topic"
@@ -381,7 +416,8 @@ impl NodeState {
     ///     |_msg: test_msgs::msg::Empty| {
     ///         println!("Received message!");
     ///     },
-    /// );
+    /// )
+    /// .unwrap();
     /// ```
     ///
     /// [1]: crate::Subscription

--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -20,7 +20,7 @@ use rosidl_runtime_rs::Message;
 
 use crate::{
     rcl_bindings::*, Client, ClientBase, Clock, ContextHandle, GuardCondition,
-    ParameterBuilder, ParameterInterface, ParameterVariant, Parameters, Publisher, QoSProfile,
+    ParameterBuilder, ParameterInterface, ParameterVariant, Parameters, Publisher, PublisherOptions,
     RclrsError, Service, ServiceBase, Subscription, SubscriptionBase, SubscriptionCallback,
     SubscriptionOptions, TimeSource, ENTITY_LIFECYCLE_MUTEX,
 };
@@ -271,15 +271,14 @@ impl NodeState {
     ///
     /// [1]: crate::Publisher
     // TODO: make publisher's lifetime depend on node's lifetime
-    pub fn create_publisher<T>(
+    pub fn create_publisher<'a, T>(
         &self,
-        topic: &str,
-        qos: QoSProfile,
+        options: impl Into<PublisherOptions<'a>>,
     ) -> Result<Arc<Publisher<T>>, RclrsError>
     where
         T: Message,
     {
-        let publisher = Arc::new(Publisher::<T>::new(Arc::clone(&self.handle), topic, qos)?);
+        let publisher = Arc::new(Publisher::<T>::new(Arc::clone(&self.handle), options)?);
         Ok(publisher)
     }
 

--- a/rclrs/src/node/graph.rs
+++ b/rclrs/src/node/graph.rs
@@ -482,8 +482,7 @@ mod tests {
             .map(|value: usize| if value != 99 { 99 } else { 98 })
             .unwrap_or(99);
 
-        let executor =
-            Context::new([], InitOptions::new().with_domain_id(Some(domain_id)))
+        let executor = Context::new([], InitOptions::new().with_domain_id(Some(domain_id)))
             .unwrap()
             .create_basic_executor();
         let node_name = "test_publisher_names_and_types";

--- a/rclrs/src/node/graph.rs
+++ b/rclrs/src/node/graph.rs
@@ -482,11 +482,12 @@ mod tests {
             .map(|value: usize| if value != 99 { 99 } else { 98 })
             .unwrap_or(99);
 
-        let context =
-            Context::new_with_options([], InitOptions::new().with_domain_id(Some(domain_id)))
-                .unwrap();
+        let executor =
+            Context::new([], InitOptions::new().with_domain_id(Some(domain_id)))
+            .unwrap()
+            .create_basic_executor();
         let node_name = "test_publisher_names_and_types";
-        let node = Node::new(&context, node_name).unwrap();
+        let node = executor.create_node(node_name).unwrap();
         // Test that the graph has no publishers
         let names_and_topics = node
             .get_publisher_names_and_types_by_node(node_name, "")
@@ -543,9 +544,9 @@ mod tests {
 
     #[test]
     fn test_node_names() {
-        let context = Context::new([]).unwrap();
+        let executor = Context::default().create_basic_executor();
         let node_name = "test_node_names";
-        let node = Node::new(&context, node_name).unwrap();
+        let node = executor.create_node(node_name).unwrap();
 
         let names_and_namespaces = node.get_node_names().unwrap();
 
@@ -559,9 +560,9 @@ mod tests {
 
     #[test]
     fn test_node_names_with_enclaves() {
-        let context = Context::new([]).unwrap();
+        let executor = Context::default().create_basic_executor();
         let node_name = "test_node_names_with_enclaves";
-        let node = Node::new(&context, node_name).unwrap();
+        let node = executor.create_node(node_name).unwrap();
 
         let names_and_namespaces = node.get_node_names_with_enclaves().unwrap();
 

--- a/rclrs/src/node/graph.rs
+++ b/rclrs/src/node/graph.rs
@@ -3,7 +3,7 @@ use std::{
     ffi::{CStr, CString},
 };
 
-use crate::{rcl_bindings::*, Node, RclrsError, ToResult};
+use crate::{rcl_bindings::*, NodeState, RclrsError, ToResult};
 
 impl Drop for rmw_names_and_types_t {
     fn drop(&mut self) {
@@ -57,7 +57,7 @@ pub struct TopicEndpointInfo {
     pub topic_type: String,
 }
 
-impl Node {
+impl NodeState {
     /// Returns a list of topic names and types for publishers associated with a node.
     pub fn get_publisher_names_and_types_by_node(
         &self,

--- a/rclrs/src/node/node_options.rs
+++ b/rclrs/src/node/node_options.rs
@@ -292,7 +292,7 @@ impl NodeOptions {
 
         let handle = Arc::new(NodeHandle {
             rcl_node: Mutex::new(rcl_node),
-            context_handle: Arc::clone(&context),
+            context_handle: Arc::clone(context),
         });
         let parameter = {
             let rcl_node = handle.rcl_node.lock().unwrap();

--- a/rclrs/src/node/node_options.rs
+++ b/rclrs/src/node/node_options.rs
@@ -4,8 +4,7 @@ use std::{
 };
 
 use crate::{
-    rcl_bindings::*,
-    ClockType, Node, NodeState, NodeHandle, ParameterInterface, ContextHandle,
+    rcl_bindings::*, ClockType, ContextHandle, Node, NodeHandle, NodeState, ParameterInterface,
     QoSProfile, RclrsError, TimeSource, ToResult, ENTITY_LIFECYCLE_MUTEX, QOS_PROFILE_CLOCK,
 };
 
@@ -257,10 +256,7 @@ impl NodeOptions {
     ///
     /// Only used internally. Downstream users should call
     /// [`Executor::create_node`].
-    pub(crate) fn build(
-        self,
-        context: &Arc<ContextHandle>,
-    ) -> Result<Node, RclrsError> {
+    pub(crate) fn build(self, context: &Arc<ContextHandle>) -> Result<Node, RclrsError> {
         let node_name =
             CString::new(self.name.as_str()).map_err(|err| RclrsError::StringContainsNul {
                 err,

--- a/rclrs/src/node/node_options.rs
+++ b/rclrs/src/node/node_options.rs
@@ -9,10 +9,9 @@ use crate::{
     QoSProfile, RclrsError, TimeSource, ToResult, ENTITY_LIFECYCLE_MUTEX, QOS_PROFILE_CLOCK,
 };
 
-/// A builder for creating a [`Node`][1].
+/// A set of options for creating a [`Node`][1].
 ///
 /// The builder pattern allows selectively setting some fields, and leaving all others at their default values.
-/// This struct instance can be created via [`Node::builder()`][2].
 ///
 /// The default values for optional fields are:
 /// - `namespace: "/"`
@@ -43,7 +42,6 @@ use crate::{
 /// ```
 ///
 /// [1]: crate::Node
-/// [2]: crate::Node::builder
 pub struct NodeOptions {
     name: String,
     namespace: String,
@@ -68,7 +66,7 @@ impl NodeOptions {
     /// - Must not be empty and not be longer than `RMW_NODE_NAME_MAX_NAME_LENGTH`
     /// - Must not start with a number
     ///
-    /// Note that node name validation is delayed until [`NodeBuilder::build()`][3].
+    /// Note that node name validation is delayed until [`Executor::create_node`][3].
     ///
     /// # Example
     /// ```
@@ -88,7 +86,7 @@ impl NodeOptions {
     ///
     /// [1]: crate::Node#naming
     /// [2]: https://docs.ros2.org/latest/api/rmw/validate__node__name_8h.html#a5690a285aed9735f89ef11950b6e39e3
-    /// [3]: NodeBuilder::build
+    /// [3]: crate::Executor::create_node
     pub fn new(name: impl ToString) -> NodeOptions {
         NodeOptions {
             name: name.to_string(),
@@ -119,7 +117,7 @@ impl NodeOptions {
     /// - Must not contain two or more `/` characters in a row
     /// - Must not have a `/` character at the end, except if `/` is the full namespace
     ///
-    /// Note that namespace validation is delayed until [`NodeBuilder::build()`][4].
+    /// Note that namespace validation is delayed until [`Executor::create_node`][4].
     ///
     /// # Example
     /// ```
@@ -150,7 +148,7 @@ impl NodeOptions {
     /// [1]: crate::Node#naming
     /// [2]: http://design.ros2.org/articles/topic_and_service_names.html
     /// [3]: https://docs.ros2.org/latest/api/rmw/validate__namespace_8h.html#a043f17d240cf13df01321b19a469ee49
-    /// [4]: NodeBuilder::build
+    /// [4]: crate::Executor::create_node
     pub fn namespace(mut self, namespace: impl ToString) -> Self {
         self.namespace = namespace.to_string();
         self

--- a/rclrs/src/node/node_options.rs
+++ b/rclrs/src/node/node_options.rs
@@ -4,7 +4,8 @@ use std::{
 };
 
 use crate::{
-    rcl_bindings::*, ClockType, Context, ContextHandle, Node, NodeHandle, ParameterInterface,
+    rcl_bindings::*,
+    ClockType, Node, NodeHandle, ParameterInterface, NodePrimitives, ContextHandle,
     QoSProfile, RclrsError, TimeSource, ToResult, ENTITY_LIFECYCLE_MUTEX, QOS_PROFILE_CLOCK,
 };
 
@@ -24,27 +25,26 @@ use crate::{
 ///
 /// # Example
 /// ```
-/// # use rclrs::{Context, NodeBuilder, Node, RclrsError};
-/// let context = Context::new([])?;
+/// # use rclrs::{Context, NodeOptions, Node, RclrsError};
+/// let executor = Context::default().create_basic_executor();
 /// // Building a node in a single expression
-/// let node = NodeBuilder::new(&context, "foo_node").namespace("/bar").build()?;
+/// let node = executor.create_node(NodeOptions::new("foo_node").namespace("/bar"))?;
 /// assert_eq!(node.name(), "foo_node");
 /// assert_eq!(node.namespace(), "/bar");
-/// // Building a node via Node::builder()
-/// let node = Node::builder(&context, "bar_node").build()?;
+/// // Building a node via NodeOptions
+/// let node = executor.create_node(NodeOptions::new("bar_node"))?;
 /// assert_eq!(node.name(), "bar_node");
 /// // Building a node step-by-step
-/// let mut builder = Node::builder(&context, "goose");
-/// builder = builder.namespace("/duck/duck");
-/// let node = builder.build()?;
+/// let mut options = NodeOptions::new("goose");
+/// options = options.namespace("/duck/duck");
+/// let node = executor.create_node(options)?;
 /// assert_eq!(node.fully_qualified_name(), "/duck/duck/goose");
 /// # Ok::<(), RclrsError>(())
 /// ```
 ///
 /// [1]: crate::Node
 /// [2]: crate::Node::builder
-pub struct NodeBuilder {
-    context: Arc<ContextHandle>,
+pub struct NodeOptions {
     name: String,
     namespace: String,
     use_global_arguments: bool,
@@ -55,7 +55,7 @@ pub struct NodeBuilder {
     clock_qos: QoSProfile,
 }
 
-impl NodeBuilder {
+impl NodeOptions {
     /// Creates a builder for a node with the given name.
     ///
     /// See the [`Node` docs][1] for general information on node names.
@@ -72,17 +72,15 @@ impl NodeBuilder {
     ///
     /// # Example
     /// ```
-    /// # use rclrs::{Context, NodeBuilder, RclrsError, RclReturnCode};
-    /// let context = Context::new([])?;
+    /// # use rclrs::{Context, NodeOptions, RclrsError, RclReturnCode};
+    /// let executor = Context::default().create_basic_executor();
     /// // This is a valid node name
-    /// assert!(NodeBuilder::new(&context, "my_node").build().is_ok());
+    /// assert!(executor.create_node(NodeOptions::new("my_node")).is_ok());
     /// // This is another valid node name (although not a good one)
-    /// assert!(NodeBuilder::new(&context, "_______").build().is_ok());
+    /// assert!(executor.create_node(NodeOptions::new("_______")).is_ok());
     /// // This is an invalid node name
     /// assert!(matches!(
-    ///     NodeBuilder::new(&context, "röböt")
-    ///         .build()
-    ///         .unwrap_err(),
+    ///     executor.create_node(NodeOptions::new("röböt")).unwrap_err(),
     ///     RclrsError::RclError { code: RclReturnCode::NodeInvalidName, .. }
     /// ));
     /// # Ok::<(), RclrsError>(())
@@ -91,9 +89,8 @@ impl NodeBuilder {
     /// [1]: crate::Node#naming
     /// [2]: https://docs.ros2.org/latest/api/rmw/validate__node__name_8h.html#a5690a285aed9735f89ef11950b6e39e3
     /// [3]: NodeBuilder::build
-    pub fn new(context: &Context, name: &str) -> NodeBuilder {
-        NodeBuilder {
-            context: Arc::clone(&context.handle),
+    pub fn new(name: impl ToString) -> NodeOptions {
+        NodeOptions {
             name: name.to_string(),
             namespace: "/".to_string(),
             use_global_arguments: true,
@@ -126,25 +123,25 @@ impl NodeBuilder {
     ///
     /// # Example
     /// ```
-    /// # use rclrs::{Context, Node, RclrsError, RclReturnCode};
-    /// let context = Context::new([])?;
+    /// # use rclrs::{Context, Node, NodeOptions, RclrsError, RclReturnCode};
+    /// let executor = Context::default().create_basic_executor();
     /// // This is a valid namespace
-    /// let builder_ok_ns = Node::builder(&context, "my_node").namespace("/some/nested/namespace");
-    /// assert!(builder_ok_ns.build().is_ok());
+    /// let options_ok_ns = NodeOptions::new("my_node").namespace("/some/nested/namespace");
+    /// assert!(executor.create_node(options_ok_ns).is_ok());
     /// // This is an invalid namespace
     /// assert!(matches!(
-    ///     Node::builder(&context, "my_node")
+    ///     executor.create_node(
+    ///         NodeOptions::new("my_node")
     ///         .namespace("/10_percent_luck/20_percent_skill")
-    ///         .build()
-    ///         .unwrap_err(),
+    ///     ).unwrap_err(),
     ///     RclrsError::RclError { code: RclReturnCode::NodeInvalidNamespace, .. }
     /// ));
     /// // A missing forward slash at the beginning is automatically added
     /// assert_eq!(
-    ///     Node::builder(&context, "my_node")
+    ///     executor.create_node(
+    ///         NodeOptions::new("my_node")
     ///         .namespace("foo")
-    ///         .build()?
-    ///         .namespace(),
+    ///     )?.namespace(),
     ///     "/foo"
     /// );
     /// # Ok::<(), RclrsError>(())
@@ -154,7 +151,7 @@ impl NodeBuilder {
     /// [2]: http://design.ros2.org/articles/topic_and_service_names.html
     /// [3]: https://docs.ros2.org/latest/api/rmw/validate__namespace_8h.html#a043f17d240cf13df01321b19a469ee49
     /// [4]: NodeBuilder::build
-    pub fn namespace(mut self, namespace: &str) -> Self {
+    pub fn namespace(mut self, namespace: impl ToString) -> Self {
         self.namespace = namespace.to_string();
         self
     }
@@ -165,21 +162,21 @@ impl NodeBuilder {
     ///
     /// # Example
     /// ```
-    /// # use rclrs::{Context, Node, NodeBuilder, RclrsError};
+    /// # use rclrs::{Context, InitOptions, Node, NodeOptions, RclrsError};
     /// let context_args = ["--ros-args", "--remap", "__node:=your_node"]
     ///   .map(String::from);
-    /// let context = Context::new(context_args)?;
+    /// let executor = Context::new(context_args, InitOptions::default())?.create_basic_executor();
     /// // Ignore the global arguments:
-    /// let node_without_global_args =
-    ///   rclrs::create_node_builder(&context, "my_node")
-    ///   .use_global_arguments(false)
-    ///   .build()?;
+    /// let node_without_global_args = executor.create_node(
+    ///     NodeOptions::new("my_node")
+    ///     .use_global_arguments(false)
+    /// )?;
     /// assert_eq!(node_without_global_args.name(), "my_node");
     /// // Do not ignore the global arguments:
-    /// let node_with_global_args =
-    ///   rclrs::create_node_builder(&context, "my_other_node")
-    ///   .use_global_arguments(true)
-    ///   .build()?;
+    /// let node_with_global_args = executor.create_node(
+    ///     NodeOptions::new("my_other_node")
+    ///     .use_global_arguments(true)
+    /// )?;
     /// assert_eq!(node_with_global_args.name(), "your_node");
     /// # Ok::<(), RclrsError>(())
     /// ```
@@ -200,26 +197,29 @@ impl NodeBuilder {
     ///
     /// # Example
     /// ```
-    /// # use rclrs::{Context, Node, NodeBuilder, RclrsError};
+    /// # use rclrs::{Context, InitOptions, Node, NodeOptions, RclrsError};
     /// // Usually, this would change the name of "my_node" to "context_args_node":
     /// let context_args = ["--ros-args", "--remap", "my_node:__node:=context_args_node"]
     ///   .map(String::from);
-    /// let context = Context::new(context_args)?;
+    /// let executor = Context::new(context_args, InitOptions::default())?.create_basic_executor();
     /// // But the node arguments will change it to "node_args_node":
     /// let node_args = ["--ros-args", "--remap", "my_node:__node:=node_args_node"]
     ///   .map(String::from);
-    /// let node =
-    ///   rclrs::create_node_builder(&context, "my_node")
-    ///   .arguments(node_args)
-    ///   .build()?;
+    /// let node = executor.create_node(
+    ///     NodeOptions::new("my_node")
+    ///     .arguments(node_args)
+    /// )?;
     /// assert_eq!(node.name(), "node_args_node");
     /// # Ok::<(), RclrsError>(())
     /// ```
     ///
     /// [1]: crate::Context::new
     /// [2]: https://design.ros2.org/articles/ros_command_line_arguments.html
-    pub fn arguments(mut self, arguments: impl IntoIterator<Item = String>) -> Self {
-        self.arguments = arguments.into_iter().collect();
+    pub fn arguments<Args: IntoIterator>(mut self, arguments: Args) -> Self
+    where
+        Args::Item: ToString,
+    {
+        self.arguments = arguments.into_iter().map(|item| item.to_string()).collect();
         self
     }
 
@@ -257,12 +257,12 @@ impl NodeBuilder {
 
     /// Builds the node instance.
     ///
-    /// Node name and namespace validation is performed in this method.
-    ///
-    /// For example usage, see the [`NodeBuilder`][1] docs.
-    ///
-    /// [1]: crate::NodeBuilder
-    pub fn build(&self) -> Result<Arc<Node>, RclrsError> {
+    /// Only used internally. Downstream users should call
+    /// [`Executor::create_node`].
+    pub(crate) fn build(
+        self,
+        context: &Arc<ContextHandle>,
+    ) -> Result<Node, RclrsError> {
         let node_name =
             CString::new(self.name.as_str()).map_err(|err| RclrsError::StringContainsNul {
                 err,
@@ -274,7 +274,7 @@ impl NodeBuilder {
                 s: self.namespace.clone(),
             })?;
         let rcl_node_options = self.create_rcl_node_options()?;
-        let rcl_context = &mut *self.context.rcl_context.lock().unwrap();
+        let rcl_context = &mut *context.rcl_context.lock().unwrap();
 
         // SAFETY: Getting a zero-initialized value is always safe.
         let mut rcl_node = unsafe { rcl_get_zero_initialized_node() };
@@ -298,7 +298,7 @@ impl NodeBuilder {
 
         let handle = Arc::new(NodeHandle {
             rcl_node: Mutex::new(rcl_node),
-            context_handle: Arc::clone(&self.context),
+            context_handle: Arc::clone(&context),
         });
         let parameter = {
             let rcl_node = handle.rcl_node.lock().unwrap();
@@ -308,21 +308,26 @@ impl NodeBuilder {
                 &rcl_context.global_arguments,
             )?
         };
-        let node = Arc::new(Node {
+
+        let node = Node {
             handle,
-            clients_mtx: Mutex::new(vec![]),
-            guard_conditions_mtx: Mutex::new(vec![]),
-            services_mtx: Mutex::new(vec![]),
-            subscriptions_mtx: Mutex::new(vec![]),
-            time_source: TimeSource::builder(self.clock_type)
-                .clock_qos(self.clock_qos)
-                .build(),
-            parameter,
-        });
-        node.time_source.attach_node(&node);
+            primitives: Arc::new(NodePrimitives {
+                clients_mtx: Mutex::default(),
+                guard_conditions_mtx: Mutex::default(),
+                services_mtx: Mutex::default(),
+                subscriptions_mtx: Mutex::default(),
+                time_source: TimeSource::builder(self.clock_type)
+                    .clock_qos(self.clock_qos)
+                    .build(),
+                parameter,
+            }),
+        };
+        node.primitives.time_source.attach_node(&node);
+
         if self.start_parameter_services {
-            node.parameter.create_services(&node)?;
+            node.primitives.parameter.create_services(&node)?;
         }
+
         Ok(node)
     }
 
@@ -364,6 +369,12 @@ impl NodeBuilder {
         rcl_node_options.allocator = unsafe { rcutils_get_default_allocator() };
 
         Ok(rcl_node_options)
+    }
+}
+
+impl<T: ToString> From<T> for NodeOptions {
+    fn from(name: T) -> Self {
+        NodeOptions::new(name)
     }
 }
 

--- a/rclrs/src/node/primitive_options.rs
+++ b/rclrs/src/node/primitive_options.rs
@@ -39,8 +39,8 @@ pub struct PrimitiveOptions<'a> {
     pub liveliness: Option<QoSLivelinessPolicy>,
     /// Override the default [`QoSProfile::liveliness_lease_duration`] for the primitive.
     pub liveliness_lease: Option<QoSDuration>,
-    /// Override the default [`QoSProfile::avoid_ros_namespace_convention`] for the primitive.
-    pub avoid_ros_namespace_convention: Option<bool>,
+    /// Override the default [`QoSProfile::avoid_ros_namespace_conventions`] for the primitive.
+    pub avoid_ros_namespace_conventions: Option<bool>,
 }
 
 /// Trait to implicitly convert a compatible object into [`PrimitiveOptions`].
@@ -205,7 +205,7 @@ impl<'a> PrimitiveOptions<'a> {
             lifespan: None,
             liveliness: None,
             liveliness_lease: None,
-            avoid_ros_namespace_convention: None,
+            avoid_ros_namespace_conventions: None,
         }
     }
 
@@ -239,7 +239,7 @@ impl<'a> PrimitiveOptions<'a> {
             qos.liveliness_lease = liveliness_lease;
         }
 
-        if let Some(convention) = self.avoid_ros_namespace_convention {
+        if let Some(convention) = self.avoid_ros_namespace_conventions {
             qos.avoid_ros_namespace_conventions = convention;
         }
     }

--- a/rclrs/src/node/primitive_options.rs
+++ b/rclrs/src/node/primitive_options.rs
@@ -1,9 +1,9 @@
 use crate::{
-    QoSHistoryPolicy, QoSReliabilityPolicy, QoSDurabilityPolicy, QoSDuration,
-    QoSLivelinessPolicy, QoSProfile,
+    QoSDurabilityPolicy, QoSDuration, QoSHistoryPolicy, QoSLivelinessPolicy, QoSProfile,
+    QoSReliabilityPolicy,
 };
 
-use std::{time::Duration, borrow::Borrow};
+use std::{borrow::Borrow, time::Duration};
 
 /// `PrimitiveOptions` are the subset of options that are relevant across all
 /// primitives (e.g. [`Subscription`][1], [`Publisher`][2], [`Client`][3], and
@@ -50,9 +50,7 @@ pub trait IntoPrimitiveOptions<'a>: Sized {
 
     /// Override all the quality of service settings for the primitive.
     fn qos(self, profile: QoSProfile) -> PrimitiveOptions<'a> {
-        self
-        .into_primitive_options()
-        .history(profile.history)
+        self.into_primitive_options().history(profile.history)
     }
 
     /// Use the default topics quality of service profile.

--- a/rclrs/src/node/primitive_options.rs
+++ b/rclrs/src/node/primitive_options.rs
@@ -1,0 +1,246 @@
+use crate::{
+    QoSHistoryPolicy, QoSReliabilityPolicy, QoSDurabilityPolicy, QoSDuration,
+    QoSLivelinessPolicy, QoSProfile,
+};
+
+use std::{time::Duration, borrow::Borrow};
+
+/// `PrimitiveOptions` are the subset of options that are relevant across all
+/// primitives (e.g. [`Subscription`][1], [`Publisher`][2], [`Client`][3], and
+/// [`Service`][4]).
+///
+/// Each different primitive type may have its own defaults for the overall
+/// quality of service settings, and we cannot know what the default will be
+/// until the `PrimitiveOptions` gets converted into the more specific set of
+/// options. Therefore we store each quality of service field separately so that
+/// we will only override the settings that the user explicitly asked for, and
+/// the rest will be determined by the default settings for each primitive.
+///
+/// [1]: crate::Subscription
+/// [2]: crate::Publisher
+/// [3]: crate::Client
+/// [4]: crate::Service
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub struct PrimitiveOptions<'a> {
+    /// The name that will be used for the primitive
+    pub name: &'a str,
+    /// Override the default [`QoSProfile::history`] for the primitive.
+    pub history: Option<QoSHistoryPolicy>,
+    /// Override the default [`QoSProfile::reliability`] for the primitive.
+    pub reliability: Option<QoSReliabilityPolicy>,
+    /// Override the default [`QoSProfile::durability`] for the primitive.
+    pub durability: Option<QoSDurabilityPolicy>,
+    /// Override the default [`QoSProfile::deadline`] for the primitive.
+    pub deadline: Option<QoSDuration>,
+    /// Override the default [`QoSProfile::lifespan`] for the primitive.
+    pub lifespan: Option<QoSDuration>,
+    /// Override the default [`QoSProfile::liveliness`] for the primitive.
+    pub liveliness: Option<QoSLivelinessPolicy>,
+    /// Override the default [`QoSProfile::liveliness_lease_duration`] for the primitive.
+    pub liveliness_lease: Option<QoSDuration>,
+    /// Override the default [`QoSProfile::avoid_ros_namespace_convention`] for the primitive.
+    pub avoid_ros_namespace_convention: Option<bool>,
+}
+
+/// Trait to implicitly convert a compatible object into [`PrimitiveOptions`].
+pub trait IntoPrimitiveOptions<'a>: Sized {
+    /// Convert the object into [`PrimitiveOptions`] with default settings.
+    fn into_primitive_options(self) -> PrimitiveOptions<'a>;
+
+    /// Override all the quality of service settings for the primitive.
+    fn qos(self, profile: QoSProfile) -> PrimitiveOptions<'a> {
+        self
+        .into_primitive_options()
+        .history(profile.history)
+    }
+
+    /// Use the default topics quality of service profile.
+    fn topics_qos(self) -> PrimitiveOptions<'a> {
+        self.qos(QoSProfile::topics_default())
+    }
+
+    /// Use the default sensor data quality of service profile.
+    fn sensor_data_qos(self) -> PrimitiveOptions<'a> {
+        self.qos(QoSProfile::sensor_data_default())
+    }
+
+    /// Use the default services quality of service profile.
+    fn services_qos(self) -> PrimitiveOptions<'a> {
+        self.qos(QoSProfile::services_default())
+    }
+
+    /// Use the system-defined default quality of service profile. This profile
+    /// is determined by the underlying RMW implementation, so you cannot rely
+    /// on this profile being consistent or appropriate for your needs.
+    fn system_qos(self) -> PrimitiveOptions<'a> {
+        self.qos(QoSProfile::system_default())
+    }
+
+    /// Override the default [`QoSProfile::history`] for the primitive.
+    fn history(self, history: QoSHistoryPolicy) -> PrimitiveOptions<'a> {
+        let mut options = self.into_primitive_options();
+        options.history = Some(history);
+        options
+    }
+
+    /// Keep the last `depth` messages for the primitive.
+    fn keep_last(self, depth: u32) -> PrimitiveOptions<'a> {
+        self.history(QoSHistoryPolicy::KeepLast { depth })
+    }
+
+    /// Keep all messages for the primitive.
+    fn keep_all(self) -> PrimitiveOptions<'a> {
+        self.history(QoSHistoryPolicy::KeepAll)
+    }
+
+    /// Override the default [`QoSProfile::reliability`] for the primitive.
+    fn reliability(self, reliability: QoSReliabilityPolicy) -> PrimitiveOptions<'a> {
+        let mut options = self.into_primitive_options();
+        options.reliability = Some(reliability);
+        options
+    }
+
+    /// Set the primitive to have [reliable][QoSReliabilityPolicy::Reliable] communication.
+    fn reliable(self) -> PrimitiveOptions<'a> {
+        self.reliability(QoSReliabilityPolicy::Reliable)
+    }
+
+    /// Set the primitive to have [best-effort][QoSReliabilityPolicy::BestEffort] communication.
+    fn best_effort(self) -> PrimitiveOptions<'a> {
+        self.reliability(QoSReliabilityPolicy::BestEffort)
+    }
+
+    /// Override the default [`QoSProfile::durability`] for the primitive.
+    fn durability(self, durability: QoSDurabilityPolicy) -> PrimitiveOptions<'a> {
+        let mut options = self.into_primitive_options();
+        options.durability = Some(durability);
+        options
+    }
+
+    /// Set the primitive to have [volatile][QoSDurabilityPolicy::Volatile] durability.
+    fn volatile(self) -> PrimitiveOptions<'a> {
+        self.durability(QoSDurabilityPolicy::Volatile)
+    }
+
+    /// Set the primitive to have [transient local][QoSDurabilityPolicy::TransientLocal] durability.
+    fn transient_local(self) -> PrimitiveOptions<'a> {
+        self.durability(QoSDurabilityPolicy::TransientLocal)
+    }
+
+    /// Override the default [`QoSProfile::lifespan`] for the primitive.
+    fn lifespan(self, lifespan: QoSDuration) -> PrimitiveOptions<'a> {
+        let mut options = self.into_primitive_options();
+        options.lifespan = Some(lifespan);
+        options
+    }
+
+    /// Set a custom duration for the [lifespan][QoSProfile::lifespan] of the primitive.
+    fn lifespan_duration(self, duration: Duration) -> PrimitiveOptions<'a> {
+        self.lifespan(QoSDuration::Custom(duration))
+    }
+
+    /// Make the [lifespan][QoSProfile::lifespan] of the primitive infinite.
+    fn infinite_lifespan(self) -> PrimitiveOptions<'a> {
+        self.lifespan(QoSDuration::Infinite)
+    }
+
+    /// Override the default [`QoSProfile::deadline`] for the primitive.
+    fn deadline(self, deadline: QoSDuration) -> PrimitiveOptions<'a> {
+        let mut options = self.into_primitive_options();
+        options.deadline = Some(deadline);
+        options
+    }
+
+    /// Set the [`QoSProfile::deadline`] to a custom finite value.
+    fn deadline_duration(self, duration: Duration) -> PrimitiveOptions<'a> {
+        self.deadline(QoSDuration::Custom(duration))
+    }
+
+    /// Do not use a deadline for liveliness for this primitive.
+    fn no_deadline(self) -> PrimitiveOptions<'a> {
+        self.deadline(QoSDuration::Infinite)
+    }
+
+    /// Override the default [`QoSProfile::liveliness_lease`] for the primitive.
+    fn liveliness_lease(self, lease: QoSDuration) -> PrimitiveOptions<'a> {
+        let mut options = self.into_primitive_options();
+        options.liveliness_lease = Some(lease);
+        options
+    }
+
+    /// Set a custom duration for the [liveliness lease][QoSProfile::liveliness_lease].
+    fn liveliness_lease_duration(self, duration: Duration) -> PrimitiveOptions<'a> {
+        self.liveliness_lease(QoSDuration::Custom(duration))
+    }
+}
+
+impl<'a> IntoPrimitiveOptions<'a> for PrimitiveOptions<'a> {
+    fn into_primitive_options(self) -> PrimitiveOptions<'a> {
+        self
+    }
+}
+
+impl<'a> IntoPrimitiveOptions<'a> for &'a str {
+    fn into_primitive_options(self) -> PrimitiveOptions<'a> {
+        PrimitiveOptions::new(self)
+    }
+}
+
+impl<'a, T: Borrow<str>> IntoPrimitiveOptions<'a> for &'a T {
+    fn into_primitive_options(self) -> PrimitiveOptions<'a> {
+        self.borrow().into_primitive_options()
+    }
+}
+
+impl<'a> PrimitiveOptions<'a> {
+    /// Begin building a new set of `PrimitiveOptions` with only the name set.
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            history: None,
+            reliability: None,
+            durability: None,
+            deadline: None,
+            lifespan: None,
+            liveliness: None,
+            liveliness_lease: None,
+            avoid_ros_namespace_convention: None,
+        }
+    }
+
+    /// Apply the user-specified options to a pre-initialized [`QoSProfile`].
+    pub fn apply(&self, qos: &mut QoSProfile) {
+        if let Some(history) = self.history {
+            qos.history = history;
+        }
+
+        if let Some(reliability) = self.reliability {
+            qos.reliability = reliability;
+        }
+
+        if let Some(durability) = self.durability {
+            qos.durability = durability;
+        }
+
+        if let Some(deadline) = self.deadline {
+            qos.deadline = deadline;
+        }
+
+        if let Some(lifespan) = self.lifespan {
+            qos.lifespan = lifespan;
+        }
+
+        if let Some(liveliness) = self.liveliness {
+            qos.liveliness = liveliness;
+        }
+
+        if let Some(liveliness_lease) = self.liveliness_lease {
+            qos.liveliness_lease = liveliness_lease;
+        }
+
+        if let Some(convention) = self.avoid_ros_namespace_convention {
+            qos.avoid_ros_namespace_conventions = convention;
+        }
+    }
+}

--- a/rclrs/src/parameter.rs
+++ b/rclrs/src/parameter.rs
@@ -82,7 +82,9 @@ enum DeclaredValue {
 }
 
 /// Builder used to declare a parameter. Obtain this by calling
-/// [`crate::Node::declare_parameter`].
+/// [`Node::declare_parameter`][1].
+///
+/// [1]: crate::NodeState::declare_parameter
 #[must_use]
 pub struct ParameterBuilder<'a, T: ParameterVariant> {
     name: Arc<str>,

--- a/rclrs/src/parameter.rs
+++ b/rclrs/src/parameter.rs
@@ -871,18 +871,23 @@ impl ParameterInterface {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{create_node, Context};
+    use crate::{Context, InitOptions};
 
     #[test]
     fn test_parameter_override_errors() {
         // Create a new node with a few parameter overrides
-        let ctx = Context::new([
-            String::from("--ros-args"),
-            String::from("-p"),
-            String::from("declared_int:=10"),
-        ])
-        .unwrap();
-        let node = create_node(&ctx, "param_test_node").unwrap();
+        let executor = Context::new(
+            [
+                String::from("--ros-args"),
+                String::from("-p"),
+                String::from("declared_int:=10"),
+            ],
+            InitOptions::default(),
+        )
+        .unwrap()
+        .create_basic_executor();
+
+        let node = executor.create_node("param_test_node").unwrap();
 
         // Declaring a parameter with a different type than what was overridden should return an
         // error
@@ -928,19 +933,24 @@ mod tests {
     #[test]
     fn test_parameter_setting_declaring() {
         // Create a new node with a few parameter overrides
-        let ctx = Context::new([
-            String::from("--ros-args"),
-            String::from("-p"),
-            String::from("declared_int:=10"),
-            String::from("-p"),
-            String::from("double_array:=[1.0, 2.0]"),
-            String::from("-p"),
-            String::from("optional_bool:=true"),
-            String::from("-p"),
-            String::from("non_declared_string:='param'"),
-        ])
-        .unwrap();
-        let node = create_node(&ctx, "param_test_node").unwrap();
+        let executor = Context::new(
+            [
+                String::from("--ros-args"),
+                String::from("-p"),
+                String::from("declared_int:=10"),
+                String::from("-p"),
+                String::from("double_array:=[1.0, 2.0]"),
+                String::from("-p"),
+                String::from("optional_bool:=true"),
+                String::from("-p"),
+                String::from("non_declared_string:='param'"),
+            ],
+            InitOptions::default(),
+        )
+        .unwrap()
+        .create_basic_executor();
+
+        let node = executor.create_node("param_test_node").unwrap();
 
         let overridden_int = node
             .declare_parameter("declared_int")
@@ -1084,13 +1094,18 @@ mod tests {
 
     #[test]
     fn test_override_undeclared_set_priority() {
-        let ctx = Context::new([
-            String::from("--ros-args"),
-            String::from("-p"),
-            String::from("declared_int:=10"),
-        ])
-        .unwrap();
-        let node = create_node(&ctx, "param_test_node").unwrap();
+        let executor = Context::new(
+            [
+                String::from("--ros-args"),
+                String::from("-p"),
+                String::from("declared_int:=10"),
+            ],
+            InitOptions::default(),
+        )
+        .unwrap()
+        .create_basic_executor();
+
+        let node = executor.create_node("param_test_node").unwrap();
         // If a parameter was set as an override and as an undeclared parameter, the undeclared
         // value should get priority
         node.use_undeclared_parameters()
@@ -1106,13 +1121,18 @@ mod tests {
 
     #[test]
     fn test_parameter_scope_redeclaring() {
-        let ctx = Context::new([
-            String::from("--ros-args"),
-            String::from("-p"),
-            String::from("declared_int:=10"),
-        ])
-        .unwrap();
-        let node = create_node(&ctx, "param_test_node").unwrap();
+        let executor = Context::new(
+            [
+                String::from("--ros-args"),
+                String::from("-p"),
+                String::from("declared_int:=10"),
+            ],
+            InitOptions::default(),
+        )
+        .unwrap()
+        .create_basic_executor();
+
+        let node = executor.create_node("param_test_node").unwrap();
         {
             // Setting a parameter with an override
             let param = node
@@ -1157,8 +1177,10 @@ mod tests {
 
     #[test]
     fn test_parameter_ranges() {
-        let ctx = Context::new([]).unwrap();
-        let node = create_node(&ctx, "param_test_node").unwrap();
+        let node = Context::default()
+            .create_basic_executor()
+            .create_node("param_test_node")
+            .unwrap();
         // Setting invalid ranges should fail
         let range = ParameterRange {
             lower: Some(10),
@@ -1285,8 +1307,10 @@ mod tests {
 
     #[test]
     fn test_readonly_parameters() {
-        let ctx = Context::new([]).unwrap();
-        let node = create_node(&ctx, "param_test_node").unwrap();
+        let node = Context::default()
+            .create_basic_executor()
+            .create_node("param_test_node")
+            .unwrap();
         let param = node
             .declare_parameter("int_param")
             .default(100)
@@ -1312,8 +1336,10 @@ mod tests {
 
     #[test]
     fn test_preexisting_value_error() {
-        let ctx = Context::new([]).unwrap();
-        let node = create_node(&ctx, "param_test_node").unwrap();
+        let node = Context::default()
+            .create_basic_executor()
+            .create_node("param_test_node")
+            .unwrap();
         node.use_undeclared_parameters()
             .set("int_param", 100)
             .unwrap();
@@ -1365,8 +1391,10 @@ mod tests {
 
     #[test]
     fn test_optional_parameter_apis() {
-        let ctx = Context::new([]).unwrap();
-        let node = create_node(&ctx, "param_test_node").unwrap();
+        let node = Context::default()
+            .create_basic_executor()
+            .create_node("param_test_node")
+            .unwrap();
         node.declare_parameter::<i64>("int_param")
             .optional()
             .unwrap();

--- a/rclrs/src/parameter/service.rs
+++ b/rclrs/src/parameter/service.rs
@@ -9,7 +9,8 @@ use rosidl_runtime_rs::Sequence;
 use super::ParameterMap;
 use crate::{
     parameter::{DeclaredValue, ParameterKind, ParameterStorage},
-    rmw_request_id_t, Node, RclrsError, Service,
+    rmw_request_id_t, Node, RclrsError, Service, IntoPrimitiveOptions,
+    QoSProfile,
 };
 
 // The variables only exist to keep a strong reference to the services and are technically unused.
@@ -247,7 +248,8 @@ impl ParameterService {
         // destruction is made for the parameter map.
         let map = parameter_map.clone();
         let describe_parameters_service = node.create_service(
-            &(fqn.clone() + "/describe_parameters"),
+            (fqn.clone() + "/describe_parameters")
+            .qos(QoSProfile::parameter_services_default()),
             move |_req_id: &rmw_request_id_t, req: DescribeParameters_Request| {
                 let map = map.lock().unwrap();
                 describe_parameters(req, &map)
@@ -255,7 +257,8 @@ impl ParameterService {
         )?;
         let map = parameter_map.clone();
         let get_parameter_types_service = node.create_service(
-            &(fqn.clone() + "/get_parameter_types"),
+            (fqn.clone() + "/get_parameter_types")
+            .qos(QoSProfile::parameter_services_default()),
             move |_req_id: &rmw_request_id_t, req: GetParameterTypes_Request| {
                 let map = map.lock().unwrap();
                 get_parameter_types(req, &map)
@@ -263,7 +266,8 @@ impl ParameterService {
         )?;
         let map = parameter_map.clone();
         let get_parameters_service = node.create_service(
-            &(fqn.clone() + "/get_parameters"),
+            (fqn.clone() + "/get_parameters")
+            .qos(QoSProfile::parameter_services_default()),
             move |_req_id: &rmw_request_id_t, req: GetParameters_Request| {
                 let map = map.lock().unwrap();
                 get_parameters(req, &map)
@@ -271,7 +275,8 @@ impl ParameterService {
         )?;
         let map = parameter_map.clone();
         let list_parameters_service = node.create_service(
-            &(fqn.clone() + "/list_parameters"),
+            (fqn.clone() + "/list_parameters")
+            .qos(QoSProfile::parameter_services_default()),
             move |_req_id: &rmw_request_id_t, req: ListParameters_Request| {
                 let map = map.lock().unwrap();
                 list_parameters(req, &map)
@@ -279,14 +284,16 @@ impl ParameterService {
         )?;
         let map = parameter_map.clone();
         let set_parameters_service = node.create_service(
-            &(fqn.clone() + "/set_parameters"),
+            (fqn.clone() + "/set_parameters")
+            .qos(QoSProfile::parameter_services_default()),
             move |_req_id: &rmw_request_id_t, req: SetParameters_Request| {
                 let mut map = map.lock().unwrap();
                 set_parameters(req, &mut map)
             },
         )?;
         let set_parameters_atomically_service = node.create_service(
-            &(fqn.clone() + "/set_parameters_atomically"),
+            (fqn.clone() + "/set_parameters_atomically")
+            .qos(QoSProfile::parameter_services_default()),
             move |_req_id: &rmw_request_id_t, req: SetParametersAtomically_Request| {
                 let mut map = parameter_map.lock().unwrap();
                 set_parameters_atomically(req, &mut map)

--- a/rclrs/src/parameter/service.rs
+++ b/rclrs/src/parameter/service.rs
@@ -17,17 +17,17 @@ use crate::{
 // What is used is the Weak that is stored in the node, and is upgraded when spinning.
 pub struct ParameterService {
     #[allow(dead_code)]
-    describe_parameters_service: Arc<Service<DescribeParameters>>,
+    describe_parameters_service: Service<DescribeParameters>,
     #[allow(dead_code)]
-    get_parameter_types_service: Arc<Service<GetParameterTypes>>,
+    get_parameter_types_service: Service<GetParameterTypes>,
     #[allow(dead_code)]
-    get_parameters_service: Arc<Service<GetParameters>>,
+    get_parameters_service: Service<GetParameters>,
     #[allow(dead_code)]
-    list_parameters_service: Arc<Service<ListParameters>>,
+    list_parameters_service: Service<ListParameters>,
     #[allow(dead_code)]
-    set_parameters_service: Arc<Service<SetParameters>>,
+    set_parameters_service: Service<SetParameters>,
     #[allow(dead_code)]
-    set_parameters_atomically_service: Arc<Service<SetParametersAtomically>>,
+    set_parameters_atomically_service: Service<SetParametersAtomically>,
 }
 
 fn describe_parameters(

--- a/rclrs/src/parameter/service.rs
+++ b/rclrs/src/parameter/service.rs
@@ -9,8 +9,7 @@ use rosidl_runtime_rs::Sequence;
 use super::ParameterMap;
 use crate::{
     parameter::{DeclaredValue, ParameterKind, ParameterStorage},
-    rmw_request_id_t, Node, RclrsError, Service, IntoPrimitiveOptions,
-    QoSProfile,
+    rmw_request_id_t, IntoPrimitiveOptions, Node, QoSProfile, RclrsError, Service,
 };
 
 // The variables only exist to keep a strong reference to the services and are technically unused.
@@ -248,8 +247,7 @@ impl ParameterService {
         // destruction is made for the parameter map.
         let map = parameter_map.clone();
         let describe_parameters_service = node.create_service(
-            (fqn.clone() + "/describe_parameters")
-            .qos(QoSProfile::parameter_services_default()),
+            (fqn.clone() + "/describe_parameters").qos(QoSProfile::parameter_services_default()),
             move |_req_id: &rmw_request_id_t, req: DescribeParameters_Request| {
                 let map = map.lock().unwrap();
                 describe_parameters(req, &map)
@@ -257,8 +255,7 @@ impl ParameterService {
         )?;
         let map = parameter_map.clone();
         let get_parameter_types_service = node.create_service(
-            (fqn.clone() + "/get_parameter_types")
-            .qos(QoSProfile::parameter_services_default()),
+            (fqn.clone() + "/get_parameter_types").qos(QoSProfile::parameter_services_default()),
             move |_req_id: &rmw_request_id_t, req: GetParameterTypes_Request| {
                 let map = map.lock().unwrap();
                 get_parameter_types(req, &map)
@@ -266,8 +263,7 @@ impl ParameterService {
         )?;
         let map = parameter_map.clone();
         let get_parameters_service = node.create_service(
-            (fqn.clone() + "/get_parameters")
-            .qos(QoSProfile::parameter_services_default()),
+            (fqn.clone() + "/get_parameters").qos(QoSProfile::parameter_services_default()),
             move |_req_id: &rmw_request_id_t, req: GetParameters_Request| {
                 let map = map.lock().unwrap();
                 get_parameters(req, &map)
@@ -275,8 +271,7 @@ impl ParameterService {
         )?;
         let map = parameter_map.clone();
         let list_parameters_service = node.create_service(
-            (fqn.clone() + "/list_parameters")
-            .qos(QoSProfile::parameter_services_default()),
+            (fqn.clone() + "/list_parameters").qos(QoSProfile::parameter_services_default()),
             move |_req_id: &rmw_request_id_t, req: ListParameters_Request| {
                 let map = map.lock().unwrap();
                 list_parameters(req, &map)
@@ -284,8 +279,7 @@ impl ParameterService {
         )?;
         let map = parameter_map.clone();
         let set_parameters_service = node.create_service(
-            (fqn.clone() + "/set_parameters")
-            .qos(QoSProfile::parameter_services_default()),
+            (fqn.clone() + "/set_parameters").qos(QoSProfile::parameter_services_default()),
             move |_req_id: &rmw_request_id_t, req: SetParameters_Request| {
                 let mut map = map.lock().unwrap();
                 set_parameters(req, &mut map)
@@ -293,7 +287,7 @@ impl ParameterService {
         )?;
         let set_parameters_atomically_service = node.create_service(
             (fqn.clone() + "/set_parameters_atomically")
-            .qos(QoSProfile::parameter_services_default()),
+                .qos(QoSProfile::parameter_services_default()),
             move |_req_id: &rmw_request_id_t, req: SetParametersAtomically_Request| {
                 let mut map = parameter_map.lock().unwrap();
                 set_parameters_atomically(req, &mut map)
@@ -319,8 +313,8 @@ mod tests {
             },
             srv::rmw::*,
         },
-        Context, MandatoryParameter, Node, ParameterRange, ParameterValue, RclrsError,
-        ReadOnlyParameter, NodeOptions, Executor, SpinOptions, RclrsErrorFilter,
+        Context, Executor, MandatoryParameter, Node, NodeOptions, ParameterRange, ParameterValue,
+        RclrsError, RclrsErrorFilter, ReadOnlyParameter, SpinOptions,
     };
     use rosidl_runtime_rs::{seq, Sequence};
     use std::{
@@ -353,11 +347,9 @@ mod tests {
 
     fn construct_test_nodes(ns: &str) -> (Executor, TestNode, Node) {
         let executor = Context::default().create_basic_executor();
-        let node = executor.create_node(
-            NodeOptions::new("node")
-            .namespace(ns)
-        )
-        .unwrap();
+        let node = executor
+            .create_node(NodeOptions::new("node").namespace(ns))
+            .unwrap();
         let range = ParameterRange {
             lower: Some(0),
             upper: Some(100),
@@ -387,11 +379,9 @@ mod tests {
             .mandatory()
             .unwrap();
 
-        let client = executor.create_node(
-            NodeOptions::new("client")
-            .namespace(ns)
-        )
-        .unwrap();
+        let client = executor
+            .create_node(NodeOptions::new("client").namespace(ns))
+            .unwrap();
 
         (
             executor,
@@ -454,12 +444,10 @@ mod tests {
         let inner_done = done.clone();
         let rclrs_spin = tokio::task::spawn(async move {
             try_until_timeout(move || {
-                executor.spin(
-                    SpinOptions::spin_once()
-                    .timeout(Duration::ZERO)
-                )
-                .timeout_ok()
-                .unwrap();
+                executor
+                    .spin(SpinOptions::spin_once().timeout(Duration::ZERO))
+                    .timeout_ok()
+                    .unwrap();
 
                 *inner_done.read().unwrap()
             })
@@ -601,12 +589,10 @@ mod tests {
         let rclrs_spin = tokio::task::spawn(async move {
             try_until_timeout(move || {
                 println!(" -- spin");
-                executor.spin(
-                    SpinOptions::spin_once()
-                    .timeout(Duration::ZERO)
-                )
-                .timeout_ok()
-                .unwrap();
+                executor
+                    .spin(SpinOptions::spin_once().timeout(Duration::ZERO))
+                    .timeout_ok()
+                    .unwrap();
 
                 *inner_done.read().unwrap()
             })
@@ -664,8 +650,8 @@ mod tests {
                 println!("checking client");
                 *client_finished.read().unwrap()
             })
-                .await
-                .unwrap();
+            .await
+            .unwrap();
 
             // Set a mix of existing, non existing, dynamic and out of range parameters
             let bool_parameter = RmwParameter {
@@ -814,8 +800,8 @@ mod tests {
                 println!("checking client finished");
                 *client_finished.read().unwrap()
             })
-                .await
-                .unwrap();
+            .await
+            .unwrap();
             *done.write().unwrap() = true;
         });
 
@@ -845,12 +831,10 @@ mod tests {
         let inner_done = done.clone();
         let rclrs_spin = tokio::task::spawn(async move {
             try_until_timeout(move || {
-                executor.spin(
-                    SpinOptions::spin_once()
-                    .timeout(Duration::ZERO)
-                )
-                .timeout_ok()
-                .unwrap();
+                executor
+                    .spin(SpinOptions::spin_once().timeout(Duration::ZERO))
+                    .timeout_ok()
+                    .unwrap();
 
                 *inner_done.read().unwrap()
             })

--- a/rclrs/src/parameter/value.rs
+++ b/rclrs/src/parameter/value.rs
@@ -537,7 +537,7 @@ impl ParameterValue {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Context, RclrsError, ToResult};
+    use crate::{Context, RclrsError, ToResult, InitOptions};
 
     // TODO(luca) tests for all from / to ParameterVariant functions
 
@@ -565,11 +565,14 @@ mod tests {
             ),
         ];
         for pair in input_output_pairs {
-            let ctx = Context::new([
-                String::from("--ros-args"),
-                String::from("-p"),
-                format!("foo:={}", pair.0),
-            ])?;
+            let ctx = Context::new(
+                [
+                    String::from("--ros-args"),
+                    String::from("-p"),
+                    format!("foo:={}", pair.0),
+                ],
+                InitOptions::default(),
+            )?;
             let mut rcl_params = std::ptr::null_mut();
             unsafe {
                 rcl_arguments_get_param_overrides(

--- a/rclrs/src/parameter/value.rs
+++ b/rclrs/src/parameter/value.rs
@@ -537,7 +537,7 @@ impl ParameterValue {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Context, RclrsError, ToResult, InitOptions};
+    use crate::{Context, InitOptions, RclrsError, ToResult};
 
     // TODO(luca) tests for all from / to ParameterVariant functions
 

--- a/rclrs/src/publisher.rs
+++ b/rclrs/src/publisher.rs
@@ -45,15 +45,32 @@ impl Drop for PublisherHandle {
 
 /// Struct for sending messages of type `T`.
 ///
+/// Create a publisher using [`Node::create_publisher`][1].
+///
 /// Multiple publishers can be created for the same topic, in different nodes or the same node.
+/// A clone of a `Publisher` will refer to the same publisher instance as the original.
+/// The underlying instance is tied to [`PublisherState`] which implements the [`Publisher`] API.
 ///
 /// The underlying RMW will decide on the concrete delivery mechanism (network stack, shared
 /// memory, or intraprocess).
 ///
-/// Sending messages does not require calling [`spin`][1] on the publisher's node.
+/// Sending messages does not require the node's executor to [spin][2].
 ///
-/// [1]: crate::spin
-pub struct Publisher<T>
+/// [1]: crate::NodeState::create_publisher
+/// [2]: crate::Executor::spin
+pub type Publisher<T> = Arc<PublisherState<T>>;
+
+/// The inner state of a [`Publisher`].
+///
+/// This is public so that you can choose to create a [`Weak`][1] reference to it
+/// if you want to be able to refer to a [`Publisher`] in a non-owning way. It is
+/// generally recommended to manage the `PublisherState` inside of an [`Arc`],
+/// and [`Publisher`] is provided as a convenience alias for that.
+///
+/// The public API of the [`Publisher`] type is implemented via `PublisherState`.
+///
+/// [1]: std::sync::Weak
+pub struct PublisherState<T>
 where
     T: Message,
 {
@@ -66,12 +83,12 @@ where
 
 // SAFETY: The functions accessing this type, including drop(), shouldn't care about the thread
 // they are running in. Therefore, this type can be safely sent to another thread.
-unsafe impl<T> Send for Publisher<T> where T: Message {}
+unsafe impl<T> Send for PublisherState<T> where T: Message {}
 // SAFETY: The type_support_ptr prevents the default Sync impl.
 // rosidl_message_type_support_t is a read-only type without interior mutability.
-unsafe impl<T> Sync for Publisher<T> where T: Message {}
+unsafe impl<T> Sync for PublisherState<T> where T: Message {}
 
-impl<T> Publisher<T>
+impl<T> PublisherState<T>
 where
     T: Message,
 {
@@ -179,7 +196,7 @@ where
     }
 }
 
-impl<T> Publisher<T>
+impl<T> PublisherState<T>
 where
     T: RmwMessage,
 {
@@ -260,7 +277,7 @@ impl<'a, T: IntoPrimitiveOptions<'a>> From<T> for PublisherOptions<'a> {
     }
 }
 
-/// Convenience trait for [`Publisher::publish`].
+/// Convenience trait for [`PublisherState::publish`].
 pub trait MessageCow<'a, T: Message> {
     /// Wrap the owned or borrowed message in a `Cow`.
     fn into_cow(self) -> Cow<'a, T>;

--- a/rclrs/src/publisher.rs
+++ b/rclrs/src/publisher.rs
@@ -244,12 +244,19 @@ pub struct PublisherOptions<'a> {
     pub qos: QoSProfile,
 }
 
+impl<'a> PublisherOptions<'a> {
+    /// Initialize a new [`PublisherOptions`] with default settings.
+    pub fn new(topic: &'a str) -> Self {
+        Self { topic, qos: QoSProfile::topics_default() }
+    }
+}
+
 impl<'a, T: IntoPrimitiveOptions<'a>> From<T> for PublisherOptions<'a> {
     fn from(value: T) -> Self {
-        let options = value.into_primitive_options();
-        let mut qos = QoSProfile::topics_default();
-        options.apply(&mut qos);
-        Self { topic: options.name, qos }
+        let primitive = value.into_primitive_options();
+        let mut options = Self::new(primitive.name);
+        primitive.apply(&mut options.qos);
+        options
     }
 }
 

--- a/rclrs/src/publisher.rs
+++ b/rclrs/src/publisher.rs
@@ -11,7 +11,7 @@ use crate::{
     error::{RclrsError, ToResult},
     qos::QoSProfile,
     rcl_bindings::*,
-    NodeHandle, ENTITY_LIFECYCLE_MUTEX,
+    NodeHandle, ENTITY_LIFECYCLE_MUTEX, IntoPrimitiveOptions,
 };
 
 mod loaned_message;
@@ -78,14 +78,14 @@ where
     /// Creates a new `Publisher`.
     ///
     /// Node and namespace changes are always applied _before_ topic remapping.
-    pub(crate) fn new(
+    pub(crate) fn new<'a>(
         node_handle: Arc<NodeHandle>,
-        topic: &str,
-        qos: QoSProfile,
+        options: impl Into<PublisherOptions<'a>>,
     ) -> Result<Self, RclrsError>
     where
         T: Message,
     {
+        let PublisherOptions { topic, qos } = options.into();
         // SAFETY: Getting a zero-initialized value is always safe.
         let mut rcl_publisher = unsafe { rcl_get_zero_initialized_publisher() };
         let type_support_ptr =
@@ -231,6 +231,28 @@ where
     }
 }
 
+/// `PublisherOptions` are used by [`Node::create_publisher`][1] to initialize
+/// a [`Publisher`].
+///
+/// [1]: crate::NodeState::create_publisher
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct PublisherOptions<'a> {
+    /// The topic name for the publisher.
+    pub topic: &'a str,
+    /// The quality of service settings for the publisher.
+    pub qos: QoSProfile,
+}
+
+impl<'a, T: IntoPrimitiveOptions<'a>> From<T> for PublisherOptions<'a> {
+    fn from(value: T) -> Self {
+        let options = value.into_primitive_options();
+        let mut qos = QoSProfile::topics_default();
+        options.apply(&mut qos);
+        Self { topic: options.name, qos }
+    }
+}
+
 /// Convenience trait for [`Publisher::publish`].
 pub trait MessageCow<'a, T: Message> {
     /// Wrap the owned or borrowed message in a `Cow`.
@@ -262,7 +284,7 @@ mod tests {
 
     #[test]
     fn test_publishers() -> Result<(), RclrsError> {
-        use crate::{TopicEndpointInfo, QOS_PROFILE_SYSTEM_DEFAULT};
+        use crate::TopicEndpointInfo;
         use test_msgs::msg;
 
         let namespace = "/test_publishers_graph";
@@ -270,16 +292,15 @@ mod tests {
 
         let node_1_empty_publisher = graph
             .node1
-            .create_publisher::<msg::Empty>("graph_test_topic_1", QOS_PROFILE_SYSTEM_DEFAULT)?;
+            .create_publisher::<msg::Empty>("graph_test_topic_1")?;
         let topic1 = node_1_empty_publisher.topic_name();
         let node_1_basic_types_publisher = graph.node1.create_publisher::<msg::BasicTypes>(
-            "graph_test_topic_2",
-            QOS_PROFILE_SYSTEM_DEFAULT,
+            "graph_test_topic_2"
         )?;
         let topic2 = node_1_basic_types_publisher.topic_name();
         let node_2_default_publisher = graph
             .node2
-            .create_publisher::<msg::Defaults>("graph_test_topic_3", QOS_PROFILE_SYSTEM_DEFAULT)?;
+            .create_publisher::<msg::Defaults>("graph_test_topic_3")?;
         let topic3 = node_2_default_publisher.topic_name();
 
         std::thread::sleep(std::time::Duration::from_millis(100));

--- a/rclrs/src/publisher.rs
+++ b/rclrs/src/publisher.rs
@@ -11,7 +11,7 @@ use crate::{
     error::{RclrsError, ToResult},
     qos::QoSProfile,
     rcl_bindings::*,
-    NodeHandle, ENTITY_LIFECYCLE_MUTEX, IntoPrimitiveOptions,
+    IntoPrimitiveOptions, NodeHandle, ENTITY_LIFECYCLE_MUTEX,
 };
 
 mod loaned_message;
@@ -264,7 +264,10 @@ pub struct PublisherOptions<'a> {
 impl<'a> PublisherOptions<'a> {
     /// Initialize a new [`PublisherOptions`] with default settings.
     pub fn new(topic: &'a str) -> Self {
-        Self { topic, qos: QoSProfile::topics_default() }
+        Self {
+            topic,
+            qos: QoSProfile::topics_default(),
+        }
     }
 }
 
@@ -318,9 +321,9 @@ mod tests {
             .node1
             .create_publisher::<msg::Empty>("graph_test_topic_1")?;
         let topic1 = node_1_empty_publisher.topic_name();
-        let node_1_basic_types_publisher = graph.node1.create_publisher::<msg::BasicTypes>(
-            "graph_test_topic_2"
-        )?;
+        let node_1_basic_types_publisher = graph
+            .node1
+            .create_publisher::<msg::BasicTypes>("graph_test_topic_2")?;
         let topic2 = node_1_basic_types_publisher.topic_name();
         let node_2_default_publisher = graph
             .node2

--- a/rclrs/src/publisher/loaned_message.rs
+++ b/rclrs/src/publisher/loaned_message.rs
@@ -2,13 +2,13 @@ use std::ops::{Deref, DerefMut};
 
 use rosidl_runtime_rs::RmwMessage;
 
-use crate::{rcl_bindings::*, Publisher, RclrsError, ToResult};
+use crate::{rcl_bindings::*, PublisherState, RclrsError, ToResult};
 
 /// A message that is owned by the middleware, loaned for publishing.
 ///
 /// It dereferences to a `&mut T`.
 ///
-/// This type is returned by [`Publisher::borrow_loaned_message()`], see the documentation of
+/// This type is returned by [`PublisherState::borrow_loaned_message()`], see the documentation of
 /// that function for more information.
 ///
 /// The loan is returned by dropping the message or [publishing it][1].
@@ -19,7 +19,7 @@ where
     T: RmwMessage,
 {
     pub(super) msg_ptr: *mut T,
-    pub(super) publisher: &'a Publisher<T>,
+    pub(super) publisher: &'a PublisherState<T>,
 }
 
 impl<'a, T> Deref for LoanedMessage<'a, T>

--- a/rclrs/src/qos.rs
+++ b/rclrs/src/qos.rs
@@ -166,7 +166,7 @@ pub struct QoSProfile {
     /// The time within which the RMW publisher must show that it is alive.
     ///
     /// If this is `Infinite`, liveliness is not enforced.
-    pub liveliness_lease_duration: QoSDuration,
+    pub liveliness_lease: QoSDuration,
     /// If true, any ROS specific namespacing conventions will be circumvented.
     ///
     /// In the case of DDS and topics, for example, this means the typical
@@ -200,7 +200,7 @@ impl From<QoSProfile> for rmw_qos_profile_t {
             deadline: qos.deadline.into(),
             lifespan: qos.lifespan.into(),
             liveliness: qos.liveliness.into(),
-            liveliness_lease_duration: qos.liveliness_lease_duration.into(),
+            liveliness_lease_duration: qos.liveliness_lease.into(),
             avoid_ros_namespace_conventions: qos.avoid_ros_namespace_conventions,
         }
     }
@@ -251,7 +251,7 @@ impl QoSProfile {
 
     /// Sets the QoS profile liveliness lease duration to the specified `Duration`.
     pub fn liveliness_lease_duration(mut self, lease_duration: Duration) -> Self {
-        self.liveliness_lease_duration = QoSDuration::Custom(lease_duration);
+        self.liveliness_lease = QoSDuration::Custom(lease_duration);
         self
     }
 
@@ -259,6 +259,38 @@ impl QoSProfile {
     pub fn lifespan(mut self, lifespan: Duration) -> Self {
         self.lifespan = QoSDuration::Custom(lifespan);
         self
+    }
+
+    /// Get the default QoS profile for ordinary topics.
+    pub fn topics_default() -> Self {
+        QOS_PROFILE_DEFAULT
+    }
+
+    /// Get the default QoS profile for topics that transmit sensor data.
+    pub fn sensor_data_default() -> Self {
+        QOS_PROFILE_SENSOR_DATA
+    }
+
+    /// Get the default QoS profile for services.
+    pub fn services_default() -> Self {
+        QOS_PROFILE_SERVICES_DEFAULT
+    }
+
+    /// Get the default QoS profile for parameter services.
+    pub fn parameter_services_default() -> Self {
+        QOS_PROFILE_PARAMETERS
+    }
+
+    /// Get the default QoS profile for parameter event topics.
+    pub fn parameter_events_default() -> Self {
+        QOS_PROFILE_PARAMETER_EVENTS
+    }
+
+    /// Get the system-defined default quality of service profile. This profile
+    /// is determined by the underlying RMW implementation, so you cannot rely
+    /// on this profile being consistent or appropriate for your needs.
+    pub fn system_default() -> Self {
+        QOS_PROFILE_SYSTEM_DEFAULT
     }
 }
 
@@ -355,7 +387,7 @@ pub const QOS_PROFILE_SENSOR_DATA: QoSProfile = QoSProfile {
     deadline: QoSDuration::SystemDefault,
     lifespan: QoSDuration::SystemDefault,
     liveliness: QoSLivelinessPolicy::SystemDefault,
-    liveliness_lease_duration: QoSDuration::SystemDefault,
+    liveliness_lease: QoSDuration::SystemDefault,
     avoid_ros_namespace_conventions: false,
 };
 
@@ -370,7 +402,7 @@ pub const QOS_PROFILE_CLOCK: QoSProfile = QoSProfile {
     deadline: QoSDuration::SystemDefault,
     lifespan: QoSDuration::SystemDefault,
     liveliness: QoSLivelinessPolicy::SystemDefault,
-    liveliness_lease_duration: QoSDuration::SystemDefault,
+    liveliness_lease: QoSDuration::SystemDefault,
     avoid_ros_namespace_conventions: false,
 };
 
@@ -384,7 +416,7 @@ pub const QOS_PROFILE_PARAMETERS: QoSProfile = QoSProfile {
     deadline: QoSDuration::SystemDefault,
     lifespan: QoSDuration::SystemDefault,
     liveliness: QoSLivelinessPolicy::SystemDefault,
-    liveliness_lease_duration: QoSDuration::SystemDefault,
+    liveliness_lease: QoSDuration::SystemDefault,
     avoid_ros_namespace_conventions: false,
 };
 
@@ -398,7 +430,7 @@ pub const QOS_PROFILE_DEFAULT: QoSProfile = QoSProfile {
     deadline: QoSDuration::SystemDefault,
     lifespan: QoSDuration::SystemDefault,
     liveliness: QoSLivelinessPolicy::SystemDefault,
-    liveliness_lease_duration: QoSDuration::SystemDefault,
+    liveliness_lease: QoSDuration::SystemDefault,
     avoid_ros_namespace_conventions: false,
 };
 
@@ -412,7 +444,7 @@ pub const QOS_PROFILE_SERVICES_DEFAULT: QoSProfile = QoSProfile {
     deadline: QoSDuration::SystemDefault,
     lifespan: QoSDuration::SystemDefault,
     liveliness: QoSLivelinessPolicy::SystemDefault,
-    liveliness_lease_duration: QoSDuration::SystemDefault,
+    liveliness_lease: QoSDuration::SystemDefault,
     avoid_ros_namespace_conventions: false,
 };
 
@@ -426,7 +458,7 @@ pub const QOS_PROFILE_PARAMETER_EVENTS: QoSProfile = QoSProfile {
     deadline: QoSDuration::SystemDefault,
     lifespan: QoSDuration::SystemDefault,
     liveliness: QoSLivelinessPolicy::SystemDefault,
-    liveliness_lease_duration: QoSDuration::SystemDefault,
+    liveliness_lease: QoSDuration::SystemDefault,
     avoid_ros_namespace_conventions: false,
 };
 
@@ -440,6 +472,6 @@ pub const QOS_PROFILE_SYSTEM_DEFAULT: QoSProfile = QoSProfile {
     deadline: QoSDuration::SystemDefault,
     lifespan: QoSDuration::SystemDefault,
     liveliness: QoSLivelinessPolicy::SystemDefault,
-    liveliness_lease_duration: QoSDuration::SystemDefault,
+    liveliness_lease: QoSDuration::SystemDefault,
     avoid_ros_namespace_conventions: false,
 };

--- a/rclrs/src/service.rs
+++ b/rclrs/src/service.rs
@@ -185,6 +185,8 @@ where
 
 /// `ServiceOptions are used by [`Node::create_service`][1] to initialize a
 /// [`Service`] provider.
+///
+/// [1]: crate::NodeState::create_service
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct ServiceOptions<'a> {

--- a/rclrs/src/service.rs
+++ b/rclrs/src/service.rs
@@ -59,14 +59,33 @@ pub trait ServiceBase: Send + Sync {
 type ServiceCallback<Request, Response> =
     Box<dyn Fn(&rmw_request_id_t, Request) -> Response + 'static + Send>;
 
-/// Main class responsible for responding to requests sent by ROS clients.
+/// Provide a service that can respond to requests sent by ROS service clients.
 ///
-/// The only available way to instantiate services is via [`Node::create_service()`][1], this is to
-/// ensure that [`Node`][2]s can track all the services that have been created.
+/// Create a service using [`Node::create_service`][1].
 ///
-/// [1]: crate::Node::create_service
-/// [2]: crate::Node
-pub struct Service<T>
+/// ROS only supports having one service provider for any given fully-qualified
+/// service name. "Fully-qualified" means the namespace is also taken into account
+/// for uniqueness. A clone of a `Service` will refer to the same service provider
+/// instance as the original. The underlying instance is tied to [`ServiceState`]
+/// which implements the [`Service`] API.
+///
+/// Responding to requests requires the node's executor to [spin][2].
+///
+/// [1]: crate::NodeState::create_service
+/// [2]: crate::Executor::spin
+pub type Service<T> = Arc<ServiceState<T>>;
+
+/// The inner state of a [`Service`].
+///
+/// This is public so that you can choose to create a [`Weak`][1] reference to it
+/// if you want to be able to refer to a [`Service`] in a non-owning way. It is
+/// generally recommended to manage the `ServiceState` inside of an [`Arc`],
+/// and [`Service`] is provided as a convenience alias for that.
+///
+/// The public API of the [`Service`] type is implemented via `ServiceState`.
+///
+/// [1]: std::sync::Weak
+pub struct ServiceState<T>
 where
     T: rosidl_runtime_rs::Service,
 {
@@ -75,7 +94,7 @@ where
     pub callback: Mutex<ServiceCallback<T::Request, T::Response>>,
 }
 
-impl<T> Service<T>
+impl<T> ServiceState<T>
 where
     T: rosidl_runtime_rs::Service,
 {
@@ -212,7 +231,7 @@ impl<'a, T: IntoPrimitiveOptions<'a>> From<T> for ServiceOptions<'a> {
     }
 }
 
-impl<T> ServiceBase for Service<T>
+impl<T> ServiceBase for ServiceState<T>
 where
     T: rosidl_runtime_rs::Service,
 {

--- a/rclrs/src/service.rs
+++ b/rclrs/src/service.rs
@@ -9,7 +9,7 @@ use rosidl_runtime_rs::Message;
 use crate::{
     error::{RclReturnCode, ToResult},
     rcl_bindings::*,
-    IntoPrimitiveOptions, MessageCow, NodeHandle, RclrsError, ENTITY_LIFECYCLE_MUTEX, QoSProfile,
+    IntoPrimitiveOptions, MessageCow, NodeHandle, QoSProfile, RclrsError, ENTITY_LIFECYCLE_MUTEX,
 };
 
 // SAFETY: The functions accessing this type, including drop(), shouldn't care about the thread
@@ -218,7 +218,10 @@ pub struct ServiceOptions<'a> {
 impl<'a> ServiceOptions<'a> {
     /// Initialize a new [`ServiceOptions`] with default settings.
     pub fn new(name: &'a str) -> Self {
-        Self { name, qos: QoSProfile::services_default() }
+        Self {
+            name,
+            qos: QoSProfile::services_default(),
+        }
     }
 }
 

--- a/rclrs/src/service.rs
+++ b/rclrs/src/service.rs
@@ -192,16 +192,23 @@ where
 pub struct ServiceOptions<'a> {
     /// The name for the service
     pub name: &'a str,
-    /// The quality of service for the service.
+    /// The quality of service profile for the service.
     pub qos: QoSProfile,
+}
+
+impl<'a> ServiceOptions<'a> {
+    /// Initialize a new [`ServiceOptions`] with default settings.
+    pub fn new(name: &'a str) -> Self {
+        Self { name, qos: QoSProfile::services_default() }
+    }
 }
 
 impl<'a, T: IntoPrimitiveOptions<'a>> From<T> for ServiceOptions<'a> {
     fn from(value: T) -> Self {
-        let options = value.into_primitive_options();
-        let mut qos = QoSProfile::services_default();
-        options.apply(&mut qos);
-        Self { name: options.name, qos }
+        let primitive = value.into_primitive_options();
+        let mut options = Self::new(primitive.name);
+        primitive.apply(&mut options.qos);
+        options
     }
 }
 

--- a/rclrs/src/subscription.rs
+++ b/rclrs/src/subscription.rs
@@ -10,7 +10,7 @@ use crate::{
     error::{RclReturnCode, ToResult},
     qos::QoSProfile,
     rcl_bindings::*,
-    NodeHandle, RclrsError, ENTITY_LIFECYCLE_MUTEX, IntoPrimitiveOptions,
+    IntoPrimitiveOptions, NodeHandle, RclrsError, ENTITY_LIFECYCLE_MUTEX,
 };
 
 mod callback;
@@ -290,7 +290,10 @@ pub struct SubscriptionOptions<'a> {
 impl<'a> SubscriptionOptions<'a> {
     /// Initialize a new [`SubscriptionOptions`] with default settings.
     pub fn new(topic: &'a str) -> Self {
-        Self { topic, qos: QoSProfile::topics_default() }
+        Self {
+            topic,
+            qos: QoSProfile::topics_default(),
+        }
     }
 }
 
@@ -377,10 +380,9 @@ mod tests {
         let namespace = "/test_subscriptions_graph";
         let graph = construct_test_graph(namespace)?;
 
-        let node_2_empty_subscription = graph.node2.create_subscription::<msg::Empty, _>(
-            "graph_test_topic_1",
-            |_msg: msg::Empty| {},
-        )?;
+        let node_2_empty_subscription = graph
+            .node2
+            .create_subscription::<msg::Empty, _>("graph_test_topic_1", |_msg: msg::Empty| {})?;
         let topic1 = node_2_empty_subscription.topic_name();
         let node_2_basic_types_subscription =
             graph.node2.create_subscription::<msg::BasicTypes, _>(

--- a/rclrs/src/subscription.rs
+++ b/rclrs/src/subscription.rs
@@ -64,21 +64,32 @@ pub trait SubscriptionBase: Send + Sync {
 
 /// Struct for receiving messages of type `T`.
 ///
-/// There can be multiple subscriptions for the same topic, in different nodes or the same node.
+/// Create a subscription using [`Node::create_subscription`][1].
 ///
-/// Receiving messages requires calling [`spin_once`][1] or [`spin`][2] on the subscription's node.
+/// There can be multiple subscriptions for the same topic, in different nodes or the same node.
+/// A clone of a `Subscription` will refer to the same subscription instance as the original.
+/// The underlying instance is tied to [`SubscriptionState`] which implements the [`Subscription`] API.
+///
+/// Receiving messages requires the node's executor to [spin][2].
 ///
 /// When a subscription is created, it may take some time to get "matched" with a corresponding
 /// publisher.
 ///
-/// The only available way to instantiate subscriptions is via [`Node::create_subscription()`][3], this
-/// is to ensure that [`Node`][4]s can track all the subscriptions that have been created.
+/// [1]: crate::NodeState::create_subscription
+/// [2]: crate::Executor::spin
+pub type Subscription<T> = Arc<SubscriptionState<T>>;
+
+/// The inner state of a [`Subscription`].
 ///
-/// [1]: crate::spin_once
-/// [2]: crate::spin
-/// [3]: crate::Node::create_subscription
-/// [4]: crate::Node
-pub struct Subscription<T>
+/// This is public so that you can choose to create a [`Weak`][1] reference to it
+/// if you want to be able to refer to a [`Subscription`] in a non-owning way. It is
+/// generally recommended to manage the `SubscriptionState` inside of an [`Arc`],
+/// and [`Subscription`] is provided as a convenience alias for that.
+///
+/// The public API of the [`Subscription`] type is implemented via `SubscriptionState`.
+///
+/// [1]: std::sync::Weak
+pub struct SubscriptionState<T>
 where
     T: Message,
 {
@@ -88,7 +99,7 @@ where
     message: PhantomData<T>,
 }
 
-impl<T> Subscription<T>
+impl<T> SubscriptionState<T>
 where
     T: Message,
 {
@@ -237,7 +248,7 @@ where
     /// for more information.
     ///
     /// [1]: crate::RclrsError
-    /// [2]: crate::Publisher::borrow_loaned_message
+    /// [2]: crate::PublisherState::borrow_loaned_message
     pub fn take_loaned(&self) -> Result<(ReadOnlyLoanedMessage<'_, T>, MessageInfo), RclrsError> {
         let mut msg_ptr = std::ptr::null_mut();
         let mut message_info = unsafe { rmw_get_zero_initialized_message_info() };
@@ -292,7 +303,7 @@ impl<'a, T: IntoPrimitiveOptions<'a>> From<T> for SubscriptionOptions<'a> {
     }
 }
 
-impl<T> SubscriptionBase for Subscription<T>
+impl<T> SubscriptionBase for SubscriptionState<T>
 where
     T: Message,
 {

--- a/rclrs/src/subscription.rs
+++ b/rclrs/src/subscription.rs
@@ -263,8 +263,10 @@ where
     }
 }
 
-/// `SubscriptionOptions` are used by [`Node::create_subscription`] to initialize
-/// a [`Subscription`].
+/// `SubscriptionOptions` are used by [`Node::create_subscription`][1]
+/// to initialize a [`Subscription`].
+///
+/// [1]: crate::NodeState::create_subscription
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct SubscriptionOptions<'a> {

--- a/rclrs/src/subscription.rs
+++ b/rclrs/src/subscription.rs
@@ -10,7 +10,7 @@ use crate::{
     error::{RclReturnCode, ToResult},
     qos::QoSProfile,
     rcl_bindings::*,
-    NodeHandle, RclrsError, ENTITY_LIFECYCLE_MUTEX,
+    NodeHandle, RclrsError, ENTITY_LIFECYCLE_MUTEX, IntoPrimitiveOptions,
 };
 
 mod callback;
@@ -93,10 +93,9 @@ where
     T: Message,
 {
     /// Creates a new subscription.
-    pub(crate) fn new<Args>(
+    pub(crate) fn new<'a, Args>(
         node_handle: Arc<NodeHandle>,
-        topic: &str,
-        qos: QoSProfile,
+        options: impl Into<SubscriptionOptions<'a>>,
         callback: impl SubscriptionCallback<T, Args>,
     ) -> Result<Self, RclrsError>
     // This uses pub(crate) visibility to avoid instantiating this struct outside
@@ -104,6 +103,7 @@ where
     where
         T: Message,
     {
+        let SubscriptionOptions { topic, qos } = options.into();
         // SAFETY: Getting a zero-initialized value is always safe.
         let mut rcl_subscription = unsafe { rcl_get_zero_initialized_subscription() };
         let type_support =
@@ -114,8 +114,8 @@ where
         })?;
 
         // SAFETY: No preconditions for this function.
-        let mut subscription_options = unsafe { rcl_subscription_get_default_options() };
-        subscription_options.qos = qos.into();
+        let mut rcl_subscription_options = unsafe { rcl_subscription_get_default_options() };
+        rcl_subscription_options.qos = qos.into();
 
         {
             let rcl_node = node_handle.rcl_node.lock().unwrap();
@@ -132,7 +132,7 @@ where
                     &*rcl_node,
                     type_support,
                     topic_c_string.as_ptr(),
-                    &subscription_options,
+                    &rcl_subscription_options,
                 )
                 .ok()?;
             }
@@ -263,6 +263,28 @@ where
     }
 }
 
+/// `SubscriptionOptions` are used by [`Node::create_subscription`] to initialize
+/// a [`Subscription`].
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct SubscriptionOptions<'a> {
+    /// The topic name for the subscription.
+    pub topic: &'a str,
+    /// The quality of service settings for the subscription.
+    pub qos: QoSProfile,
+}
+
+impl<'a, T: IntoPrimitiveOptions<'a>> From<T> for SubscriptionOptions<'a> {
+    fn from(value: T) -> Self {
+        let options = value.into_primitive_options();
+        // Topics will use the QOS_PROFILE_DEFAULT by default, which is designed
+        // to roughly match the ROS 1 default topic behavior.
+        let mut qos = QoSProfile::topics_default();
+        options.apply(&mut qos);
+        Self { topic: options.name, qos }
+    }
+}
+
 impl<T> SubscriptionBase for Subscription<T>
 where
     T: Message,
@@ -332,27 +354,24 @@ mod tests {
 
     #[test]
     fn test_subscriptions() -> Result<(), RclrsError> {
-        use crate::{TopicEndpointInfo, QOS_PROFILE_SYSTEM_DEFAULT};
+        use crate::TopicEndpointInfo;
 
         let namespace = "/test_subscriptions_graph";
         let graph = construct_test_graph(namespace)?;
 
         let node_2_empty_subscription = graph.node2.create_subscription::<msg::Empty, _>(
             "graph_test_topic_1",
-            QOS_PROFILE_SYSTEM_DEFAULT,
             |_msg: msg::Empty| {},
         )?;
         let topic1 = node_2_empty_subscription.topic_name();
         let node_2_basic_types_subscription =
             graph.node2.create_subscription::<msg::BasicTypes, _>(
                 "graph_test_topic_2",
-                QOS_PROFILE_SYSTEM_DEFAULT,
                 |_msg: msg::BasicTypes| {},
             )?;
         let topic2 = node_2_basic_types_subscription.topic_name();
         let node_1_defaults_subscription = graph.node1.create_subscription::<msg::Defaults, _>(
             "graph_test_topic_3",
-            QOS_PROFILE_SYSTEM_DEFAULT,
             |_msg: msg::Defaults| {},
         )?;
         let topic3 = node_1_defaults_subscription.topic_name();

--- a/rclrs/src/subscription.rs
+++ b/rclrs/src/subscription.rs
@@ -276,14 +276,19 @@ pub struct SubscriptionOptions<'a> {
     pub qos: QoSProfile,
 }
 
+impl<'a> SubscriptionOptions<'a> {
+    /// Initialize a new [`SubscriptionOptions`] with default settings.
+    pub fn new(topic: &'a str) -> Self {
+        Self { topic, qos: QoSProfile::topics_default() }
+    }
+}
+
 impl<'a, T: IntoPrimitiveOptions<'a>> From<T> for SubscriptionOptions<'a> {
     fn from(value: T) -> Self {
-        let options = value.into_primitive_options();
-        // Topics will use the QOS_PROFILE_DEFAULT by default, which is designed
-        // to roughly match the ROS 1 default topic behavior.
-        let mut qos = QoSProfile::topics_default();
-        options.apply(&mut qos);
-        Self { topic: options.name, qos }
+        let primitive = value.into_primitive_options();
+        let mut options = Self::new(primitive.name);
+        primitive.apply(&mut options.qos);
+        options
     }
 }
 

--- a/rclrs/src/subscription/readonly_loaned_message.rs
+++ b/rclrs/src/subscription/readonly_loaned_message.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 use rosidl_runtime_rs::Message;
 
-use crate::{rcl_bindings::*, Subscription, ToResult};
+use crate::{rcl_bindings::*, SubscriptionState, ToResult};
 
 /// A message that is owned by the middleware, loaned out for reading.
 ///
@@ -10,7 +10,7 @@ use crate::{rcl_bindings::*, Subscription, ToResult};
 /// message, it's the same as `&T`, and otherwise it's the corresponding RMW-native
 /// message.
 ///
-/// This type is returned by [`Subscription::take_loaned()`] and may be used in
+/// This type is returned by [`SubscriptionState::take_loaned()`] and may be used in
 /// subscription callbacks.
 ///
 /// The loan is returned by dropping the `ReadOnlyLoanedMessage`.
@@ -19,7 +19,7 @@ where
     T: Message,
 {
     pub(super) msg_ptr: *const T::RmwMsg,
-    pub(super) subscription: &'a Subscription<T>,
+    pub(super) subscription: &'a SubscriptionState<T>,
 }
 
 impl<'a, T> Deref for ReadOnlyLoanedMessage<'a, T>

--- a/rclrs/src/test_helpers/graph_helpers.rs
+++ b/rclrs/src/test_helpers/graph_helpers.rs
@@ -1,4 +1,4 @@
-use crate::{Context, Node, RclrsError, NodeOptions};
+use crate::{Context, Node, NodeOptions, RclrsError};
 
 pub(crate) struct TestGraph {
     pub node1: Node,
@@ -8,13 +8,7 @@ pub(crate) struct TestGraph {
 pub(crate) fn construct_test_graph(namespace: &str) -> Result<TestGraph, RclrsError> {
     let executor = Context::default().create_basic_executor();
     Ok(TestGraph {
-        node1: executor.create_node(
-            NodeOptions::new("graph_test_node_1")
-            .namespace(namespace)
-        )?,
-        node2: executor.create_node(
-            NodeOptions::new("graph_test_node_2")
-            .namespace(namespace)
-        )?,
+        node1: executor.create_node(NodeOptions::new("graph_test_node_1").namespace(namespace))?,
+        node2: executor.create_node(NodeOptions::new("graph_test_node_2").namespace(namespace))?,
     })
 }

--- a/rclrs/src/test_helpers/graph_helpers.rs
+++ b/rclrs/src/test_helpers/graph_helpers.rs
@@ -1,19 +1,20 @@
-use crate::{Context, Node, NodeBuilder, RclrsError};
-use std::sync::Arc;
+use crate::{Context, Node, RclrsError, NodeOptions};
 
 pub(crate) struct TestGraph {
-    pub node1: Arc<Node>,
-    pub node2: Arc<Node>,
+    pub node1: Node,
+    pub node2: Node,
 }
 
 pub(crate) fn construct_test_graph(namespace: &str) -> Result<TestGraph, RclrsError> {
-    let context = Context::new([])?;
+    let executor = Context::default().create_basic_executor();
     Ok(TestGraph {
-        node1: NodeBuilder::new(&context, "graph_test_node_1")
+        node1: executor.create_node(
+            NodeOptions::new("graph_test_node_1")
             .namespace(namespace)
-            .build()?,
-        node2: NodeBuilder::new(&context, "graph_test_node_2")
+        )?,
+        node2: executor.create_node(
+            NodeOptions::new("graph_test_node_2")
             .namespace(namespace)
-            .build()?,
+        )?,
     })
 }

--- a/rclrs/src/time_source.rs
+++ b/rclrs/src/time_source.rs
@@ -1,7 +1,7 @@
 use crate::{
     clock::{Clock, ClockSource, ClockType},
-    vendor::rosgraph_msgs::msg::Clock as ClockMsg, IntoPrimitiveOptions,
-    Node, QoSProfile, ReadOnlyParameter, Subscription, QOS_PROFILE_CLOCK,
+    vendor::rosgraph_msgs::msg::Clock as ClockMsg,
+    IntoPrimitiveOptions, Node, QoSProfile, ReadOnlyParameter, Subscription, QOS_PROFILE_CLOCK,
 };
 use std::sync::{Arc, Mutex, RwLock};
 
@@ -132,7 +132,8 @@ impl TimeSource {
                 if let Some(clock) = clock.lock().unwrap().as_mut() {
                     Self::update_clock(clock, nanoseconds);
                 }
-            })
+            },
+        )
         .unwrap()
     }
 }
@@ -143,7 +144,10 @@ mod tests {
 
     #[test]
     fn time_source_default_clock() {
-        let node = Context::default().create_basic_executor().create_node("test_node").unwrap();
+        let node = Context::default()
+            .create_basic_executor()
+            .create_node("test_node")
+            .unwrap();
         // Default clock should be above 0 (use_sim_time is default false)
         assert!(node.get_clock().now().nsec > 0);
     }
@@ -156,7 +160,7 @@ mod tests {
                 String::from("-p"),
                 String::from("use_sim_time:=true"),
             ],
-            InitOptions::default()
+            InitOptions::default(),
         )
         .unwrap()
         .create_basic_executor();

--- a/rclrs/src/time_source.rs
+++ b/rclrs/src/time_source.rs
@@ -13,7 +13,7 @@ pub(crate) struct TimeSource {
     clock_source: Arc<Mutex<Option<ClockSource>>>,
     requested_clock_type: ClockType,
     clock_qos: QoSProfile,
-    clock_subscription: Mutex<Option<Arc<Subscription<ClockMsg>>>>,
+    clock_subscription: Mutex<Option<Subscription<ClockMsg>>>,
     last_received_time: Arc<Mutex<Option<i64>>>,
     // TODO(luca) Make this parameter editable when we have parameter callbacks implemented and can
     // safely change clock type at runtime
@@ -119,7 +119,7 @@ impl TimeSource {
         clock.set_ros_time_override(nanoseconds);
     }
 
-    fn create_clock_sub(&self, node: &Node) -> Arc<Subscription<ClockMsg>> {
+    fn create_clock_sub(&self, node: &Node) -> Subscription<ClockMsg> {
         let clock = self.clock_source.clone();
         let last_received_time = self.last_received_time.clone();
         // Safe to unwrap since the function will only fail if invalid arguments are provided

--- a/rclrs/src/wait.rs
+++ b/rclrs/src/wait.rs
@@ -427,7 +427,7 @@ mod tests {
 
     #[test]
     fn guard_condition_in_wait_set_readies() -> Result<(), RclrsError> {
-        let context = Context::new([])?;
+        let context = Context::default();
 
         let guard_condition = Arc::new(GuardCondition::new(&context));
 

--- a/rclrs/src/wait.rs
+++ b/rclrs/src/wait.rs
@@ -20,7 +20,7 @@ use std::{sync::Arc, time::Duration, vec::Vec};
 use crate::{
     error::{to_rclrs_result, RclReturnCode, RclrsError, ToResult},
     rcl_bindings::*,
-    ClientBase, Context, ContextHandle, Node, ServiceBase, SubscriptionBase,
+    ClientBase, Context, ContextHandle, NodeState, ServiceBase, SubscriptionBase,
 };
 
 mod exclusivity_guard;
@@ -133,7 +133,7 @@ impl WaitSet {
     /// Creates a new wait set and adds all waitable entities in the node to it.
     ///
     /// The wait set is sized to fit the node exactly, so there is no capacity for adding other entities.
-    pub fn new_for_node(node: &Node) -> Result<Self, RclrsError> {
+    pub fn new_for_node(node: &NodeState) -> Result<Self, RclrsError> {
         let live_subscriptions = node.live_subscriptions();
         let live_clients = node.live_clients();
         let live_guard_conditions = node.live_guard_conditions();

--- a/rclrs/src/wait/guard_condition.rs
+++ b/rclrs/src/wait/guard_condition.rs
@@ -16,7 +16,7 @@ use crate::{rcl_bindings::*, Context, ContextHandle, RclrsError, ToResult};
 /// # use rclrs::{Context, GuardCondition, WaitSet, RclrsError};
 /// # use std::sync::{Arc, atomic::Ordering};
 ///
-/// let context = Context::new([])?;
+/// let context = Context::default();
 ///
 /// let atomic_bool = Arc::new(std::sync::atomic::AtomicBool::new(false));
 /// let atomic_bool_for_closure = Arc::clone(&atomic_bool);
@@ -162,7 +162,7 @@ mod tests {
 
     #[test]
     fn test_guard_condition() -> Result<(), RclrsError> {
-        let context = Context::new([])?;
+        let context = Context::default();
 
         let atomic_bool = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let atomic_bool_for_closure = Arc::clone(&atomic_bool);
@@ -180,7 +180,7 @@ mod tests {
 
     #[test]
     fn test_guard_condition_wait() -> Result<(), RclrsError> {
-        let context = Context::new([])?;
+        let context = Context::default();
 
         let atomic_bool = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let atomic_bool_for_closure = Arc::clone(&atomic_bool);


### PR DESCRIPTION
This PR introduces a number of API breakages that I will be proposing with the following goals:
* Review the API breakages needed for #421 in isolation from the introduction of the async features
* Future-proof the rclrs API so that we can add even more features beyond #421 without breaking API again
* Streamline some aspects of the API to cut down on the noise that users experience

There are three broad categories of breaking API changes that are being introduced here. Each of these categories can be discussed and iterated on independently, and I'm happy to revert or revise each of them as needed, bearing in mind that some breakages cannot be avoided in order to introduce async execution. I've lumped all three into one PR with the intent of completing all foreseeable API breakages in one fell swoop. If it's desired, I can reorganize this into a sequence of incremental API breaking PRs.

The three categories are broken down below:

### 1. Execution structure (Context -> Execution -> Node relationship)

#### (spun out in #428)

This is the most crucial change for the async execution to be feasible. Up until now, rclrs has had a loose coupling between the executor and nodes. That means nodes could be added to or removed from the executor freely. This comes with the following disadvantages:
* It's possible to add the same node to multiple executors and spin them both at the same time. We have protections in place so that this won't violate any contract with rcl, but it would be a confusing arrangement.
* We need many layers of mutexes, arcs, and weaks to manage the loose ownership.
* Users don't have a clear order in which to invoke these three top-level objects.
* For async execution, nodes will need a way of issuing jobs to their executor at any time, which isn't possible if they can be orphaned or bounce around between executors.

Due to the last bullet point in particular, I'm proposing a rigid procedure in which:
* A user creates a Context
* The Context can create one or more Executors
* Each Executor can create one or more Nodes

The [minimum publisher example](https://github.com/mxgrey/ros2_rust/blob/c46e2abc29da862f0a79dccad25a598852e44c8c/examples/minimal_pub_sub/src/minimal_publisher.rs#L4-L7) shows a good demonstration of this new procedure.

In this structure, Nodes are no longer allowed to be removed from an Executor or move between Executors. That's a very unlikely use case to begin with, so I don't think there's a downside to this restriction. After #421 we'll be able to introduce custom flavors of Executors, so if anyone really cares about moving their node around between executors, it would be possible to introduce a custom hierarchical executor that can move nodes between other executors.

### 2. Options Pattern

#### (spun out in #429)

This is a slight twist on the builder pattern that we were using via `NodeBuilder` up until now.

Instead of creating a "builder" object which will eventually `.build()` the final product, we will build an `_Options` structure which gets passed into a `create_` function. Here are some examples:
* [`create_node`](https://github.com/mxgrey/ros2_rust/blob/c46e2abc29da862f0a79dccad25a598852e44c8c/rclrs/src/test_helpers/graph_helpers.rs#L12-L13)
* [`create_subscription`](https://github.com/mxgrey/ros2_rust/blob/c46e2abc29da862f0a79dccad25a598852e44c8c/rclrs/src/node.rs#L447-L449)
* [`create_service`](https://github.com/mxgrey/ros2_rust/blob/c46e2abc29da862f0a79dccad25a598852e44c8c/rclrs/src/node.rs#L384-L386)

The user fills up the `_Options` with whichever fields are relevant to them, and the rest of the option fields will use default values. Note that publishers and subscribers will have different default QoS from clients and services, and this is taken into account by the option builders for these different primitive types.

### 3. Arcs

#### (spun out in #430)

This one is very subjective so I don't mind reverting it, but I felt that the prevalence of `Arc` in the API was adding noise that is seldom relevant to the average user. In this PR, I've refactored the API a little so that `Node`, `Subscription`, `Publisher`, `Client`, and `Service` each have a respective `_State` structure which is public and represents the underlying instance. At the same time, `Node`, `Subscription`, etc are now type aliases of the form
* `pub type Node = Arc<NodeState>;`
* `pub type Subscription<T> = Arc<SubscriptionState<T>>;` 

This does not lead to any actual change in the structure or memory management of any of these types; it's a purely superficial renaming. But it reduces how often `Arc` is tossed around in the API and thereby streamlines the 95% (my own estimate) of use cases where `Arc` is just an implementation detail. At the same time, it does not interfere with the remaining 5% of use cases where the `Arc` is relevant, e.g. if a user wants to hold onto a `Weak<Node>` for some reason.