### PR TITLE
Installs rust toolchain 1.75 in the docker workflow.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Rust and the cargo-ament-build plugin
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.74.0 -y
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.75.0 -y
 ENV PATH=/root/.cargo/bin:$PATH
 RUN cargo install cargo-ament-build
 


### PR DESCRIPTION
# Description

This PR updates the rust toolchain installation to v1.75 when using the docker workflow.

# Context

See https://github.com/ros2-rust/ros2_rust/pull/420 and https://github.com/ros2-rust/ros2_rust/issues/398

# How to test it?

Follow the https://github.com/ros2-rust/ros2_rust/blob/main/docs/building.md guidelines from the top down, branching for the docker workflow and when executing https://github.com/ros2-rust/ros2_rust/blob/main/docs/building.md#building-with-colcon do: 

```
colcon build
```

You should be able to build all packages without errors.