### PR TITLE
Minor fixes to pub sub tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Introduction
 This is a set of projects (the `rclrs` client library, code generator, examples and more) that
 enables developers to write ROS 2 applications in Rust.
 
+Installation
+------------
+
+Follow the [instructions in the documentation directory](docs/building.md).
+
 Features and limitations
 ------------------------
 

--- a/docs/writing_a_simple_publisher_and_subscriber.md
+++ b/docs/writing_a_simple_publisher_and_subscriber.md
@@ -92,7 +92,6 @@ To construct a node, replace the code in your `main.rs` file with the following:
 ```rust
 /// Creates a SimplePublisherNode, initializes a node and publisher, and provides
 /// methods to publish a simple "Hello World" message on a loop in separate threads.
-
 use rclrs::{create_node, Context, Node, Publisher, RclrsError, QOS_PROFILE_DEFAULT};
 use std::{env, sync::Arc, thread, time::Duration};
 use std_msgs::msg::String as StringMsg;
@@ -103,12 +102,12 @@ struct SimplePublisherNode {
     publisher: Arc<Publisher<StringMsg>>,
 }
 impl SimplePublisherNode {
-    fn new(context: &context) -> result<self, RclrsError> {
+    fn new(context: &Context) -> Result<Self, RclrsError> {
         let node = create_node(context, "simple_publisher").unwrap();
         let publisher = node
-            .create_publisher("publish_hello", qos_profile_default)
+            .create_publisher("publish_hello", QOS_PROFILE_DEFAULT)
             .unwrap();
-        ok(self { node, publisher })
+        Ok(Self { node, publisher })
     }
     fn publish_data(&self, increment: i32) -> Result<i32, RclrsError> {
         let msg: StringMsg = StringMsg {


### PR DESCRIPTION
* Small change to fix some capitalization on the Rust code pasted in the pub/sub tutorial. 
* Add a link to the installation instruction from the main README.md