### PR TITLE
Fix GHA status labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ROS 2 for Rust
 ==============
 
-| Target | Status |
-|----------|--------|
-| **Ubuntu 20.04** | [![Build Status](https://github.com/ros2-rust/ros2_rust/actions/workflows/rust.yml/badge.svg?branch=main)](https://github.com/ros2-rust/ros2_rust/actions/workflows/rust.yml?branch=main) |
+[![Minimal Version Status](https://github.com/ros2-rust/ros2_rust/actions/workflows/rust-minimal.yml/badge.svg?branch=main)](https://github.com/ros2-rust/ros2_rust/actions/workflows/rust-minimal.yml)
+[![Stable CI Status](https://github.com/ros2-rust/ros2_rust/actions/workflows/rust-stable.yml/badge.svg?branch=main)](https://github.com/ros2-rust/ros2_rust/actions/workflows/rust-stable.yml)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 Introduction
 ------------


### PR DESCRIPTION
# Description
This PR fixes the GitHub Action label after the corresponding workflows were renamed on [#429.](https://github.com/ros2-rust/ros2_rust/pull/420).

# Change involved
This PR applies the following changes:
- Creates one label per workflow (`rust-minimal.yaml` and `rust-stable.yaml`).
- Removes the status table in favor of a row of labels since only Ubuntu is currently supported (and it easily gets outdated since `ubuntu-latest` is used for CI jobs).
- Adds a new label for the repository license.

# How was this tested?
Rendered README file visually inspected.
