### PR TITLE
Fix GHA set-output command warning

### DIFF
--- a/.github/workflows/rust-minimal.yml
+++ b/.github/workflows/rust-minimal.yml
@@ -45,7 +45,11 @@ jobs:
     - name: Search packages in this repository
       id: list_packages
       run: |
-        echo ::set-output name=package_list::$(colcon list --names-only)
+        {
+          echo 'package_list<<EOF'
+          colcon list --names-only
+          echo EOF
+        } >> "$GITHUB_OUTPUT"
 
     - name: Setup ROS environment
       uses: ros-tooling/setup-ros@v0.7

--- a/.github/workflows/rust-stable.yml
+++ b/.github/workflows/rust-stable.yml
@@ -45,7 +45,11 @@ jobs:
     - name: Search packages in this repository
       id: list_packages
       run: |
-        echo ::set-output name=package_list::$(colcon list --names-only)
+        {
+          echo 'package_list<<EOF'
+          colcon list --names-only
+          echo EOF
+        } >> "$GITHUB_OUTPUT"
 
     - name: Setup ROS environment
       uses: ros-tooling/setup-ros@v0.7


### PR DESCRIPTION
# Description
This PR fixes a GitHub Action warning related to using the deprecated set-output command.

# Context
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.

# Change involved
This PR applies the following changes:
- Removes the command in favor of environment files as indicated by the documentation.

# How was this tested?
CI should pass and warning message shall be gone.
