### PR TITLE
Basic Timer implementation

### DIFF
--- a/rclrs/src/clock.rs
+++ b/rclrs/src/clock.rs
@@ -28,8 +28,7 @@ impl From<ClockType> for rcl_clock_type_t {
 #[derive(Clone, Debug)]
 pub struct Clock {
     kind: ClockType,
-    // TODO(ekumen): Fix the extra pub here.
-    pub rcl_clock: Arc<Mutex<rcl_clock_t>>,
+    rcl_clock: Arc<Mutex<rcl_clock_t>>,
     // TODO(luca) Implement jump callbacks
 }
 
@@ -82,6 +81,11 @@ impl Clock {
             kind,
             rcl_clock: Arc::new(Mutex::new(rcl_clock)),
         }
+    }
+
+    /// Return the 'rcl_clock_t' of the Clock
+    pub(crate) fn get_rcl_clock(&self) -> &Arc<Mutex<rcl_clock_t>> {
+        &self.rcl_clock
     }
 
     /// Returns the clock's `ClockType`.

--- a/rclrs/src/clock.rs
+++ b/rclrs/src/clock.rs
@@ -28,7 +28,7 @@ impl From<ClockType> for rcl_clock_type_t {
 #[derive(Clone, Debug)]
 pub struct Clock {
     kind: ClockType,
-    rcl_clock: Arc<Mutex<rcl_clock_t>>,
+    pub rcl_clock: Arc<Mutex<rcl_clock_t>>,
     // TODO(luca) Implement jump callbacks
 }
 

--- a/rclrs/src/clock.rs
+++ b/rclrs/src/clock.rs
@@ -28,6 +28,7 @@ impl From<ClockType> for rcl_clock_type_t {
 #[derive(Clone, Debug)]
 pub struct Clock {
     kind: ClockType,
+    // TODO(ekumen): Fix the extra pub here.
     pub rcl_clock: Arc<Mutex<rcl_clock_t>>,
     // TODO(luca) Implement jump callbacks
 }

--- a/rclrs/src/executor.rs
+++ b/rclrs/src/executor.rs
@@ -48,7 +48,11 @@ impl SingleThreadedExecutor {
             })
         {
             let wait_set = WaitSet::new_for_node(&node)?;
-            let ready_entities = wait_set.wait(timeout)?;
+            let mut ready_entities = wait_set.wait(timeout)?;
+
+            for ready_timer in ready_entities.timers.iter_mut() {
+                ready_timer.execute()?;
+            }
 
             for ready_subscription in ready_entities.subscriptions {
                 ready_subscription.execute()?;

--- a/rclrs/src/lib.rs
+++ b/rclrs/src/lib.rs
@@ -19,6 +19,7 @@ mod qos;
 mod service;
 mod subscription;
 mod time;
+mod timer;
 mod time_source;
 mod vendor;
 mod wait;
@@ -48,6 +49,7 @@ pub use rcl_bindings::rmw_request_id_t;
 pub use service::*;
 pub use subscription::*;
 pub use time::*;
+pub use timer::*;
 use time_source::*;
 pub use wait::*;
 

--- a/rclrs/src/lib.rs
+++ b/rclrs/src/lib.rs
@@ -19,8 +19,8 @@ mod qos;
 mod service;
 mod subscription;
 mod time;
-mod timer;
 mod time_source;
+mod timer;
 mod vendor;
 mod wait;
 
@@ -49,8 +49,8 @@ pub use rcl_bindings::rmw_request_id_t;
 pub use service::*;
 pub use subscription::*;
 pub use time::*;
-pub use timer::*;
 use time_source::*;
+pub use timer::*;
 pub use wait::*;
 
 /// Polls the node for new messages and executes the corresponding callbacks.

--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -16,7 +16,7 @@ use crate::{
     rcl_bindings::*, Client, ClientBase, Clock, Context, ContextHandle, GuardCondition, LogParams,
     Logger, ParameterBuilder, ParameterInterface, ParameterVariant, Parameters, Publisher,
     QoSProfile, RclrsError, Service, ServiceBase, Subscription, SubscriptionBase,
-    SubscriptionCallback, Timer, TimerCallback, TimeSource, ToLogParams, ENTITY_LIFECYCLE_MUTEX,
+    SubscriptionCallback, TimeSource, Timer, TimerCallback, ToLogParams, ENTITY_LIFECYCLE_MUTEX,
 };
 
 /// Constant conversion from seconds to nanoseconds
@@ -350,7 +350,7 @@ impl Node {
         period_ns: i64,
         context: &Context,
         callback: Option<TimerCallback>,
-        clock: Option<Clock>
+        clock: Option<Clock>,
     ) -> Result<Arc<Timer>, RclrsError> {
         let clock_used = match clock {
             Some(value) => value,
@@ -358,7 +358,10 @@ impl Node {
         };
         let timer = Timer::new_with_callback(&clock_used, &context, period_ns, callback)?;
         let timer = Arc::new(timer);
-        self.timers_mtx.lock().unwrap().push(Arc::downgrade(&timer) as Weak<Timer>);
+        self.timers_mtx
+            .lock()
+            .unwrap()
+            .push(Arc::downgrade(&timer) as Weak<Timer>);
         Ok(timer)
     }
 

--- a/rclrs/src/node/builder.rs
+++ b/rclrs/src/node/builder.rs
@@ -340,6 +340,7 @@ impl NodeBuilder {
             guard_conditions_mtx: Mutex::new(vec![]),
             services_mtx: Mutex::new(vec![]),
             subscriptions_mtx: Mutex::new(vec![]),
+            timers_mtx: Mutex::new(vec![]),
             time_source: TimeSource::builder(self.clock_type)
                 .clock_qos(self.clock_qos)
                 .build(),

--- a/rclrs/src/rcl_bindings.rs
+++ b/rclrs/src/rcl_bindings.rs
@@ -91,6 +91,10 @@ cfg_if::cfg_if! {
 
         #[repr(C)]
         #[derive(Debug)]
+        pub struct rcl_timer_t;
+
+        #[repr(C)]
+        #[derive(Debug)]
         pub struct rcutils_string_array_t;
 
         #[repr(C)]

--- a/rclrs/src/timer.rs
+++ b/rclrs/src/timer.rs
@@ -4,13 +4,15 @@ use crate::{
 use std::sync::{Arc, Mutex};
 
 
+
+pub trait TimerCallback {
+    fn call(time_since_last_callback_ns: i64);
+}
+
 #[derive(Debug)]
 pub struct Timer {
     rcl_timer: Arc<Mutex<rcl_timer_t>>,
-}
-
-unsafe extern "C" fn timer_callback(_: *mut rcl_timer_t, time_since_last_callback_ns: i64) {
-    println!("timer_callback, time_since_last_callback_ns {0}", time_since_last_callback_ns);
+    // callback: Option<T>,
 }
 
 impl Timer {
@@ -22,7 +24,7 @@ impl Timer {
             let allocator = rcutils_get_default_allocator();
             let mut rcl_clock = clock.rcl_clock.lock().unwrap();
             let mut rcl_context = context.handle.rcl_context.lock().unwrap();
-            let callback: rcl_timer_callback_t = Some(timer_callback);
+            let callback: rcl_timer_callback_t = None;
             // Function will return Err(_) only if there isn't enough memory to allocate a clock
             // object.
             rcl_timer_init(
@@ -36,7 +38,8 @@ impl Timer {
         };
         to_rclrs_result(timer_init_result).map(|_| {
             Timer {
-                rcl_timer: Arc::new(Mutex::new(rcl_timer))
+                rcl_timer: Arc::new(Mutex::new(rcl_timer)),
+                // callback: None
             }
         })
     }

--- a/rclrs/src/timer.rs
+++ b/rclrs/src/timer.rs
@@ -123,7 +123,7 @@ impl Timer {
     }
 
     /// Executes the callback of the timer (this is triggered by the executor or the node directly)
-    pub fn call(&mut self) -> Result<(), RclrsError>
+    pub fn call(&self) -> Result<(), RclrsError>
     {
         let mut rcl_timer = self.rcl_timer.lock().unwrap();
         to_rclrs_result(unsafe {rcl_timer_call(&mut *rcl_timer)})
@@ -146,7 +146,7 @@ impl Timer {
         })
     }
     
-    pub(crate) fn execute(&self) -> Result<(), RclrsError>
+    pub/* (crate)*/ fn execute(&self) -> Result<(), RclrsError>
     {
         if self.is_ready()?
         {

--- a/rclrs/src/timer.rs
+++ b/rclrs/src/timer.rs
@@ -146,7 +146,7 @@ impl Timer {
         })
     }
     
-    pub/* (crate)*/ fn execute(&self) -> Result<(), RclrsError>
+    pub fn execute(&self) -> Result<(), RclrsError>
     {
         if self.is_ready()?
         {

--- a/rclrs/src/timer.rs
+++ b/rclrs/src/timer.rs
@@ -1,0 +1,92 @@
+use crate::{
+    clock::Clock, context::Context, error::RclrsError, rcl_bindings::*, to_rclrs_result
+};
+use std::sync::{Arc, Mutex};
+
+
+#[derive(Debug)]
+pub struct Timer {
+    rcl_timer: Arc<Mutex<rcl_timer_t>>,
+}
+
+unsafe extern "C" fn timer_callback(_: *mut rcl_timer_t, time_since_last_callback_ns: i64) {
+    println!("timer_callback, time_since_last_callback_ns {0}", time_since_last_callback_ns);
+}
+
+impl Timer {
+    pub fn new(clock: &Clock, context: &Context, period: i64) -> Result<Timer, RclrsError> {
+        let mut rcl_timer;
+        let timer_init_result;
+        unsafe {
+            // SAFETY: Getting a default value is always safe.
+            rcl_timer = rcl_get_zero_initialized_timer();
+            let allocator = rcutils_get_default_allocator();
+            let mut rcl_clock = clock.rcl_clock.lock().unwrap();
+            let mut rcl_context = context.handle.rcl_context.lock().unwrap();
+            let callback: rcl_timer_callback_t = Some(timer_callback);
+            // Function will return Err(_) only if there isn't enough memory to allocate a clock
+            // object.
+            timer_init_result = rcl_timer_init(
+                &mut rcl_timer,
+                &mut *rcl_clock,
+                &mut *rcl_context,
+                period,
+                callback,
+                allocator,
+            );
+        }        
+        to_rclrs_result(timer_init_result).map(|_| {
+            Timer {
+                rcl_timer: Arc::new(Mutex::new(rcl_timer))
+            }
+        })
+    }
+
+    // handle() -> RCLC Timer Type
+
+    // destroy() -> None 
+
+    // clock() -> Clock ?
+
+    // timer_period_ns -> i64 ?
+
+    // is_ready() -> bool
+
+    // is_cancelled() -> bool
+
+    // cancel() -> None
+
+    // reset() -> None
+
+    // time_since_last_call() -> i64
+
+    // time_until_next_call() -> Option<i64>
+
+}
+
+impl Drop for rcl_timer_t {
+    fn drop(&mut self) {
+        // SAFETY: No preconditions for this function
+        let rc = unsafe { rcl_timer_fini(&mut *self) };
+        if let Err(e) = to_rclrs_result(rc) {
+            panic!("Unable to release Timer. {:?}", e)
+        }
+    }
+}
+
+// SAFETY: The functions accessing this type, including drop(), shouldn't care about the thread
+// they are running in. Therefore, this type can be safely sent to another thread.
+unsafe impl Send for rcl_timer_t {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn traits() {
+        use crate::test_helpers::*;
+
+        assert_send::<Timer>();
+        assert_sync::<Timer>();
+    }
+}

--- a/rclrs/src/timer.rs
+++ b/rclrs/src/timer.rs
@@ -1,8 +1,6 @@
-use crate::{
-    clock::Clock, context::Context, error::RclrsError, rcl_bindings::*, to_rclrs_result
-};
+use crate::{clock::Clock, context::Context, error::RclrsError, rcl_bindings::*, to_rclrs_result};
 // use std::fmt::Debug;
-use std::sync::{atomic::AtomicBool, Arc,  Mutex};
+use std::sync::{atomic::AtomicBool, Arc, Mutex};
 
 pub type TimerCallback = Box<dyn Fn(i64) + Send + Sync>;
 
@@ -19,7 +17,12 @@ impl Timer {
         Self::new_with_callback(clock, context, period, None)
     }
 
-    pub fn new_with_callback(clock: &Clock, context: &Context, period: i64, callback: Option<TimerCallback>) -> Result<Timer, RclrsError> {
+    pub fn new_with_callback(
+        clock: &Clock,
+        context: &Context,
+        period: i64,
+        callback: Option<TimerCallback>,
+    ) -> Result<Timer, RclrsError> {
         let mut rcl_timer;
         let timer_init_result = unsafe {
             // SAFETY: Getting a default value is always safe.
@@ -40,12 +43,10 @@ impl Timer {
                 allocator,
             )
         };
-        to_rclrs_result(timer_init_result).map(|_| {
-            Timer {
-                rcl_timer: Arc::new(Mutex::new(rcl_timer)),
-                callback,
-                in_use_by_wait_set: Arc::new(AtomicBool::new(false)),
-            }
+        to_rclrs_result(timer_init_result).map(|_| Timer {
+            rcl_timer: Arc::new(Mutex::new(rcl_timer)),
+            callback,
+            in_use_by_wait_set: Arc::new(AtomicBool::new(false)),
         })
     }
 
@@ -54,14 +55,9 @@ impl Timer {
         let mut timer_period_ns = 0;
         let get_period_result = unsafe {
             let rcl_timer = self.rcl_timer.lock().unwrap();
-            rcl_timer_get_period(
-                &* rcl_timer,
-                &mut timer_period_ns
-            )
+            rcl_timer_get_period(&*rcl_timer, &mut timer_period_ns)
         };
-        to_rclrs_result(get_period_result).map(|_| {
-            timer_period_ns
-        })
+        to_rclrs_result(get_period_result).map(|_| timer_period_ns)
     }
 
     /// Cancels the timer, stopping the execution of the callback
@@ -76,14 +72,9 @@ impl Timer {
         let mut is_canceled = false;
         let is_canceled_result = unsafe {
             let rcl_timer = self.rcl_timer.lock().unwrap();
-            rcl_timer_is_canceled(
-                &* rcl_timer,
-                &mut is_canceled
-            )
+            rcl_timer_is_canceled(&*rcl_timer, &mut is_canceled)
         };
-        to_rclrs_result(is_canceled_result).map(|_| {
-            is_canceled
-        })
+        to_rclrs_result(is_canceled_result).map(|_| is_canceled)
     }
 
     /// Retrieves the time since the last call to the callback
@@ -91,14 +82,9 @@ impl Timer {
         let mut time_value_ns: i64 = 0;
         let time_since_last_call_result = unsafe {
             let rcl_timer = self.rcl_timer.lock().unwrap();
-            rcl_timer_get_time_since_last_call(
-                &* rcl_timer,
-                &mut time_value_ns
-            )
+            rcl_timer_get_time_since_last_call(&*rcl_timer, &mut time_value_ns)
         };
-        to_rclrs_result(time_since_last_call_result).map(|_| {
-            time_value_ns
-        })
+        to_rclrs_result(time_since_last_call_result).map(|_| time_value_ns)
     }
 
     /// Retrieves the time until the next call of the callback
@@ -106,59 +92,43 @@ impl Timer {
         let mut time_value_ns: i64 = 0;
         let time_until_next_call_result = unsafe {
             let rcl_timer = self.rcl_timer.lock().unwrap();
-            rcl_timer_get_time_until_next_call(
-                &* rcl_timer,
-                &mut time_value_ns
-            )
+            rcl_timer_get_time_until_next_call(&*rcl_timer, &mut time_value_ns)
         };
-        to_rclrs_result(time_until_next_call_result).map(|_| {
-            time_value_ns
-        })
+        to_rclrs_result(time_until_next_call_result).map(|_| time_value_ns)
     }
 
-    pub fn reset(&self) -> Result<(), RclrsError>
-    {
+    pub fn reset(&self) -> Result<(), RclrsError> {
         let mut rcl_timer = self.rcl_timer.lock().unwrap();
-        to_rclrs_result(unsafe {rcl_timer_reset(&mut *rcl_timer)})
+        to_rclrs_result(unsafe { rcl_timer_reset(&mut *rcl_timer) })
     }
 
     /// Executes the callback of the timer (this is triggered by the executor or the node directly)
-    pub fn call(&self) -> Result<(), RclrsError>
-    {
+    pub fn call(&self) -> Result<(), RclrsError> {
         let mut rcl_timer = self.rcl_timer.lock().unwrap();
-        to_rclrs_result(unsafe {rcl_timer_call(&mut *rcl_timer)})
+        to_rclrs_result(unsafe { rcl_timer_call(&mut *rcl_timer) })
     }
 
     /// Checks if the timer is ready (not canceled)
-    pub fn is_ready(&self) -> Result<bool, RclrsError>
-    {
+    pub fn is_ready(&self) -> Result<bool, RclrsError> {
         let (is_ready, is_ready_result) = unsafe {
             let mut is_ready: bool = false;
             let rcl_timer = self.rcl_timer.lock().unwrap();
-            let is_ready_result = rcl_timer_is_ready(
-                &* rcl_timer,
-                &mut is_ready
-            );
+            let is_ready_result = rcl_timer_is_ready(&*rcl_timer, &mut is_ready);
             (is_ready, is_ready_result)
         };
-        to_rclrs_result(is_ready_result).map(|_| {
-            is_ready
-        })
+        to_rclrs_result(is_ready_result).map(|_| is_ready)
     }
-    
-    pub fn execute(&self) -> Result<(), RclrsError>
-    {
-        if self.is_ready()?
-        {
+
+    pub fn execute(&self) -> Result<(), RclrsError> {
+        if self.is_ready()? {
             let time_since_last_call = self.time_since_last_call()?;
             self.call()?;
-            if let Some(ref callback) = self.callback
-            {
+            if let Some(ref callback) = self.callback {
                 callback(time_since_last_call);
             }
         }
         Ok(())
-    } 
+    }
 }
 
 /// 'Drop' trait implementation to be able to release the resources
@@ -199,7 +169,7 @@ mod tests {
     fn test_new_with_system_clock() {
         let clock = Clock::system();
         let context = Context::new(vec![]).unwrap();
-        let period: i64 = 1e6 as i64;  // 1 milliseconds.
+        let period: i64 = 1e6 as i64; // 1 milliseconds.
 
         let dut = Timer::new(&clock, &context, period);
         assert!(dut.is_ok());
@@ -209,7 +179,7 @@ mod tests {
     fn test_new_with_steady_clock() {
         let clock = Clock::steady();
         let context = Context::new(vec![]).unwrap();
-        let period: i64 = 1e6 as i64;  // 1 milliseconds.
+        let period: i64 = 1e6 as i64; // 1 milliseconds.
 
         let dut = Timer::new(&clock, &context, period);
         assert!(dut.is_ok());
@@ -227,7 +197,7 @@ mod tests {
         assert_eq!(clock.now().nsec, set_time);
 
         let context = Context::new(vec![]).unwrap();
-        let period: i64 = 1e6 as i64;  // 1 milliseconds..
+        let period: i64 = 1e6 as i64; // 1 milliseconds..
 
         let dut = Timer::new(&clock, &context, period);
         assert!(dut.is_ok());
@@ -237,7 +207,7 @@ mod tests {
     fn test_get_period() {
         let clock = Clock::steady();
         let context = Context::new(vec![]).unwrap();
-        let period: i64 = 1e6 as i64;  // 1 milliseconds.
+        let period: i64 = 1e6 as i64; // 1 milliseconds.
 
         let dut = Timer::new(&clock, &context, period);
         assert!(dut.is_ok());
@@ -252,7 +222,7 @@ mod tests {
     fn test_cancel() {
         let clock = Clock::steady();
         let context = Context::new(vec![]).unwrap();
-        let period: i64 = 1e6 as i64;  // 1 milliseconds.
+        let period: i64 = 1e6 as i64; // 1 milliseconds.
 
         let dut = Timer::new(&clock, &context, period);
         assert!(dut.is_ok());
@@ -269,7 +239,7 @@ mod tests {
     fn test_time_since_last_call_before_first_event() {
         let clock = Clock::steady();
         let context = Context::new(vec![]).unwrap();
-        let period_ns: i64 = 2e6 as i64;  // 2 milliseconds.
+        let period_ns: i64 = 2e6 as i64; // 2 milliseconds.
         let sleep_period_ms = time::Duration::from_millis(1);
 
         let dut = Timer::new(&clock, &context, period_ns);
@@ -279,21 +249,29 @@ mod tests {
         let time_since_last_call = dut.time_since_last_call();
         assert!(time_since_last_call.is_ok());
         let time_since_last_call = time_since_last_call.unwrap();
-        assert!(time_since_last_call > 9e5 as i64, "time_since_last_call: {}", time_since_last_call);
+        assert!(
+            time_since_last_call > 9e5 as i64,
+            "time_since_last_call: {}",
+            time_since_last_call
+        );
     }
 
     #[test]
     fn test_time_until_next_call_before_first_event() {
         let clock = Clock::steady();
         let context = Context::new(vec![]).unwrap();
-        let period_ns: i64 = 2e6 as i64;  // 2 milliseconds.
+        let period_ns: i64 = 2e6 as i64; // 2 milliseconds.
         let dut = Timer::new(&clock, &context, period_ns);
         assert!(dut.is_ok());
         let dut = dut.unwrap();
         let time_until_next_call = dut.time_until_next_call();
         assert!(time_until_next_call.is_ok());
         let time_until_next_call = time_until_next_call.unwrap();
-        assert!(time_until_next_call < period_ns, "time_until_next_call: {}", time_until_next_call);
+        assert!(
+            time_until_next_call < period_ns,
+            "time_until_next_call: {}",
+            time_until_next_call
+        );
     }
 
     #[test]
@@ -301,14 +279,14 @@ mod tests {
         let tolerance = 20e4 as i64;
         let clock = Clock::steady();
         let context = Context::new(vec![]).unwrap();
-        let period_ns: i64 = 2e6 as i64;  // 2 milliseconds.
+        let period_ns: i64 = 2e6 as i64; // 2 milliseconds.
         let dut = Timer::new(&clock, &context, period_ns).unwrap();
         let elapsed = period_ns - dut.time_until_next_call().unwrap();
-        assert!(elapsed < tolerance , "elapsed before reset: {}", elapsed);
+        assert!(elapsed < tolerance, "elapsed before reset: {}", elapsed);
         thread::sleep(time::Duration::from_millis(1));
         assert!(dut.reset().is_ok());
         let elapsed = period_ns - dut.time_until_next_call().unwrap();
-        assert!(elapsed < tolerance , "elapsed after reset: {}", elapsed);
+        assert!(elapsed < tolerance, "elapsed after reset: {}", elapsed);
     }
 
     #[test]
@@ -316,27 +294,35 @@ mod tests {
         let tolerance = 20e4 as i64;
         let clock = Clock::steady();
         let context = Context::new(vec![]).unwrap();
-        let period_ns: i64 = 1e6 as i64;  // 1 millisecond.
+        let period_ns: i64 = 1e6 as i64; // 1 millisecond.
         let dut = Timer::new(&clock, &context, period_ns).unwrap();
         let elapsed = period_ns - dut.time_until_next_call().unwrap();
-        assert!(elapsed < tolerance , "elapsed before reset: {}", elapsed);
+        assert!(elapsed < tolerance, "elapsed before reset: {}", elapsed);
 
         thread::sleep(time::Duration::from_micros(1500));
 
         let elapsed = period_ns - dut.time_until_next_call().unwrap();
-        assert!(elapsed > 1500000i64, "time_until_next_call before call: {}", elapsed);
+        assert!(
+            elapsed > 1500000i64,
+            "time_until_next_call before call: {}",
+            elapsed
+        );
 
         assert!(dut.call().is_ok());
 
         let elapsed = dut.time_until_next_call().unwrap();
-        assert!(elapsed < 500000i64, "time_until_next_call after call: {}", elapsed);
+        assert!(
+            elapsed < 500000i64,
+            "time_until_next_call after call: {}",
+            elapsed
+        );
     }
 
     #[test]
     fn test_is_ready() {
         let clock = Clock::steady();
         let context = Context::new(vec![]).unwrap();
-        let period_ns: i64 = 1e6 as i64;  // 1 millisecond.
+        let period_ns: i64 = 1e6 as i64; // 1 millisecond.
         let dut = Timer::new(&clock, &context, period_ns).unwrap();
 
         let is_ready = dut.is_ready();
@@ -354,10 +340,16 @@ mod tests {
     fn test_callback_wip() {
         let clock = Clock::steady();
         let context = Context::new(vec![]).unwrap();
-        let period_ns: i64 = 1e6 as i64;  // 1 millisecond.
+        let period_ns: i64 = 1e6 as i64; // 1 millisecond.
         let foo = Arc::new(Mutex::new(0i64));
         let foo_callback = foo.clone();
-        let dut = Timer::new_with_callback(&clock, &context, period_ns, Some(Box::new(move |x| *foo_callback.lock().unwrap() = x ))).unwrap();
+        let dut = Timer::new_with_callback(
+            &clock,
+            &context,
+            period_ns,
+            Some(Box::new(move |x| *foo_callback.lock().unwrap() = x)),
+        )
+        .unwrap();
         dut.callback.unwrap()(123);
         assert_eq!(*foo.lock().unwrap(), 123);
     }
@@ -366,10 +358,16 @@ mod tests {
     fn test_execute_when_is_not_ready() {
         let clock = Clock::steady();
         let context = Context::new(vec![]).unwrap();
-        let period_ns: i64 = 1e6 as i64;  // 1 millisecond.
+        let period_ns: i64 = 1e6 as i64; // 1 millisecond.
         let foo = Arc::new(Mutex::new(0i64));
         let foo_callback = foo.clone();
-        let dut = Timer::new_with_callback(&clock, &context, period_ns, Some(Box::new(move |x| *foo_callback.lock().unwrap() = x ))).unwrap();
+        let dut = Timer::new_with_callback(
+            &clock,
+            &context,
+            period_ns,
+            Some(Box::new(move |x| *foo_callback.lock().unwrap() = x)),
+        )
+        .unwrap();
         assert!(dut.execute().is_ok());
         assert_eq!(*foo.lock().unwrap(), 0i64);
     }
@@ -378,10 +376,16 @@ mod tests {
     fn test_execute_when_is_ready() {
         let clock = Clock::steady();
         let context = Context::new(vec![]).unwrap();
-        let period_ns: i64 = 1e6 as i64;  // 1 millisecond.
+        let period_ns: i64 = 1e6 as i64; // 1 millisecond.
         let foo = Arc::new(Mutex::new(0i64));
         let foo_callback = foo.clone();
-        let dut = Timer::new_with_callback(&clock, &context, period_ns, Some(Box::new(move |x| *foo_callback.lock().unwrap() = x ))).unwrap();
+        let dut = Timer::new_with_callback(
+            &clock,
+            &context,
+            period_ns,
+            Some(Box::new(move |x| *foo_callback.lock().unwrap() = x)),
+        )
+        .unwrap();
         thread::sleep(time::Duration::from_micros(1500));
         assert!(dut.execute().is_ok());
         let x = *foo.lock().unwrap();

--- a/rclrs/src/wait.rs
+++ b/rclrs/src/wait.rs
@@ -142,13 +142,14 @@ impl WaitSet {
         let live_clients = node.live_clients();
         let live_guard_conditions = node.live_guard_conditions();
         let live_services = node.live_services();
+        let live_timers = node.live_timers();
         let ctx = Context {
             handle: Arc::clone(&node.handle.context_handle),
         };
         let mut wait_set = WaitSet::new(
             live_subscriptions.len(),
             live_guard_conditions.len(),
-            0,
+            live_timers.len(),
             live_clients.len(),
             live_services.len(),
             0,
@@ -169,6 +170,10 @@ impl WaitSet {
 
         for live_service in &live_services {
             wait_set.add_service(live_service.clone())?;
+        }
+
+        for live_timer in &live_timers {
+            wait_set.add_timer(live_timer.clone())?;
         }
         Ok(wait_set)
     }

--- a/rclrs/src/wait.rs
+++ b/rclrs/src/wait.rs
@@ -20,7 +20,7 @@ use std::{sync::Arc, time::Duration, vec::Vec};
 use crate::{
     error::{to_rclrs_result, RclReturnCode, RclrsError, ToResult},
     rcl_bindings::*,
-    ClientBase, Context, ContextHandle, Node, ServiceBase, SubscriptionBase, Timer
+    ClientBase, Context, ContextHandle, Node, ServiceBase, SubscriptionBase, Timer,
 };
 
 mod exclusivity_guard;
@@ -323,17 +323,15 @@ impl WaitSet {
 
     /// TBD
     pub fn add_timer(&mut self, timer: Arc<Timer>) -> Result<(), RclrsError> {
-        let exclusive_timer = ExclusivityGuard::new(
-            Arc::clone(&timer),
-            Arc::clone(&timer.in_use_by_wait_set),
-        )?;
+        let exclusive_timer =
+            ExclusivityGuard::new(Arc::clone(&timer), Arc::clone(&timer.in_use_by_wait_set))?;
         unsafe {
             // SAFETY: I'm not sure if it's required, but the timer pointer will remain valid
             // for as long as the wait set exists, because it's stored in self.timers.
             // Passing in a null pointer for the third argument is explicitly allowed.
             rcl_wait_set_add_timer(
                 &mut self.handle.rcl_wait_set,
-                &* (*(*timer).rcl_timer).lock().unwrap() as *const _, // TODO :)
+                &*(*(*timer).rcl_timer).lock().unwrap() as *const _, // TODO :)
                 core::ptr::null_mut(),
             )
         }
@@ -458,7 +456,7 @@ impl WaitSet {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{clock::Clock};
+    use crate::clock::Clock;
 
     #[test]
     fn traits() {
@@ -488,7 +486,7 @@ mod tests {
     fn timer_in_wait_not_set_readies() -> Result<(), RclrsError> {
         let context = Context::new([])?;
         let clock = Clock::steady();
-        let period: i64 = 1e6 as i64;  // 1 milliseconds.
+        let period: i64 = 1e6 as i64; // 1 milliseconds.
         let timer = Arc::new(Timer::new(&clock, &context, period)?);
 
         let mut wait_set = WaitSet::new(0, 0, 1, 0, 0, 0, &context)?;
@@ -504,7 +502,7 @@ mod tests {
     fn timer_in_wait_set_readies() -> Result<(), RclrsError> {
         let context = Context::new([])?;
         let clock = Clock::steady();
-        let period: i64 = 1e6 as i64;  // 1 milliseconds.
+        let period: i64 = 1e6 as i64; // 1 milliseconds.
         let timer = Arc::new(Timer::new(&clock, &context, period)?);
 
         let mut wait_set = WaitSet::new(0, 0, 1, 0, 0, 0, &context)?;

--- a/rclrs/src/wait.rs
+++ b/rclrs/src/wait.rs
@@ -331,7 +331,7 @@ impl WaitSet {
             // Passing in a null pointer for the third argument is explicitly allowed.
             rcl_wait_set_add_timer(
                 &mut self.handle.rcl_wait_set,
-                &*(*(*timer).rcl_timer).lock().unwrap() as *const _, // TODO :)
+                &* timer.rcl_timer.lock().unwrap() as *const _,
                 core::ptr::null_mut(),
             )
         }


### PR DESCRIPTION
# Description

This is a basic Timer implementation. It is heavily based on what other client libraries do, i.e. use RCL bindings and provide a safe API against the bindings.

## Details

It is by no means a final version but it is a good first approach to something close to the final version. We will happily change everything you tell us to change :)

It is important to look at the `TimerCallback` type trait definition.

We tried to keep mutable and non-mutable functions within `Timer` but then when integrating it against `WaitSet`, `Node` and `Executor` we had to make it all "non-mutable". 

This has been done in collaboration (peer programming) with @tulku , @JesusSilvaUtrera, @jballoffet :confetti_ball: 

## How to test it?

- [ ] Add end to end example 

We wrote an end to end example, we will soon add it so it can be show how to do it.
We introduced some unit tests, we can certainly extend them as soon as we define the final API.

# Notes

We observed some non-trivial delays in the callback execution. Certainly the overhead between the bindings and what we are doing is non-negligible. We would appreciate some input here.

# Identified discussion points

- i64 for durations, shall we use proper `Duration` types?
- Using the `Clock::with_source()` makes the test in `Timer` crash with SIGSEGV. See the comment and test in timer.rs.