### PR TITLE
Update for clippy 1.83

### DIFF
--- a/rclrs/src/parameter.rs
+++ b/rclrs/src/parameter.rs
@@ -195,7 +195,7 @@ impl<'a, T: ParameterVariant> ParameterBuilder<'a, T> {
     }
 }
 
-impl<'a, T> ParameterBuilder<'a, Arc<[T]>>
+impl<T> ParameterBuilder<'_, Arc<[T]>>
 where
     Arc<[T]>: ParameterVariant,
 {
@@ -206,7 +206,7 @@ where
     }
 }
 
-impl<'a> ParameterBuilder<'a, Arc<[Arc<str>]>> {
+impl ParameterBuilder<'_, Arc<[Arc<str>]>> {
     /// Sets the default for the parameter from a string-like array.
     pub fn default_string_array<U>(mut self, default_value: U) -> Self
     where
@@ -679,7 +679,7 @@ impl std::fmt::Display for DeclarationError {
 
 impl std::error::Error for DeclarationError {}
 
-impl<'a> Parameters<'a> {
+impl Parameters<'_> {
     /// Tries to read a parameter of the requested type.
     ///
     /// Returns `Some(T)` if a parameter of the requested type exists, `None` otherwise.

--- a/rclrs/src/publisher/loaned_message.rs
+++ b/rclrs/src/publisher/loaned_message.rs
@@ -22,7 +22,7 @@ where
     pub(super) publisher: &'a Publisher<T>,
 }
 
-impl<'a, T> Deref for LoanedMessage<'a, T>
+impl<T> Deref for LoanedMessage<'_, T>
 where
     T: RmwMessage,
 {
@@ -33,7 +33,7 @@ where
     }
 }
 
-impl<'a, T> DerefMut for LoanedMessage<'a, T>
+impl<T> DerefMut for LoanedMessage<'_, T>
 where
     T: RmwMessage,
 {
@@ -43,7 +43,7 @@ where
     }
 }
 
-impl<'a, T> Drop for LoanedMessage<'a, T>
+impl<T> Drop for LoanedMessage<'_, T>
 where
     T: RmwMessage,
 {
@@ -66,11 +66,11 @@ where
 
 // SAFETY: The functions accessing this type, including drop(), shouldn't care about the thread
 // they are running in. Therefore, this type can be safely sent to another thread.
-unsafe impl<'a, T> Send for LoanedMessage<'a, T> where T: RmwMessage {}
+unsafe impl<T> Send for LoanedMessage<'_, T> where T: RmwMessage {}
 // SAFETY: There is no interior mutability in this type. All mutation happens through &mut references.
-unsafe impl<'a, T> Sync for LoanedMessage<'a, T> where T: RmwMessage {}
+unsafe impl<T> Sync for LoanedMessage<'_, T> where T: RmwMessage {}
 
-impl<'a, T> LoanedMessage<'a, T>
+impl<T> LoanedMessage<'_, T>
 where
     T: RmwMessage,
 {

--- a/rclrs/src/subscription/readonly_loaned_message.rs
+++ b/rclrs/src/subscription/readonly_loaned_message.rs
@@ -22,7 +22,7 @@ where
     pub(super) subscription: &'a Subscription<T>,
 }
 
-impl<'a, T> Deref for ReadOnlyLoanedMessage<'a, T>
+impl<T> Deref for ReadOnlyLoanedMessage<'_, T>
 where
     T: Message,
 {
@@ -32,7 +32,7 @@ where
     }
 }
 
-impl<'a, T> Drop for ReadOnlyLoanedMessage<'a, T>
+impl<T> Drop for ReadOnlyLoanedMessage<'_, T>
 where
     T: Message,
 {
@@ -50,9 +50,9 @@ where
 
 // SAFETY: The functions accessing this type, including drop(), shouldn't care about the thread
 // they are running in. Therefore, this type can be safely sent to another thread.
-unsafe impl<'a, T> Send for ReadOnlyLoanedMessage<'a, T> where T: Message {}
+unsafe impl<T> Send for ReadOnlyLoanedMessage<'_, T> where T: Message {}
 // SAFETY: This type has no interior mutability, in fact it has no mutability at all.
-unsafe impl<'a, T> Sync for ReadOnlyLoanedMessage<'a, T> where T: Message {}
+unsafe impl<T> Sync for ReadOnlyLoanedMessage<'_, T> where T: Message {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Stable CI for new PRs are failing right now because of an update in clippy 1.83 that emits a warning when an explicit lifetime can be elided.

This PR updates based on the clippy recommendation, so Stable CI should go green now.