### PR TITLE
chore: remove references to installing cargo-ament-build via cargo

### DIFF
--- a/.github/workflows/rust-minimal.yml
+++ b/.github/workflows/rust-minimal.yml
@@ -76,10 +76,6 @@ jobs:
         cd -
         done
 
-    - name: Install cargo-ament-build
-      run: |
-        cargo install --debug cargo-ament-build
-
     - name: Build and test
       id: build
       uses: ros-tooling/action-ros-ci@v0.3

--- a/.github/workflows/rust-stable.yml
+++ b/.github/workflows/rust-stable.yml
@@ -76,10 +76,6 @@ jobs:
         cd -
         done
 
-    - name: Install cargo-ament-build
-      run: |
-        cargo install --debug cargo-ament-build
-
     - name: Build and test
       id: build
       uses: ros-tooling/action-ros-ci@v0.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,9 @@ RUN apt-get update && apt-get install -y \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Rust and the cargo-ament-build plugin
+# Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.75.0 -y
 ENV PATH=/root/.cargo/bin:$PATH
-RUN cargo install cargo-ament-build
 
 RUN pip install --upgrade pytest 
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Here are the steps for building the `ros2_rust` examples in a vanilla Ubuntu Foc
 # Assuming you installed the minimal version of ROS 2, you need these additional packages:
 sudo apt install -y git libclang-dev python3-pip python3-vcstool # libclang-dev is required by bindgen
 # Install these plugins for cargo and colcon:
-cargo install --debug cargo-ament-build  # --debug is faster to install
 pip install git+https://github.com/colcon/colcon-cargo.git
 pip install git+https://github.com/colcon/colcon-ros-cargo.git
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -43,7 +43,6 @@ The exact steps may differ between platforms, but as an example, here is how you
 # Assuming you installed the minimal version of ROS 2, you need these additional packages:
 sudo apt install -y git libclang-dev python3-pip python3-vcstool # libclang-dev is required by bindgen
 # Install these plugins for cargo and colcon:
-cargo install cargo-ament-build
 pip install git+https://github.com/colcon/colcon-cargo.git
 pip install git+https://github.com/colcon/colcon-ros-cargo.git
 ```


### PR DESCRIPTION
Now that [cargo-ament-build](https://pypi.org/project/cargo-ament-build/) is avaialble via PyPI as a Python wheel and that [cargo-ros-cargo](https://pypi.org/project/colcon-ros-cargo/) depends on it, we can install both in one go.