### PR TITLE
Fix buffer overflow for bounded sequence example

### DIFF
--- a/examples/message_demo/src/message_demo.rs
+++ b/examples/message_demo/src/message_demo.rs
@@ -15,8 +15,8 @@ fn check_default_values() {
     assert_eq!(msg.float_seq_unbounded, seq![6.0]);
     assert_eq!(msg.string_member.to_string(), "Χαίρετε 你好");
     assert_eq!(msg.wstring_member.to_string(), "αντίο σου 再见");
-    assert_eq!(msg.bounded_string_member.to_string(), "äöü");
-    assert_eq!(msg.bounded_wstring_member.to_string(), "äöü");
+    assert_eq!(msg.bounded_string_member.to_string(), "aou");
+    assert_eq!(msg.bounded_wstring_member.to_string(), "aou");
     assert_eq!(
         msg.string_array.clone().map(|s| s.to_string()),
         ["R", "O", "S", "2"].map(String::from)

--- a/examples/message_demo/src/message_demo.rs
+++ b/examples/message_demo/src/message_demo.rs
@@ -16,7 +16,7 @@ fn check_default_values() {
     assert_eq!(msg.string_member.to_string(), "Χαίρετε 你好");
     assert_eq!(msg.wstring_member.to_string(), "αντίο σου 再见");
     assert_eq!(msg.bounded_string_member.to_string(), "aou");
-    assert_eq!(msg.bounded_wstring_member.to_string(), "aou");
+    assert_eq!(msg.bounded_wstring_member.to_string(), "äöü");
     assert_eq!(
         msg.string_array.clone().map(|s| s.to_string()),
         ["R", "O", "S", "2"].map(String::from)

--- a/examples/rclrs_example_msgs/msg/VariousTypes.msg
+++ b/examples/rclrs_example_msgs/msg/VariousTypes.msg
@@ -13,8 +13,8 @@ float32[] float_seq_unbounded [6.0]
 # String types
 string string_member "Χαίρετε 你好"
 wstring wstring_member "αντίο σου 再见"
-string<=3 bounded_string_member "äöü"
-wstring<=3 bounded_wstring_member "äöü"
+string<=3 bounded_string_member "aou"
+wstring<=3 bounded_wstring_member "aou"
 
 # Array/sequence of string type
 string[4] string_array ["R", "O", "S", "2"]

--- a/examples/rclrs_example_msgs/msg/VariousTypes.msg
+++ b/examples/rclrs_example_msgs/msg/VariousTypes.msg
@@ -14,7 +14,7 @@ float32[] float_seq_unbounded [6.0]
 string string_member "Χαίρετε 你好"
 wstring wstring_member "αντίο σου 再见"
 string<=3 bounded_string_member "aou"
-wstring<=3 bounded_wstring_member "aou"
+wstring<=3 bounded_wstring_member "äöü"
 
 # Array/sequence of string type
 string[4] string_array ["R", "O", "S", "2"]


### PR DESCRIPTION
The example message `VariousTypes` has a `string<=3` with a default value containing three characters which each have a length of two bytes in utf-8. This means the real length of the default value is 6 bytes even though the byte limit is `<=3`.

This PR changes the default value to be `"aou"` to be three bytes long. The other bounded string is a wide string (utf-16), so it can remain as-is.

To observe the problem, use `$ cargo run` in the `message_demo` example to see it return an error code if you use the `main` branch. Then use the branch of this PR and see that it does not return an error code.