### PR TITLE
Fix docker build instructions missing build context

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -54,7 +54,7 @@ Build the Docker image with
 ```shell
 # Make sure to run this in the workspace directory
 # ROS_DISTRO can be humble|iron|rolling
-docker build -f src/ros2_rust/Dockerfile --build-arg "ROS_DISTRO=humble" -t ros2_rust_dev
+docker build -f src/ros2_rust/Dockerfile --build-arg "ROS_DISTRO=humble" -t ros2_rust_dev .
 ```
 
 and then run it with


### PR DESCRIPTION
CI failing due to https://github.com/ros2-rust/ros2_rust/issues/449