### PR TITLE
Bumb bindgen dependency to 0.70

### DIFF
--- a/rclrs/Cargo.toml
+++ b/rclrs/Cargo.toml
@@ -43,7 +43,7 @@ tokio = { version = "*", features = ["rt", "time", "macros"] }
 
 [build-dependencies]
 # Needed for FFI
-bindgen = "0.66.1"
+bindgen = "0.70"
 # Needed for uploading documentation to docs.rs
 cfg-if = "1.0.0"
 

--- a/rclrs/build.rs
+++ b/rclrs/build.rs
@@ -57,7 +57,7 @@ fn main() {
         .default_enum_style(bindgen::EnumVariation::Rust {
             non_exhaustive: false,
         })
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks));
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()));
 
     // Invalidate the built crate whenever this script or the wrapper changes
     println!("cargo:rerun-if-changed=build.rs");


### PR DESCRIPTION
Alternative to https://github.com/ros2-rust/ros2_rust/pull/451, fixes https://github.com/ros2-rust/ros2_rust/issues/449.

It turns out `bindgen` fully dropped the `which` dependency that caused the issue in the first place in 0.70 in [this PR](https://github.com/rust-lang/rust-bindgen/pull/2809/).

We can just avoid the issue altogether by bumping `bindgen`. Why not 0.71? Because I encountered a build error due to an outdated lock file that would be fixed by [this PR](https://github.com/rust-lang/rust-bindgen/pull/3048) that is however not released. If we were to bump to 0.71 users that have a semi-old lockfile will have a failing build.
My proposal would be, once that PR is released, to update to the version with it (most likely a 0.71.2).

### Migration

The one line code diff addresses a deprecated API. Note however that it is a behavior change as noted [here](https://docs.rs/bindgen/latest/bindgen/struct.CargoCallbacks.html#method.rerun_on_header_files). The new behavior looked sensible but we can just set it to false if we want to be extra conservative