### PR TITLE
Add support for the newer Rolling and Jazzy distros in our dev Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG ROS_DISTRO=humble
-FROM ros:$ROS_DISTRO as base
+FROM ros:$ROS_DISTRO AS base
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies
@@ -15,10 +15,10 @@ RUN apt-get update && apt-get install -y \
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.75.0 -y
 ENV PATH=/root/.cargo/bin:$PATH
 
-RUN pip install --upgrade pytest 
-
 # Install the colcon-cargo and colcon-ros-cargo plugins
-RUN pip install git+https://github.com/colcon/colcon-cargo.git git+https://github.com/colcon/colcon-ros-cargo.git
+RUN if [ "$ROS_DISTRO" = "humble" ] ;  \
+    then pip install --upgrade pytest && pip install colcon-ros-cargo ;  \
+    else pip install --break-system-packages pytest colcon-ros-cargo ; fi
 
 RUN mkdir -p /workspace && echo "Did you forget to mount the repository into the Docker container?" > /workspace/HELLO.txt
 WORKDIR /workspace


### PR DESCRIPTION
- Change the pip command based on the ROS_DISTRO argument
- Swap to the PyPi version of [colcon-ros-cargo](https://pypi.org/project/colcon-ros-cargo/)
- Only install `colcon-ros-cargo` as it lists `colcon-cargo` and `cargo-ament-build` as dependencies ([link](https://github.com/colcon/colcon-ros-cargo/blob/main/setup.cfg#L29))