### PR TITLE
Add a job to build and deploy the main branch doc on Github pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,87 @@
+name: Docs
+on:
+  push:
+    branches: [main]
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+concurrency:
+  group: deploy
+  cancel-in-progress: false
+env:
+  CARGO_TERM_COLOR: always
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    container: rostooling/setup-ros-docker:ubuntu-jammy-ros-rolling-ros-base-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # ROS 2 WS part
+      - name: Search packages in this repository
+        id: list_packages
+        run: |
+          {
+            echo 'package_list<<EOF'
+            colcon list --names-only
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+      - name: Setup ROS environment
+        uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: rolling
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - name: Install colcon-cargo and colcon-ros-cargo
+        run: |
+          sudo pip3 install git+https://github.com/colcon/colcon-cargo.git
+          sudo pip3 install git+https://github.com/colcon/colcon-ros-cargo.git
+      - name: Build ROS 2 WS
+        id: build_ros_ws
+        uses: ros-tooling/action-ros-ci@v0.3
+        with:
+          package-name: ${{ steps.list_packages.outputs.package_list }}
+          target-ros2-distro: rolling
+          vcs-repo-file-url: ros2_rust_rolling.repos
+          skip-tests: true
+      # DOC part
+      - name: Setup pages
+        id: pages
+        uses: actions/configure-pages@v5
+      - name: Build docs
+        id: build_doc
+        run: |
+          cd ${{ steps.build_ros_ws.outputs.ros-workspace-directory-name }}
+          . install/setup.sh
+          cd $(colcon list | awk '$1 == "rclrs" { print $2 }')
+          cargo doc --no-deps
+          {
+            echo 'rclrs_path<<EOF'
+            pwd
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+      - name: Add redirect
+        working-directory: ${{ steps.build_doc.outputs.rclrs_path }}
+        run: |
+          pwd
+          ls
+          echo '<meta http-equiv="refresh" content="0;url=rclrs/index.html">' > target/doc/index.html
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ${{ steps.build_doc.outputs.rclrs_path }}/target/doc
+  deploy:
+    name: Deploy
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ ROS 2 for Rust
 
 [![Minimal Version Status](https://github.com/ros2-rust/ros2_rust/actions/workflows/rust-minimal.yml/badge.svg?branch=main)](https://github.com/ros2-rust/ros2_rust/actions/workflows/rust-minimal.yml)
 [![Stable CI Status](https://github.com/ros2-rust/ros2_rust/actions/workflows/rust-stable.yml/badge.svg?branch=main)](https://github.com/ros2-rust/ros2_rust/actions/workflows/rust-stable.yml)
+[![Doc CI Status](https://github.com/ros2-rust/ros2_rust/actions/workflows/docs.yml/badge.svg?branch=main)](https://ros2-rust.github.io/ros2_rust/rclrs/index.html)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 Introduction
@@ -71,5 +72,6 @@ ros2 launch examples_rclrs_minimal_pub_sub minimal_pub_sub.launch.xml
 ```
 
 Further documentation articles:
+- [API documentation generated from `main` branch](https://ros2-rust.github.io/ros2_rust/rclrs/index.html)
 - [Tutorial on writing your first node with `rclrs`](docs/writing-your-first-rclrs-node.md)
 - [Contributor's guide](docs/CONTRIBUTING.md)


### PR DESCRIPTION
As proposed in https://github.com/ros2-rust/ros2_rust/pull/460, I suggest to host the doc of the git version of rclrs on Github pages.

In order for it to work, you need to enable Github Pages on this repo:
![image](https://github.com/user-attachments/assets/27977012-f8a1-4b6d-8fd9-186f0a3eb977)

I understand @esteve point in https://github.com/ros2-rust/ros2_rust/pull/460#issuecomment-2688224887 that people using the git version of rclrs can do `cargo doc` themselves because the doc is already published on doc.rs for the released version of the crate so feel free to decline my PR if you prefer.

But I my point was to ease the access to the documentation of the git version instead of adding simple examples that have the same content than the rustdoc snippets to reduce the maintenance effort on API changes.

The workflow was tested on my fork in the [feature/add_doc_job](https://github.com/romainreignier/ros2_rust/blob/feature/add_doc_job/.github/workflows/docs.yml) with the result exposed [here](https://romainreignier.github.io/ros2_rust/rclrs/index.html). I had to do a different branch for the PR to point to the `main` branch of this repo.