### PR TITLE
Fix RAII for subscription, client, and service

### DIFF
--- a/rclrs/src/client.rs
+++ b/rclrs/src/client.rs
@@ -78,6 +78,7 @@ where
     futures: Arc<Mutex<HashMap<RequestId, oneshot::Sender<T::Response>>>>,
     /// Ensure the parent node remains alive as long as the subscription is held.
     /// This implementation will change in the future.
+    #[allow(unused)]
     node: Arc<Node>,
 }
 
@@ -129,7 +130,7 @@ where
 
         let handle = Arc::new(ClientHandle {
             rcl_client: Mutex::new(rcl_client),
-            node_handle,
+            node_handle: Arc::clone(&node.handle),
             in_use_by_wait_set: Arc::new(AtomicBool::new(false)),
         });
 

--- a/rclrs/src/parameter.rs
+++ b/rclrs/src/parameter.rs
@@ -789,7 +789,7 @@ impl ParameterInterface {
         }
     }
 
-    pub(crate) fn create_services(&self, node: &Node) -> Result<(), RclrsError> {
+    pub(crate) fn create_services(&self, node: &Arc<Node>) -> Result<(), RclrsError> {
         *self.services.lock().unwrap() =
             Some(ParameterService::new(node, self.parameter_map.clone())?);
         Ok(())

--- a/rclrs/src/parameter/service.rs
+++ b/rclrs/src/parameter/service.rs
@@ -239,7 +239,7 @@ fn set_parameters_atomically(
 
 impl ParameterService {
     pub(crate) fn new(
-        node: &Node,
+        node: &Arc<Node>,
         parameter_map: Arc<Mutex<ParameterMap>>,
     ) -> Result<Self, RclrsError> {
         let fqn = node.fully_qualified_name();

--- a/rclrs/src/service.rs
+++ b/rclrs/src/service.rs
@@ -75,6 +75,7 @@ where
     pub callback: Mutex<ServiceCallback<T::Request, T::Response>>,
     /// Ensure the parent node remains alive as long as the subscription is held.
     /// This implementation will change in the future.
+    #[allow(unused)]
     node: Arc<Node>,
 }
 
@@ -126,7 +127,7 @@ where
 
         let handle = Arc::new(ServiceHandle {
             rcl_service: Mutex::new(rcl_service),
-            node_handle,
+            node_handle: Arc::clone(&node.handle),
             in_use_by_wait_set: Arc::new(AtomicBool::new(false)),
         });
 

--- a/rclrs/src/service.rs
+++ b/rclrs/src/service.rs
@@ -83,11 +83,7 @@ where
     T: rosidl_runtime_rs::Service,
 {
     /// Creates a new service.
-    pub(crate) fn new<F>(
-        node: &Arc<Node>,
-        topic: &str,
-        callback: F,
-    ) -> Result<Self, RclrsError>
+    pub(crate) fn new<F>(node: &Arc<Node>, topic: &str, callback: F) -> Result<Self, RclrsError>
     // This uses pub(crate) visibility to avoid instantiating this struct outside
     // [`Node::create_service`], see the struct's documentation for the rationale
     where

--- a/rclrs/src/service.rs
+++ b/rclrs/src/service.rs
@@ -9,7 +9,7 @@ use rosidl_runtime_rs::Message;
 use crate::{
     error::{RclReturnCode, ToResult},
     rcl_bindings::*,
-    MessageCow, NodeHandle, RclrsError, ENTITY_LIFECYCLE_MUTEX,
+    MessageCow, Node, NodeHandle, RclrsError, ENTITY_LIFECYCLE_MUTEX,
 };
 
 // SAFETY: The functions accessing this type, including drop(), shouldn't care about the thread
@@ -73,6 +73,9 @@ where
     pub(crate) handle: Arc<ServiceHandle>,
     /// The callback function that runs when a request was received.
     pub callback: Mutex<ServiceCallback<T::Request, T::Response>>,
+    /// Ensure the parent node remains alive as long as the subscription is held.
+    /// This implementation will change in the future.
+    node: Arc<Node>,
 }
 
 impl<T> Service<T>
@@ -81,7 +84,7 @@ where
 {
     /// Creates a new service.
     pub(crate) fn new<F>(
-        node_handle: Arc<NodeHandle>,
+        node: &Arc<Node>,
         topic: &str,
         callback: F,
     ) -> Result<Self, RclrsError>
@@ -104,7 +107,7 @@ where
         let service_options = unsafe { rcl_service_get_default_options() };
 
         {
-            let rcl_node = node_handle.rcl_node.lock().unwrap();
+            let rcl_node = node.handle.rcl_node.lock().unwrap();
             let _lifecycle_lock = ENTITY_LIFECYCLE_MUTEX.lock().unwrap();
             unsafe {
                 // SAFETY:
@@ -133,6 +136,7 @@ where
 
         Ok(Self {
             handle,
+            node: Arc::clone(node),
             callback: Mutex::new(Box::new(callback)),
         })
     }

--- a/rclrs/src/subscription.rs
+++ b/rclrs/src/subscription.rs
@@ -419,8 +419,12 @@ mod tests {
                 .unwrap();
 
             let qos = QoSProfile::default().keep_all().reliable();
-            let subscription = node.create_subscription::<msg::Empty>("test_topic", qos, callback).unwrap();
-            let publisher = node.create_publisher::<msg::Empty>("test_topic", qos).unwrap();
+            let subscription = node
+                .create_subscription::<msg::Empty>("test_topic", qos, callback)
+                .unwrap();
+            let publisher = node
+                .create_publisher::<msg::Empty>("test_topic", qos)
+                .unwrap();
 
             (subscription, publisher)
         };


### PR DESCRIPTION
This is aimed at fixing #462. With these changes, users will no longer need to explicitly hold onto the `Arc<Node>` in order to keep their subscriptions, services, or clients running.

This will be implemented differently as we move through the async execution PRs, but this PR will be a quick and effective stop gap in the meantime. 