### PR TITLE
Force backtrace version that is compatible with 1.75

### DIFF
--- a/examples/message_demo/Cargo.toml
+++ b/examples/message_demo/Cargo.toml
@@ -10,16 +10,10 @@ path = "src/message_demo.rs"
 
 [dependencies]
 anyhow = {version = "1", features = ["backtrace"]}
+rclrs = "0.4"
+rosidl_runtime_rs = "0.4"
+rclrs_example_msgs = { version = "0.4", features = ["serde"] }
+serde_json = "1.0"
 
-[dependencies.rclrs]
-version = "0.4"
-
-[dependencies.rosidl_runtime_rs]
-version = "0.4"
-
-[dependencies.rclrs_example_msgs]
-version = "0.4"
-features = ["serde"]
-
-[dependencies.serde_json]
-version = "1.0"
+# This specific version is compatible with Rust 1.75
+backtrace = "=0.3.74"

--- a/examples/minimal_client_service/Cargo.toml
+++ b/examples/minimal_client_service/Cargo.toml
@@ -19,12 +19,9 @@ path = "src/minimal_service.rs"
 [dependencies]
 anyhow = {version = "1", features = ["backtrace"]}
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time"] }
+rclrs = "0.4"
+rosidl_runtime_rs = "0.4"
+example_interfaces = "*"
 
-[dependencies.rclrs]
-version = "0.4"
-
-[dependencies.rosidl_runtime_rs]
-version = "0.4"
-
-[dependencies.example_interfaces]
-version = "*"
+# This specific version is compatible with Rust 1.75
+backtrace = "=0.3.74"

--- a/examples/minimal_pub_sub/Cargo.toml
+++ b/examples/minimal_pub_sub/Cargo.toml
@@ -27,15 +27,12 @@ path = "src/zero_copy_publisher.rs"
 
 [dependencies]
 anyhow = {version = "1", features = ["backtrace"]}
+rclrs = "0.4"
+rosidl_runtime_rs = "0.4"
+std_msgs = "*"
 
-[dependencies.rclrs]
-version = "0.4"
-
-[dependencies.rosidl_runtime_rs]
-version = "0.4"
-
-[dependencies.std_msgs]
-version = "*"
+# This specific version is compatible with Rust 1.75
+backtrace = "=0.3.74"
 
 [package.metadata.ros]
 install_to_share = ["launch"]


### PR DESCRIPTION
A recent version bump in `backtrace` is no longer compatible with Rust version 1.75, despite being a patch increase.

This PR forces a fixed version for several examples that have a transitive dependency on `backtrace` to keep it compatible with Rust 1.75. This should fix CI failures that recently started happening.