### PR TITLE
Seems like `colcon-ros-cargo` needs a `cargo-ament-build` extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ sudo apt install -y git libclang-dev python3-pip python3-vcstool # libclang-dev 
 # Install these plugins for cargo and colcon:
 pip install git+https://github.com/colcon/colcon-cargo.git
 pip install git+https://github.com/colcon/colcon-ros-cargo.git
+cargo install cargo-ament-build
 
 mkdir -p workspace/src && cd workspace
 git clone https://github.com/ros2-rust/ros2_rust.git src/ros2_rust


### PR DESCRIPTION
As stated above ran into this issue when building a clean workspace.