### PR TITLE
Adding windows github action

### DIFF
--- a/.github/workflows/rust-win.yml
+++ b/.github/workflows/rust-win.yml
@@ -42,12 +42,10 @@ jobs:
           Expand-Archive -Path ros2-package-windows-AMD64.zip -DestinationPath C:/pixi_ws/
 
       - name: Install ros2_rust prerequisites 
-        # Prerequisits and fixes for windows build ros2_rust:
-        #     * examples_rclrs_message_demo error and incompatibility with backtrace v0.3.75 with rustc 1.75. (TODO update in ROS2 pixi.toml) 
+        # prerequisites and fixes for windows build ros2_rust:
         #     * Libclang has to be added (from the ros2_rust instructions) and the dll has to be renamed
         #     * colcon-ros-cargo and colcon-cargo have to be added as PyPI packages
         run: |
-          pixi add --manifest-path C:\pixi_ws\pixi.toml rust 
           pixi add libclang --manifest-path C:\pixi_ws\pixi.toml
           $src = "C:\pixi_ws\.pixi\envs\default\Library\bin\libclang-13.dll"
           $dst = "C:\pixi_ws\.pixi\envs\default\Library\bin\libclang.dll"

--- a/.github/workflows/rust-win.yml
+++ b/.github/workflows/rust-win.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Get prebuild ROS files and unzip
         run: |
           irm https://ci.ros2.org/view/packaging/job/packaging_windows/lastSuccessfulBuild/artifact/ws/ros2-package-windows-AMD64.zip -Outfile ros2-package-windows-AMD64.zip
-          Expand-Archive -Path ros2-package-windows-AMD64.zip -DestinationPath C:/pixi_ws\ros2_rolling
+          Expand-Archive -Path ros2-package-windows-AMD64.zip -DestinationPath C:/pixi_ws/
       - name: Install Rust ROS prerequisites
         run: pixi add libclang --manifest-path C:\pixi_ws\pixi.toml
       - name: Rename libclang-13.dll to libclang.dll
@@ -53,11 +53,23 @@ jobs:
           mkdir C:/workspace/src
           git clone  https://github.com/ros2-rust/ros2_rust.git C:/workspace/src/ros2_rust
       - name: Import other rolling ROS rust repos
-        run: vcs import C:/workspace/src --input C:/workspace/src/ros2_rust/ros2_rust_rolling.repos
+        run: pixi run --manifest-path C:\pixi_ws\pixi.toml vcs import C:/workspace/src --input C:/workspace/src/ros2_rust/ros2_rust_rolling.repos
       - name: Build the rust package
         run: |
-          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
-          call C:\pixi_ws\ros2_rolling\setup.bat
+          set FOUND_VCVARS=
+          for %%V in (Enterprise Professional Community BuildTools) do (
+            if exist "C:\Program Files (x86)\Microsoft Visual Studio\2019\%%V\VC\Auxiliary\Build\vcvars64.bat" (
+              call "C:\Program Files (x86)\Microsoft Visual Studio\2019\%%V\VC\Auxiliary\Build\vcvars64.bat"
+              set FOUND_VCVARS=1
+              goto :aftervcvars
+            )
+          )
+          :aftervcvars
+          if not defined FOUND_VCVARS (
+            echo Could not find vcvars64.bat for VS2019!
+            exit /b 1
+          )
+          call C:\pixi_ws\ros2-windows\setup.bat
           pixi run --manifest-path C:\pixi_ws\pixi.toml colcon build
         working-directory: C:\workspace
-        
+        shell: cmd

--- a/.github/workflows/rust-win.yml
+++ b/.github/workflows/rust-win.yml
@@ -53,12 +53,13 @@ jobs:
           pixi add --pypi "colcon-cargo@git+https://github.com/colcon/colcon-cargo.git" --manifest-path C:\pixi_ws\pixi.toml
       - name: Import other rolling ROS rust repos
         run: pixi run --manifest-path C:\pixi_ws\pixi.toml vcs import C:/workspace/src --input C:/workspace/src/ros2_rust/ros2_rust_rolling.repos
+      - name: update rust version
+        run: pixi add --manifest-path C:\pixi_ws\pixi.toml rust # necessary  for examples_rclrs_message_demo error and incompatibility with backtrace v0.3.75 with rustc 1.75. (TODO update in ROS2 pixi.toml) 
       - name: Build the rust package
-        env:
-          BINDGEN_EXTRA_CLANG_ARGS: -D_Check_return_= # to handle the clang error with the windows specific bindgen error
+        #env:
+        #  BINDGEN_EXTRA_CLANG_ARGS: -D_Check_return_= # to handle the clang error with the windows specific bindgen error
         run: |
-          pixi update --manifest-path C:\pixi_ws\pixi.toml rust
           call C:\pixi_ws\ros2-windows\setup.bat
-          pixi run --manifest-path C:\pixi_ws\pixi.toml colcon build
+          pixi run --manifest-path C:\pixi_ws\pixi.toml colcon build 
         working-directory: C:/workspace
         shell: cmd

--- a/.github/workflows/rust-win.yml
+++ b/.github/workflows/rust-win.yml
@@ -23,11 +23,12 @@ jobs:
       RUST_LOG: debug
     steps:
       - uses: actions/checkout@v4
-        with:
-          path: C:/workspace/src/ros2_rust
       - uses: ilammy/msvc-dev-cmd@v1.4.1
-      - name: Make new directory for pixi environment
-        run: mkdir C:\pixi_ws\
+      - name: Make new directory environment and copy ros2_rust repo in there
+        run: |
+          mkdir C:\workspace\src
+          mkdir C:\pixi_ws
+          xcopy /E /I /Y D:\a\ros2_rust\ros2_rust C:\workspace\src\ros2_rust
       - name: Get pixi toml file
         run: irm https://raw.githubusercontent.com/ros2/ros2/refs/heads/rolling/pixi.toml -OutFile C:\pixi_ws\pixi.toml
       - name: Setup Pixi environment
@@ -51,11 +52,12 @@ jobs:
           pixi add --pypi "colcon-ros-cargo@git+https://github.com/colcon/colcon-ros-cargo.git" --manifest-path C:\pixi_ws\pixi.toml
           pixi add --pypi "colcon-cargo@git+https://github.com/colcon/colcon-cargo.git" --manifest-path C:\pixi_ws\pixi.toml
       - name: Import other rolling ROS rust repos
-        run: pixi run --manifest-path C:\pixi_ws\pixi.toml vcs import C:/workspace/src --input C:/C:/workspace/src/ros2_rust/ros2_rust_rolling.repos
+        run: pixi run --manifest-path C:\pixi_ws\pixi.toml vcs import C:/workspace/src --input C:/workspace/src/ros2_rust/ros2_rust_rolling.repos
       - name: Build the rust package
         env:
           BINDGEN_EXTRA_CLANG_ARGS: -D_Check_return_= # to handle the clang error with the windows specific bindgen error
         run: |
+          pixi update --manifest-path C:\pixi_ws\pixi.toml rust
           call C:\pixi_ws\ros2-windows\setup.bat
           pixi run --manifest-path C:\pixi_ws\pixi.toml colcon build
         working-directory: C:/workspace

--- a/.github/workflows/rust-win.yml
+++ b/.github/workflows/rust-win.yml
@@ -2,8 +2,14 @@ name: Rust ROS 2 Windows build
 
 on:
   push:
-    branches: [ win-ci]
-  workflow_dispatch:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    # Run the CI at 02:22 UTC every Tuesday
+    # We pick an arbitrary time outside of most of the world's work hours
+    # to minimize the likelihood of running alongside a heavy workload.
+    - cron: '22 2 * * 2'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust-win.yml
+++ b/.github/workflows/rust-win.yml
@@ -1,12 +1,6 @@
 name: Rust ROS 2 Windows build
 
 on:
-  #push:
-  #  branches: [ main ]
-  #pull_request:
-  #  branches: [ main ]
-  #schedule:
-  #  - cron: '22 2 * * 2'
   push:
     branches: [ win-ci]
   workflow_dispatch:
@@ -17,49 +11,74 @@ env:
 jobs:
   build:
     runs-on: windows-latest
-    env:
-      LIBCLANG_PATH: C:\pixi_ws\.pixi\envs\default\Library\bin
-      RUST_BACKTRACE: 1
-      RUST_LOG: debug
     steps:
       - uses: actions/checkout@v4
+
       - uses: ilammy/msvc-dev-cmd@v1.4.1
-      - name: Make new directory environment and copy ros2_rust repo in there
+
+      - name: Make new directories and copy ros2_rust repo
         run: |
           mkdir C:\workspace\src
           mkdir C:\pixi_ws
           xcopy /E /I /Y D:\a\ros2_rust\ros2_rust C:\workspace\src\ros2_rust
+
       - name: Get pixi toml file
         run: irm https://raw.githubusercontent.com/ros2/ros2/refs/heads/rolling/pixi.toml -OutFile C:\pixi_ws\pixi.toml
-      - name: Setup Pixi environment
+
+      - name: Setup Pixi environment woth ROS2 toml file
         uses: prefix-dev/setup-pixi@v0.8.1
         with:
           manifest-path: C:/pixi_ws/pixi.toml
+
       - name: Get prebuild ROS files and unzip
         run: |
           irm https://ci.ros2.org/view/packaging/job/packaging_windows/lastSuccessfulBuild/artifact/ws/ros2-package-windows-AMD64.zip -Outfile ros2-package-windows-AMD64.zip
           Expand-Archive -Path ros2-package-windows-AMD64.zip -DestinationPath C:/pixi_ws/
-      - name: Install Rust ROS prerequisites
-        run: pixi add libclang --manifest-path C:\pixi_ws\pixi.toml
-      - name: Rename libclang-13.dll to libclang.dll
+
+      - name: Install ros2_rust prerequisites 
+        # Prerequisits and fixes for windows build ros2_rust:
+        #     * examples_rclrs_message_demo error and incompatibility with backtrace v0.3.75 with rustc 1.75. (TODO update in ROS2 pixi.toml) 
+        #     * Libclang has to be added (from the ros2_rust instructions) and the dll has to be renamed
+        #     * colcon-ros-cargo and colcon-cargo have to be added as PyPI packages
         run: |
+          pixi add --manifest-path C:\pixi_ws\pixi.toml rust 
+          pixi add libclang --manifest-path C:\pixi_ws\pixi.toml
           $src = "C:\pixi_ws\.pixi\envs\default\Library\bin\libclang-13.dll"
           $dst = "C:\pixi_ws\.pixi\envs\default\Library\bin\libclang.dll"
           if (Test-Path $src) { Rename-Item -Path $src -NewName "libclang.dll" }
-      - name: Adding Colcon to pixi as PyPI
-        working-directory: C:\pixi_ws\
-        run: |
           pixi add --pypi "colcon-ros-cargo@git+https://github.com/colcon/colcon-ros-cargo.git" --manifest-path C:\pixi_ws\pixi.toml
           pixi add --pypi "colcon-cargo@git+https://github.com/colcon/colcon-cargo.git" --manifest-path C:\pixi_ws\pixi.toml
-      - name: Import other rolling ROS rust repos
-        run: pixi run --manifest-path C:\pixi_ws\pixi.toml vcs import C:/workspace/src --input C:/workspace/src/ros2_rust/ros2_rust_rolling.repos
-      - name: update rust version
-        run: pixi add --manifest-path C:\pixi_ws\pixi.toml rust # necessary  for examples_rclrs_message_demo error and incompatibility with backtrace v0.3.75 with rustc 1.75. (TODO update in ROS2 pixi.toml) 
+
       - name: Build the rust package
-        #env:
-        #  BINDGEN_EXTRA_CLANG_ARGS: -D_Check_return_= # to handle the clang error with the windows specific bindgen error
+        env:
+          LIBCLANG_PATH: C:\pixi_ws\.pixi\envs\default\Library\bin # See https://github.com/ros2-rust/ros2_rust?tab=readme-ov-file#sounds-great-how-can-i-try-this-out
+          BINDGEN_EXTRA_CLANG_ARGS: -D_Check_return_= # to handle the clang error with the windows specific bindgen error
         run: |
           call C:\pixi_ws\ros2-windows\setup.bat
+          pixi run --manifest-path C:\pixi_ws\pixi.toml vcs import C:/workspace/src --input C:/workspace/src/ros2_rust/ros2_rust_rolling.repos
           pixi run --manifest-path C:\pixi_ws\pixi.toml colcon build 
         working-directory: C:/workspace
         shell: cmd
+
+      - name: Run cargo test on Rust packages
+        run: |
+          call C:\pixi_ws\ros2-windows\setup.bat
+          cd C:\workspace
+          for /f "tokens=1,2,3" %%A in ('pixi run --manifest-path C:\pixi_ws\pixi.toml colcon list') do (
+            if "%%C"=="(ament_cargo)" (
+              if /I not "%%A"=="examples_rclrs_minimal_pub_sub" if /I not "%%A"=="examples_rclrs_minimal_client_service" if /I not "%%A"=="rust_pubsub" (
+                cd %%B
+                echo Running cargo test in %%B
+                if /I "%%~nxB"=="rclrs" (
+                  cargo test -F default,dyn_msg
+                ) else if /I "%%~nxB"=="rosidl_runtime_rs" (
+                  cargo test -F default
+                ) else (
+                  cargo test --all-features
+                )
+                cd ..
+              )
+            )
+          )
+        shell: cmd
+        working-directory: C:\workspace

--- a/.github/workflows/rust-win.yml
+++ b/.github/workflows/rust-win.yml
@@ -31,11 +31,11 @@ jobs:
       - name: Setup Pixi environment
         uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          working-directory: C:\pixi_ws\
-      - name: Get prebuild ROS files
-        run: irm https://ci.ros2.org/view/packaging/job/packaging_windows/lastSuccessfulBuild/artifact/ws/ros2-package-windows-AMD64.zip 
-      - name: Unzip prebuild ROS files
-        run: Expand-Archive -Path ros2-package-windows-AMD64.zip -DestinationPath C:/pixi_ws\ros2_rolling
+          manifest-path: C:/pixi_ws/pixi.toml
+      - name: Get prebuild ROS files and unzip
+        run: |
+          irm https://ci.ros2.org/view/packaging/job/packaging_windows/lastSuccessfulBuild/artifact/ws/ros2-package-windows-AMD64.zip -Outfile ros2-package-windows-AMD64.zip
+          Expand-Archive -Path ros2-package-windows-AMD64.zip -DestinationPath C:/pixi_ws\ros2_rolling
       - name: Install Rust ROS prerequisites
         run: pixi add libclang --manifest-path C:\pixi_ws\pixi.toml
       - name: Rename libclang-13.dll to libclang.dll
@@ -51,9 +51,9 @@ jobs:
       - name: Get ros2-Rust in a different workspace path
         run: |
           mkdir C:/workspace/src
-          git clone clone https://github.com/ros2-rust/ros2_rust.git C:/workspace/src/ros2_rust
+          git clone  https://github.com/ros2-rust/ros2_rust.git C:/workspace/src/ros2_rust
       - name: Import other rolling ROS rust repos
-        run: vcs import C:/workspace/src < C:/workspace/src/ros2_rust/ros2_rust_rolling.repos
+        run: vcs import C:/workspace/src --input C:/workspace/src/ros2_rust/ros2_rust_rolling.repos
       - name: Build the rust package
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvars64.bat"

--- a/.github/workflows/rust-win.yml
+++ b/.github/workflows/rust-win.yml
@@ -1,0 +1,63 @@
+name: Rust ROS 2 Windows build
+
+on:
+  #push:
+  #  branches: [ main ]
+  #pull_request:
+  #  branches: [ main ]
+  #schedule:
+  #  - cron: '22 2 * * 2'
+  push:
+    branches: [ win-ci]
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: windows-latest
+    env:
+      LIBCLANG_PATH: C:\pixi_ws\.pixi\envs\default\Library\bin
+    steps:
+      - name: Install MSVC 2019
+        run: |
+          powershell -noexit irm https://aka.ms/vs/16/release/vs_buildtools.exe -OutFile vs_buildtools_2019.exe
+          .\vs_buildtools_2019.exe --quiet --wait --norestart --add Microsoft.Component.MSBuild --add Microsoft.Net.Component.4.6.1.TargetingPack --add Microsoft.Net.Component.4.8.SDK --add Microsoft.VisualStudio.Component.CoreBuildTools --add Microsoft.VisualStudio.Component.Roslyn.Compiler --add Microsoft.VisualStudio.Component.TextTemplating --add Microsoft.VisualStudio.Component.VC.CLI.Support --add Microsoft.VisualStudio.Component.VC.CoreBuildTools --add Microsoft.VisualStudio.Component.VC.CoreIde --add Microsoft.VisualStudio.Component.VC.Redist.14.Latest --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core --add Microsoft.VisualStudio.Workload.MSBuildTools --add Microsoft.VisualStudio.Workload.VCTools
+      - name: Make new directory for pixi environment
+        run: mkdir C:\pixi_ws\
+      - name: Get pixi toml file
+        run: irm https://raw.githubusercontent.com/ros2/ros2/refs/heads/rolling/pixi.toml -OutFile C:\pixi_ws\pixi.toml
+      - name: Setup Pixi environment
+        uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          working-directory: C:\pixi_ws\
+      - name: Get prebuild ROS files
+        run: irm https://ci.ros2.org/view/packaging/job/packaging_windows/lastSuccessfulBuild/artifact/ws/ros2-package-windows-AMD64.zip 
+      - name: Unzip prebuild ROS files
+        run: Expand-Archive -Path ros2-package-windows-AMD64.zip -DestinationPath C:/pixi_ws\ros2_rolling
+      - name: Install Rust ROS prerequisites
+        run: pixi add libclang --manifest-path C:\pixi_ws\pixi.toml
+      - name: Rename libclang-13.dll to libclang.dll
+        run: |
+          $src = "C:\pixi_ws\.pixi\envs\default\Library\bin\libclang-13.dll"
+          $dst = "C:\pixi_ws\.pixi\envs\default\Library\bin\libclang.dll"
+          if (Test-Path $src) { Rename-Item -Path $src -NewName "libclang.dll" }
+      - name: Adding Colcon to pixi as PyPI
+        working-directory: C:\pixi_ws\
+        run: |
+          pixi add --pypi "colcon-ros-cargo@git+https://github.com/colcon/colcon-ros-cargo.git" --manifest-path C:\pixi_ws\pixi.toml
+          pixi add --pypi "colcon-cargo@git+https://github.com/colcon/colcon-cargo.git" --manifest-path C:\pixi_ws\pixi.toml
+      - name: Get ros2-Rust in a different workspace path
+        run: |
+          mkdir C:/workspace/src
+          git clone clone https://github.com/ros2-rust/ros2_rust.git C:/workspace/src/ros2_rust
+      - name: Import other rolling ROS rust repos
+        run: vcs import C:/workspace/src < C:/workspace/src/ros2_rust/ros2_rust_rolling.repos
+      - name: Build the rust package
+        run: |
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+          call C:\pixi_ws\ros2_rolling\setup.bat
+          pixi run --manifest-path C:\pixi_ws\pixi.toml colcon build
+        working-directory: C:\workspace
+        

--- a/.github/workflows/rust-win.yml
+++ b/.github/workflows/rust-win.yml
@@ -20,6 +20,7 @@ jobs:
     env:
       LIBCLANG_PATH: C:\pixi_ws\.pixi\envs\default\Library\bin
     steps:
+      - uses: ilammy/msvc-dev-cmd@v1.4.1
       - name: Install MSVC 2019
         run: |
           powershell -noexit irm https://aka.ms/vs/16/release/vs_buildtools.exe -OutFile vs_buildtools_2019.exe
@@ -56,19 +57,6 @@ jobs:
         run: pixi run --manifest-path C:\pixi_ws\pixi.toml vcs import C:/workspace/src --input C:/workspace/src/ros2_rust/ros2_rust_rolling.repos
       - name: Build the rust package
         run: |
-          set FOUND_VCVARS=
-          for %%V in (Enterprise Professional Community BuildTools) do (
-            if exist "C:\Program Files (x86)\Microsoft Visual Studio\2019\%%V\VC\Auxiliary\Build\vcvars64.bat" (
-              call "C:\Program Files (x86)\Microsoft Visual Studio\2019\%%V\VC\Auxiliary\Build\vcvars64.bat"
-              set FOUND_VCVARS=1
-              goto :aftervcvars
-            )
-          )
-          :aftervcvars
-          if not defined FOUND_VCVARS (
-            echo Could not find vcvars64.bat for VS2019!
-            exit /b 1
-          )
           call C:\pixi_ws\ros2-windows\setup.bat
           pixi run --manifest-path C:\pixi_ws\pixi.toml colcon build
         working-directory: C:\workspace

--- a/.github/workflows/rust-win.yml
+++ b/.github/workflows/rust-win.yml
@@ -58,6 +58,8 @@ jobs:
       - name: Import other rolling ROS rust repos
         run: pixi run --manifest-path C:\pixi_ws\pixi.toml vcs import C:/workspace/src --input C:/workspace/src/ros2_rust/ros2_rust_rolling.repos
       - name: Build the rust package
+        env:
+          BINDGEN_EXTRA_CLANG_ARGS: -D_Check_return_= # to handle the clang error with the windows specific bindgen error
         run: |
           call C:\pixi_ws\ros2-windows\setup.bat
           pixi run --manifest-path C:\pixi_ws\pixi.toml colcon build

--- a/.github/workflows/rust-win.yml
+++ b/.github/workflows/rust-win.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: windows-latest
     env:
       LIBCLANG_PATH: C:\pixi_ws\.pixi\envs\default\Library\bin
+      RUST_BACKTRACE: 1
+      RUST_LOG: debug
     steps:
       - uses: ilammy/msvc-dev-cmd@v1.4.1
       - name: Install MSVC 2019

--- a/.github/workflows/rust-win.yml
+++ b/.github/workflows/rust-win.yml
@@ -22,11 +22,10 @@ jobs:
       RUST_BACKTRACE: 1
       RUST_LOG: debug
     steps:
+      - uses: actions/checkout@v4
+        with:
+          path: C:/workspace/src/ros2_rust
       - uses: ilammy/msvc-dev-cmd@v1.4.1
-      - name: Install MSVC 2019
-        run: |
-          powershell -noexit irm https://aka.ms/vs/16/release/vs_buildtools.exe -OutFile vs_buildtools_2019.exe
-          .\vs_buildtools_2019.exe --quiet --wait --norestart --add Microsoft.Component.MSBuild --add Microsoft.Net.Component.4.6.1.TargetingPack --add Microsoft.Net.Component.4.8.SDK --add Microsoft.VisualStudio.Component.CoreBuildTools --add Microsoft.VisualStudio.Component.Roslyn.Compiler --add Microsoft.VisualStudio.Component.TextTemplating --add Microsoft.VisualStudio.Component.VC.CLI.Support --add Microsoft.VisualStudio.Component.VC.CoreBuildTools --add Microsoft.VisualStudio.Component.VC.CoreIde --add Microsoft.VisualStudio.Component.VC.Redist.14.Latest --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core --add Microsoft.VisualStudio.Workload.MSBuildTools --add Microsoft.VisualStudio.Workload.VCTools
       - name: Make new directory for pixi environment
         run: mkdir C:\pixi_ws\
       - name: Get pixi toml file
@@ -51,17 +50,13 @@ jobs:
         run: |
           pixi add --pypi "colcon-ros-cargo@git+https://github.com/colcon/colcon-ros-cargo.git" --manifest-path C:\pixi_ws\pixi.toml
           pixi add --pypi "colcon-cargo@git+https://github.com/colcon/colcon-cargo.git" --manifest-path C:\pixi_ws\pixi.toml
-      - name: Get ros2-Rust in a different workspace path
-        run: |
-          mkdir C:/workspace/src
-          git clone  https://github.com/ros2-rust/ros2_rust.git C:/workspace/src/ros2_rust
       - name: Import other rolling ROS rust repos
-        run: pixi run --manifest-path C:\pixi_ws\pixi.toml vcs import C:/workspace/src --input C:/workspace/src/ros2_rust/ros2_rust_rolling.repos
+        run: pixi run --manifest-path C:\pixi_ws\pixi.toml vcs import C:/workspace/src --input C:/C:/workspace/src/ros2_rust/ros2_rust_rolling.repos
       - name: Build the rust package
         env:
           BINDGEN_EXTRA_CLANG_ARGS: -D_Check_return_= # to handle the clang error with the windows specific bindgen error
         run: |
           call C:\pixi_ws\ros2-windows\setup.bat
           pixi run --manifest-path C:\pixi_ws\pixi.toml colcon build
-        working-directory: C:\workspace
+        working-directory: C:/workspace
         shell: cmd


### PR DESCRIPTION
This PR adds a GitHub action which:
* Installs ROS2 windows binary with new pixi installation
* Builds the current ros2_rust with added modules with visual studio 2022 (with action msvc-dev-cmd)
* Runs minimal examples and cargo test

This is for windows-server 2022 (currently latest) and ROS2 rolling nightly binaries

I would wait a bit more before adding instructions for the windows install as there are more changing upcoming for the installation instructions, but luckily it wasn't much. I tried to add those extra steps in 'Get prebuild ROS files and unzip' and 'Build the rust package'. Also currently, the binaries of windows ROS2 install are hardcoded that they need to be installed in C:\pixi_ws but that will soon change as well (see this [issue](https://github.com/ros2/ros2/issues/1675))

Fixes #110 