### PR TITLE
use GITHUB_WORKSPACE instead of hardcoded dir winCI

### DIFF
--- a/.github/workflows/rust-win.yml
+++ b/.github/workflows/rust-win.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           mkdir C:\workspace\src
           mkdir C:\pixi_ws
-          xcopy /E /I /Y D:\a\ros2_rust\ros2_rust C:\workspace\src\ros2_rust
+          xcopy /E /I /Y $env:GITHUB_WORKSPACE C:\workspace\src\ros2_rust
 
       - name: Get pixi toml file
         run: irm https://raw.githubusercontent.com/ros2/ros2/refs/heads/rolling/pixi.toml -OutFile C:\pixi_ws\pixi.toml


### PR DESCRIPTION
The windows CI is failing and that is due to this line right here:

https://github.com/ros2-rust/ros2_rust/blob/d62583d2c9faab2f0342e1f803f8088b3627d148/.github/workflows/rust-win.yml#L29

Apparently this directory changed from D:/ to C:/ when it got merged into main. Why? no idea! But now it should use the GITHUB_WORKSPACE directory instead of hardcoding it, so it should should be more generic at least. 

I've put it into draft until it builds.