### PR TITLE
update CI with jazzy and noble

### DIFF
--- a/.github/workflows/rust-stable.yml
+++ b/.github/workflows/rust-stable.yml
@@ -20,14 +20,19 @@ jobs:
       matrix:
         ros_distribution:
           - humble
+          - jazzy
           - rolling
         include:
           # Humble Hawksbill (May 2022 - May 2027)
           - docker_image: rostooling/setup-ros-docker:ubuntu-jammy-ros-humble-ros-base-latest
             ros_distribution: humble
             ros_version: 2
+          # Jazzy Jalisco (May 2024 - May 2029)
+          - docker_image: rostooling/setup-ros-docker:ubuntu-noble-ros-jazzy-ros-base-latest
+            ros_distribution: jazzy
+            ros_version: 2
           # Rolling Ridley  (June 2020 - Present)
-          - docker_image: rostooling/setup-ros-docker:ubuntu-jammy-ros-rolling-ros-base-latest
+          - docker_image: rostooling/setup-ros-docker:ubuntu-noble-ros-rolling-ros-base-latest
             ros_distribution: rolling
             ros_version: 2
     runs-on: ubuntu-latest


### PR DESCRIPTION
An update to the CI

- Adding Jazzy Jalisco
- Changing Rolling tooling to Ubuntu 24.04 noble (so latest)

Do we want to keep supporting humble? and how about short term releases as iron and kilted