### PR TITLE
upgrade colcon-cargo in pixi.toml for windows CI

### DIFF
--- a/.github/workflows/rust-win.yml
+++ b/.github/workflows/rust-win.yml
@@ -52,6 +52,7 @@ jobs:
           if (Test-Path $src) { Rename-Item -Path $src -NewName "libclang.dll" }
           pixi add --pypi "colcon-ros-cargo@git+https://github.com/colcon/colcon-ros-cargo.git" --manifest-path C:\pixi_ws\pixi.toml
           pixi add --pypi "colcon-cargo@git+https://github.com/colcon/colcon-cargo.git" --manifest-path C:\pixi_ws\pixi.toml
+          pixi upgrade --pypi colcon-core --manifest-path C:\pixi_ws\pixi.toml
 
       - name: Build the rust package
         env:


### PR DESCRIPTION
In this PR of colcon-cargo, colcon-core version has been locked to be higher than 0.19: https://github.com/colcon/colcon-cargo/pull/59

Since the[ pixi.toml on the ros2 repo locks](ttps://github.com/ros2/ros2/blob/58faf9a091f9cd0bf24e93bb559b09133a75fafd/pixi.toml#L18C1-L19C1) the colcon-cargo pypi  to be less than 0.18 this is causing a dependency issue.

This PR fixes our CI temporary but a PR needs to be made to ROS2 repo pixi.toml file at least to fix this.