### PR TITLE
build: rename generate_docs feature to use_ros_shim

### DIFF
--- a/.github/workflows/rust-minimal.yml
+++ b/.github/workflows/rust-minimal.yml
@@ -99,7 +99,7 @@ jobs:
         for path in $(colcon list | awk '$3 == "(ament_cargo)" { print $2 }'); do
         cd $path
         echo "Running clippy in $path"
-        # Run clippy for all features except generate_docs (needed for docs.rs)
+        # Run clippy for all features except use_ros_shim (needed for docs.rs)
         if [ "$(basename $path)" = "rclrs" ]; then
           cargo clippy --no-deps --all-targets -F default,dyn_msg -- -D warnings
         else
@@ -115,7 +115,7 @@ jobs:
         for path in $(colcon list | awk '$3 == "(ament_cargo)" && $1 != "examples_rclrs_minimal_pub_sub" && $1 != "examples_rclrs_minimal_client_service" && $1 != "rust_pubsub" { print $2 }'); do
         cd $path
         echo "Running cargo test in $path"
-        # Run cargo test for all features except generate_docs (needed for docs.rs)
+        # Run cargo test for all features except use_ros_shim (needed for docs.rs)
         if [ "$(basename $path)" = "rclrs" ]; then
           cargo test -F default,dyn_msg
         elif [ "$(basename $path)" = "rosidl_runtime_rs" ]; then

--- a/.github/workflows/rust-stable.yml
+++ b/.github/workflows/rust-stable.yml
@@ -99,7 +99,7 @@ jobs:
         for path in $(colcon list | awk '$3 == "(ament_cargo)" { print $2 }'); do
         cd $path
         echo "Running clippy in $path"
-        # Run clippy for all features except generate_docs (needed for docs.rs)
+        # Run clippy for all features except use_ros_shim (needed for docs.rs)
         if [ "$(basename $path)" = "rclrs" ]; then
           cargo clippy --no-deps --all-targets -F default,dyn_msg -- -D warnings
         else
@@ -115,7 +115,7 @@ jobs:
         for path in $(colcon list | awk '$3 == "(ament_cargo)" && $1 != "examples_rclrs_minimal_pub_sub" && $1 != "examples_rclrs_minimal_client_service" && $1 != "rust_pubsub" { print $2 }'); do
         cd $path
         echo "Running cargo test in $path"
-        # Run cargo test for all features except generate_docs (needed for docs.rs)
+        # Run cargo test for all features except use_ros_shim (needed for docs.rs)
         if [ "$(basename $path)" = "rclrs" ]; then
           cargo test -F default,dyn_msg
         elif [ "$(basename $path)" = "rosidl_runtime_rs" ]; then

--- a/rclrs/Cargo.toml
+++ b/rclrs/Cargo.toml
@@ -58,7 +58,7 @@ dyn_msg = ["ament_rs", "libloading"]
 serde = ["dep:serde", "dep:serde-big-array", "rosidl_runtime_rs/serde"]
 # This feature is solely for the purpose of being able to generate documetation without a ROS installation
 # The only intended usage of this feature is for docs.rs builders to work, and is not intended to be used by end users
-generate_docs = ["rosidl_runtime_rs/generate_docs"]
+use_ros_shim = ["rosidl_runtime_rs/use_ros_shim"]
 
 [package.metadata.docs.rs]
-features = ["generate_docs"]
+features = ["use_ros_shim"]

--- a/rclrs/build.rs
+++ b/rclrs/build.rs
@@ -26,7 +26,7 @@ fn main() {
         let error_msg =
             "ROS_DISTRO environment variable not set - please source ROS 2 installation first.";
         cfg_if::cfg_if! {
-            if #[cfg(feature="generate_docs")] {
+            if #[cfg(feature="use_ros_shim")] {
                 println!("{}", error_msg);
                 return;
             } else {

--- a/rclrs/src/rcl_bindings.rs
+++ b/rclrs/src/rcl_bindings.rs
@@ -12,7 +12,7 @@
 #![allow(missing_docs)]
 
 cfg_if::cfg_if! {
-    if #[cfg(feature="generate_docs")] {
+    if #[cfg(feature="use_ros_shim")] {
         #[repr(C)]
         #[derive(Debug)]
         pub struct rcl_allocator_t;


### PR DESCRIPTION
This PR is the `rclrs` counterpart of https://github.com/ros2-rust/rosidl_runtime_rs/pull/14, given that we'll use this feature for publishing the crate onto crates.io in addition to docs.rs, `use_ros_shim` might make more sense.