### PR TITLE
Wake up wait set when adding a new waitable

### DIFF
--- a/rclrs/src/executor.rs
+++ b/rclrs/src/executor.rs
@@ -241,7 +241,7 @@ impl ExecutorCommands {
     }
 
     pub(crate) fn add_to_wait_set(&self, waitable: Waitable) {
-        self.async_worker_commands.channel.add_to_waitset(waitable);
+        self.async_worker_commands.add_to_wait_set(waitable);
     }
 
     #[cfg(test)]
@@ -275,7 +275,7 @@ impl ExecutorCommands {
             guard_condition: Arc::clone(&guard_condition),
         });
 
-        worker_channel.add_to_waitset(waitable);
+        worker_channel.add_to_wait_set(waitable);
 
         Arc::new(WorkerCommands {
             channel: worker_channel,
@@ -296,7 +296,8 @@ pub(crate) struct WorkerCommands {
 
 impl WorkerCommands {
     pub(crate) fn add_to_wait_set(&self, waitable: Waitable) {
-        self.channel.add_to_waitset(waitable);
+        self.channel.add_to_wait_set(waitable);
+        let _ = self.wakeup_wait_set.trigger();
     }
 
     pub(crate) fn run_async<F>(&self, f: F)
@@ -327,7 +328,7 @@ pub trait WorkerChannel: Send + Sync {
     fn add_async_task(&self, f: BoxFuture<'static, ()>);
 
     /// Add new entities to the waitset of the executor.
-    fn add_to_waitset(&self, new_entity: Waitable);
+    fn add_to_wait_set(&self, new_entity: Waitable);
 
     /// Send a one-time task for the worker to run with its payload.
     fn send_payload_task(&self, f: PayloadTask);

--- a/rclrs/src/executor/basic_executor.rs
+++ b/rclrs/src/executor/basic_executor.rs
@@ -308,7 +308,7 @@ struct BasicWorkerChannel {
 }
 
 impl WorkerChannel for BasicWorkerChannel {
-    fn add_to_waitset(&self, new_entity: Waitable) {
+    fn add_to_wait_set(&self, new_entity: Waitable) {
         if let Err(err) = self.waitable_sender.unbounded_send(new_entity) {
             // This is a debug log because it is normal for this to happen while
             // an executor is winding down.

--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -385,13 +385,13 @@ impl NodeState {
     /// ```
     ///
     pub fn create_publisher<'a, T>(
-        &self,
+        self: &Arc<Self>,
         options: impl Into<PublisherOptions<'a>>,
     ) -> Result<Publisher<T>, RclrsError>
     where
         T: Message,
     {
-        PublisherState::<T>::create(options, Arc::clone(&self.handle))
+        PublisherState::<T>::create(options, Arc::clone(self))
     }
 
     /// Creates a [`Service`] with an ordinary callback.

--- a/rclrs/src/publisher.rs
+++ b/rclrs/src/publisher.rs
@@ -11,7 +11,7 @@ use crate::{
     error::{RclrsError, ToResult},
     qos::QoSProfile,
     rcl_bindings::*,
-    IntoPrimitiveOptions, NodeHandle, ENTITY_LIFECYCLE_MUTEX,
+    IntoPrimitiveOptions, Node, Promise, ENTITY_LIFECYCLE_MUTEX,
 };
 
 mod loaned_message;
@@ -28,12 +28,14 @@ unsafe impl Send for rcl_publisher_t {}
 /// [1]: <https://doc.rust-lang.org/reference/destructors.html>
 struct PublisherHandle {
     rcl_publisher: Mutex<rcl_publisher_t>,
-    node_handle: Arc<NodeHandle>,
+    /// We store the whole node here because we use some of its user-facing API
+    /// in some of the Publisher methods.
+    node: Node,
 }
 
 impl Drop for PublisherHandle {
     fn drop(&mut self) {
-        let mut rcl_node = self.node_handle.rcl_node.lock().unwrap();
+        let mut rcl_node = self.node.handle().rcl_node.lock().unwrap();
         let _lifecycle_lock = ENTITY_LIFECYCLE_MUTEX.lock().unwrap();
         // SAFETY: The entity lifecycle mutex is locked to protect against the risk of
         // global variables in the rmw implementation being unsafely modified during cleanup.
@@ -97,7 +99,7 @@ where
     /// Node and namespace changes are always applied _before_ topic remapping.
     pub(crate) fn create<'a>(
         options: impl Into<PublisherOptions<'a>>,
-        node_handle: Arc<NodeHandle>,
+        node: Node,
     ) -> Result<Arc<Self>, RclrsError>
     where
         T: Message,
@@ -117,7 +119,7 @@ where
         publisher_options.qos = qos.into();
 
         {
-            let rcl_node = node_handle.rcl_node.lock().unwrap();
+            let rcl_node = node.handle().rcl_node.lock().unwrap();
             let _lifecycle_lock = ENTITY_LIFECYCLE_MUTEX.lock().unwrap();
             unsafe {
                 // SAFETY:
@@ -142,7 +144,7 @@ where
             message: PhantomData,
             handle: PublisherHandle {
                 rcl_publisher: Mutex::new(rcl_publisher),
-                node_handle,
+                node,
             },
         }))
     }
@@ -175,6 +177,15 @@ where
             .ok()?
         };
         Ok(subscription_count)
+    }
+
+    /// Get a promise that will be fulfilled when at least one subscriber is
+    /// listening to this publisher.
+    pub fn notify_on_subscriber_ready(self: &Arc<PublisherState<T>>) -> Promise<()> {
+        let publisher = Arc::clone(self);
+        self.handle
+            .node
+            .notify_on_graph_change(move || publisher.get_subscription_count().is_ok_and(|count| count > 0))
     }
 
     /// Publishes a message.

--- a/rclrs/src/publisher.rs
+++ b/rclrs/src/publisher.rs
@@ -183,9 +183,11 @@ where
     /// listening to this publisher.
     pub fn notify_on_subscriber_ready(self: &Arc<PublisherState<T>>) -> Promise<()> {
         let publisher = Arc::clone(self);
-        self.handle
-            .node
-            .notify_on_graph_change(move || publisher.get_subscription_count().is_ok_and(|count| count > 0))
+        self.handle.node.notify_on_graph_change(move || {
+            publisher
+                .get_subscription_count()
+                .is_ok_and(|count| count > 0)
+        })
     }
 
     /// Publishes a message.

--- a/rclrs/src/subscription.rs
+++ b/rclrs/src/subscription.rs
@@ -524,20 +524,22 @@ mod tests {
     #[test]
     fn test_delayed_subscription() {
         use crate::*;
+        use example_interfaces::msg::Empty;
         use futures::{
-            channel::{oneshot, mpsc},
+            channel::{mpsc, oneshot},
             StreamExt,
         };
-        use example_interfaces::msg::Empty;
         use std::sync::atomic::{AtomicBool, Ordering};
 
         let mut executor = Context::default().create_basic_executor();
-        let node = executor.create_node(
-            format!("test_delayed_subscription_{}", line!())
-            // We need to turn off parameter services because their activity will
-            // wake up the wait set, which defeats the purpose of this test.
-            .start_parameter_services(false)
-        ).unwrap();
+        let node = executor
+            .create_node(
+                format!("test_delayed_subscription_{}", line!())
+                    // We need to turn off parameter services because their activity will
+                    // wake up the wait set, which defeats the purpose of this test.
+                    .start_parameter_services(false),
+            )
+            .unwrap();
 
         let (promise, receiver) = oneshot::channel();
         let promise = Arc::new(Mutex::new(Some(promise)));
@@ -555,12 +557,11 @@ mod tests {
 
             let _ = commands.run(async move {
                 let (sender, mut receiver) = mpsc::unbounded();
-                let _subscription = node.create_subscription(
-                    "test_delayed_subscription",
-                    move |_: Empty| {
+                let _subscription = node
+                    .create_subscription("test_delayed_subscription", move |_: Empty| {
                         let _ = sender.unbounded_send(());
-                    },
-                ).unwrap();
+                    })
+                    .unwrap();
 
                 // Make sure the message doesn't get dropped due to the subscriber
                 // not being connected yet.
@@ -580,8 +581,8 @@ mod tests {
 
         let r = executor.spin(
             SpinOptions::default()
-            .until_promise_resolved(receiver)
-            .timeout(std::time::Duration::from_secs(10))
+                .until_promise_resolved(receiver)
+                .timeout(std::time::Duration::from_secs(10)),
         );
 
         assert!(r.is_empty(), "{r:?}");


### PR DESCRIPTION
This PR fixes a subtle bug that could cause subscriptions, clients, and services to stall out where new messages fail to wake up the wait set because the subscription, client, or service itself has not been added to the wait set yet.

The fix itself is very simple:

```rust
pub(crate) fn add_to_wait_set(&self, waitable: Waitable) {
    self.channel.add_to_wait_set(waitable);
    let _ = self.wakeup_wait_set.trigger(); // <--- We were forgetting to do this
}
```

This was an oversight that was missed in the original PR that introduced async execution. The result was:
* We send off an instruction to add a new waitable to the wait set
* The wait set is never told to wake up, so it keeps waiting on its current set of primitives
* Since the wait set doesn't wake up, the new waitable never gets added to it
* It becomes a matter of luck whether something currently in the wait set ever wakes it up so that the wait set can notice that a new thing has been added

And so the fix is simply to explicitly trigger the wait set to wake up whenever we add a new waitable to it.

I've also added a test that will fail (at least most of the time, it's a bit of a race condition) if it gets ported to `main` and run without the fix to `add_to_wait_set`.

As a bonus, I've added a `Publisher::notify_on_subscriber_ready` method since it was needed for the new test. Almost all of the changed lines of code are actually related to the new test.