### PR TITLE
feat: vendorize messages so that cargo update works

### DIFF
--- a/rclrs/Cargo.toml
+++ b/rclrs/Cargo.toml
@@ -39,10 +39,6 @@ serde-big-array = { version = "0.5.1", optional = true }
 [dev-dependencies]
 # Needed for e.g. writing yaml files in tests
 tempfile = "3.3.0"
-# Needed for publisher and subscriber tests
-test_msgs = {version = "*"}
-# Used in doctests
-example_interfaces = { version = "*" }
 # Needed for parameter service tests
 tokio = { version = "1", features = ["rt", "time", "macros"] }
 

--- a/rclrs/src/client.rs
+++ b/rclrs/src/client.rs
@@ -162,7 +162,9 @@ where
     /// # let node = Context::default()
     /// #   .create_basic_executor()
     /// #   .create_node("test_node")?;
-    /// use test_msgs::srv::{Empty, Empty_Request, Empty_Response};
+    /// # The following line of code is only needed for rclrs internal purposes,
+    /// # please use the test_msgs crate instead.
+    /// use vendor::test_msgs::srv::{Empty, Empty_Request, Empty_Response};
     ///
     /// async fn print_hello(_response: Empty_Response) {
     ///     print!("Hello!");
@@ -191,7 +193,9 @@ where
     /// # let node = Context::default()
     /// #   .create_basic_executor()
     /// #   .create_node("test_node")?;
-    /// use test_msgs::srv::{Empty, Empty_Request, Empty_Response};
+    /// # The following line of code is only needed for rclrs internal purposes,
+    /// # please use the test_msgs crate instead.
+    /// use vendor::test_msgs::srv::{Empty, Empty_Request, Empty_Response};
     ///
     /// fn print_greeting(_response: Empty_Response) -> impl Future<Output=()> {
     ///     let greeting = "Hello!";
@@ -219,7 +223,9 @@ where
     /// # let node = Context::default()
     /// #   .create_basic_executor()
     /// #   .create_node("test_node")?;
-    /// use test_msgs::srv::{Empty, Empty_Request, Empty_Response};
+    /// # The following line of code is only needed for rclrs internal purposes,
+    /// # please use the test_msgs crate instead.
+    /// use vendor::test_msgs::srv::{Empty, Empty_Request, Empty_Response};
     ///
     /// let greeting = "Hello!";
     /// let client = node.create_client::<Empty>("my_service")?;
@@ -568,7 +574,7 @@ unsafe impl Send for rcl_client_t {}
 mod tests {
     use super::*;
     use crate::test_helpers::*;
-    use test_msgs::srv;
+    use crate::vendor::test_msgs::srv;
 
     #[test]
     fn traits() {

--- a/rclrs/src/client.rs
+++ b/rclrs/src/client.rs
@@ -159,17 +159,17 @@ where
     /// signatures and which returns a `()` (a.k.a. nothing).
     /// ```
     /// # use rclrs::*;
-    /// # use rclrs::vendor::test_msgs::srv::{Empty, Empty_Request, Empty_Response};
+    /// # use crate::rclrs::vendor::test_msgs;
     /// # let node = Context::default()
     /// #   .create_basic_executor()
     /// #   .create_node("test_node")?;
     ///
-    /// async fn print_hello(_response: Empty_Response) {
+    /// async fn print_hello(_response: test_msgs::srv::Empty_Response) {
     ///     print!("Hello!");
     /// }
     ///
-    /// let client = node.create_client::<Empty>("my_service")?;
-    /// let request = Empty_Request::default();
+    /// let client = node.create_client::<test_msgs::srv::Empty>("my_service")?;
+    /// let request = test_msgs::srv::Empty_Request::default();
     /// let promise = client.call_then_async(&request, print_hello)?;
     /// # Ok::<(), RclrsError>(())
     /// ```
@@ -187,21 +187,21 @@ where
     ///
     /// ```
     /// # use rclrs::*;
-    /// # use rclrs::vendor::test_msgs::srv::{Empty, Empty_Request, Empty_Response};
+    /// # use crate::rclrs::vendor::test_msgs;
     /// # use std::future::Future;
     /// # let node = Context::default()
     /// #   .create_basic_executor()
     /// #   .create_node("test_node")?;
     ///
-    /// fn print_greeting(_response: Empty_Response) -> impl Future<Output=()> {
+    /// fn print_greeting(_response: test_msgs::srv::Empty_Response) -> impl Future<Output=()> {
     ///     let greeting = "Hello!";
     ///     async move {
     ///         print!("Hello!");
     ///     }
     /// }
     ///
-    /// let client = node.create_client::<Empty>("my_service")?;
-    /// let request = Empty_Request::default();
+    /// let client = node.create_client::<test_msgs::srv::Empty>("my_service")?;
+    /// let request = test_msgs::srv::Empty_Request::default();
     /// let promise = client.call_then_async(
     ///     &request,
     ///     print_greeting)?;
@@ -216,17 +216,17 @@ where
     ///
     /// ```
     /// # use rclrs::*;
-    /// # use rclrs::vendor::test_msgs::srv::{Empty, Empty_Request, Empty_Response};
+    /// # use crate::rclrs::vendor::test_msgs;
     /// # let node = Context::default()
     /// #   .create_basic_executor()
     /// #   .create_node("test_node")?;
     ///
     /// let greeting = "Hello!";
-    /// let client = node.create_client::<Empty>("my_service")?;
-    /// let request = Empty_Request::default();
+    /// let client = node.create_client::<test_msgs::srv::Empty>("my_service")?;
+    /// let request = test_msgs::srv::Empty_Request::default();
     /// let promise = client.call_then_async(
     ///     &request,
-    ///     move |response: Empty_Response| {
+    ///     move |response: test_msgs::srv::Empty_Response| {
     ///         async move {
     ///             print!("{greeting}");
     ///         }
@@ -568,12 +568,12 @@ unsafe impl Send for rcl_client_t {}
 mod tests {
     use super::*;
     use crate::test_helpers::*;
-    use crate::vendor::test_msgs::srv;
+    use crate::vendor::test_msgs;
 
     #[test]
     fn traits() {
-        assert_send::<Client<srv::Arrays>>();
-        assert_sync::<Client<srv::Arrays>>();
+        assert_send::<Client<test_msgs::srv::Arrays>>();
+        assert_sync::<Client<test_msgs::srv::Arrays>>();
     }
 
     #[test]
@@ -582,7 +582,7 @@ mod tests {
         let graph = construct_test_graph(namespace)?;
         let _node_2_empty_client = graph
             .node2
-            .create_client::<srv::Empty>("graph_test_topic_4")?;
+            .create_client::<test_msgs::srv::Empty>("graph_test_topic_4")?;
 
         std::thread::sleep(std::time::Duration::from_millis(200));
 

--- a/rclrs/src/client.rs
+++ b/rclrs/src/client.rs
@@ -159,12 +159,10 @@ where
     /// signatures and which returns a `()` (a.k.a. nothing).
     /// ```
     /// # use rclrs::*;
+    /// # use rclrs::vendor::test_msgs::srv::{Empty, Empty_Request, Empty_Response};
     /// # let node = Context::default()
     /// #   .create_basic_executor()
     /// #   .create_node("test_node")?;
-    /// # The following line of code is only needed for rclrs internal purposes,
-    /// # please use the test_msgs crate instead.
-    /// use vendor::test_msgs::srv::{Empty, Empty_Request, Empty_Response};
     ///
     /// async fn print_hello(_response: Empty_Response) {
     ///     print!("Hello!");
@@ -189,13 +187,11 @@ where
     ///
     /// ```
     /// # use rclrs::*;
+    /// # use rclrs::vendor::test_msgs::srv::{Empty, Empty_Request, Empty_Response};
     /// # use std::future::Future;
     /// # let node = Context::default()
     /// #   .create_basic_executor()
     /// #   .create_node("test_node")?;
-    /// # The following line of code is only needed for rclrs internal purposes,
-    /// # please use the test_msgs crate instead.
-    /// use vendor::test_msgs::srv::{Empty, Empty_Request, Empty_Response};
     ///
     /// fn print_greeting(_response: Empty_Response) -> impl Future<Output=()> {
     ///     let greeting = "Hello!";
@@ -220,12 +216,10 @@ where
     ///
     /// ```
     /// # use rclrs::*;
+    /// # use rclrs::vendor::test_msgs::srv::{Empty, Empty_Request, Empty_Response};
     /// # let node = Context::default()
     /// #   .create_basic_executor()
     /// #   .create_node("test_node")?;
-    /// # The following line of code is only needed for rclrs internal purposes,
-    /// # please use the test_msgs crate instead.
-    /// use vendor::test_msgs::srv::{Empty, Empty_Request, Empty_Response};
     ///
     /// let greeting = "Hello!";
     /// let client = node.create_client::<Empty>("my_service")?;

--- a/rclrs/src/lib.rs
+++ b/rclrs/src/lib.rs
@@ -32,7 +32,7 @@
 //!
 //! ```no_run
 //! use rclrs::*;
-//! use crate::rclrs::vendor::example_interfaces;
+//! # use crate::rclrs::vendor::example_interfaces;
 //!
 //! let context = Context::default_from_env()?;
 //! let mut executor = context.create_basic_executor();
@@ -59,8 +59,8 @@
 //! # let context = Context::default_from_env()?;
 //! # let mut executor = context.create_basic_executor();
 //! # let node = executor.create_node("example_node")?;
-//! # use rclrs::vendor::example_interfaces;
-//!
+//! # use crate::rclrs::vendor::example_interfaces;
+//! #
 //! // This worker will manage the data for us.
 //! // The worker's data is called its payload.
 //! let worker = node.create_worker::<Option<String>>(None);
@@ -99,8 +99,7 @@
 //! The following is a simple example of using a mandatory parameter:
 //! ```no_run
 //! use rclrs::*;
-//! use rclrs::vendor::example_interfaces;
-//!
+//! # use crate::rclrs::vendor::example_interfaces;
 //! use std::sync::Arc;
 //!
 //! let mut executor = Context::default_from_env()?.create_basic_executor();
@@ -130,7 +129,7 @@
 //!
 //! ```no_run
 //! use rclrs::*;
-//! use rclrs::vendor::example_interfaces;
+//! # use crate::rclrs::vendor::example_interfaces;
 //! use std::time::Duration;
 //!
 //! let mut executor = Context::default_from_env()?.create_basic_executor();

--- a/rclrs/src/lib.rs
+++ b/rclrs/src/lib.rs
@@ -32,13 +32,11 @@
 //!
 //! ```no_run
 //! use rclrs::*;
+//! use crate::rclrs::vendor::example_interfaces;
 //!
 //! let context = Context::default_from_env()?;
 //! let mut executor = context.create_basic_executor();
 //! let node = executor.create_node("example_node")?;
-//! # The following line of code is only needed for rclrs internal purposes,
-//! # please use the example_interfaces crate instead.
-//! use vendor::example_interfaces;
 //!
 //! let subscription = node.create_subscription(
 //!     "topic_name",
@@ -61,7 +59,8 @@
 //! # let context = Context::default_from_env()?;
 //! # let mut executor = context.create_basic_executor();
 //! # let node = executor.create_node("example_node")?;
-//! #
+//! # use rclrs::vendor::example_interfaces;
+//!
 //! // This worker will manage the data for us.
 //! // The worker's data is called its payload.
 //! let worker = node.create_worker::<Option<String>>(None);
@@ -100,6 +99,8 @@
 //! The following is a simple example of using a mandatory parameter:
 //! ```no_run
 //! use rclrs::*;
+//! use rclrs::vendor::example_interfaces;
+//!
 //! use std::sync::Arc;
 //!
 //! let mut executor = Context::default_from_env()?.create_basic_executor();
@@ -129,6 +130,7 @@
 //!
 //! ```no_run
 //! use rclrs::*;
+//! use rclrs::vendor::example_interfaces;
 //! use std::time::Duration;
 //!
 //! let mut executor = Context::default_from_env()?.create_basic_executor();
@@ -192,7 +194,7 @@ mod service;
 mod subscription;
 mod time;
 mod time_source;
-mod vendor;
+pub mod vendor;
 mod wait_set;
 mod worker;
 

--- a/rclrs/src/lib.rs
+++ b/rclrs/src/lib.rs
@@ -36,6 +36,9 @@
 //! let context = Context::default_from_env()?;
 //! let mut executor = context.create_basic_executor();
 //! let node = executor.create_node("example_node")?;
+//! # The following line of code is only needed for rclrs internal purposes,
+//! # please use the example_interfaces crate instead.
+//! use vendor::example_interfaces;
 //!
 //! let subscription = node.create_subscription(
 //!     "topic_name",

--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -244,6 +244,7 @@ impl NodeState {
     /// In some cases the payload type can be inferred by Rust:
     /// ```
     /// # use rclrs::*;
+    /// # use rclrs::vendor::example_interfaces;
     /// let executor = Context::default().create_basic_executor();
     /// let node = executor.create_node("my_node").unwrap();
     ///
@@ -269,6 +270,7 @@ impl NodeState {
     ///
     /// ```
     /// # use rclrs::*;
+    /// # use rclrs::vendor::example_interfaces;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
     /// let worker = node.create_worker::<String>(String::new());
@@ -277,6 +279,7 @@ impl NodeState {
     /// The data given to the worker can be any custom data type:
     /// ```
     /// # use rclrs::*;
+    /// # use rclrs::vendor::example_interfaces;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
     ///
@@ -312,6 +315,7 @@ impl NodeState {
     /// # use rclrs::*;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
+    /// # use rclrs::vendor::test_msgs;
     /// let client = node.create_client::<test_msgs::srv::Empty>(
     ///     "my_service"
     /// )
@@ -325,6 +329,7 @@ impl NodeState {
     /// # use rclrs::*;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
+    /// # use rclrs::vendor::test_msgs;
     /// let client = node.create_client::<test_msgs::srv::Empty>(
     ///     "my_service"
     ///     .keep_all()
@@ -357,6 +362,7 @@ impl NodeState {
     /// # use rclrs::*;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
+    /// # use rclrs::vendor::test_msgs;
     /// let publisher = node.create_publisher::<test_msgs::msg::Empty>(
     ///     "my_topic"
     /// )
@@ -368,6 +374,7 @@ impl NodeState {
     ///
     /// ```
     /// # use rclrs::*;
+    /// # use rclrs::vendor::test_msgs;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
     /// let publisher = node.create_publisher::<test_msgs::msg::Empty>(
@@ -414,8 +421,10 @@ impl NodeState {
     /// Pass in only the service name for the `options` argument to use all default service options:
     /// ```
     /// # use rclrs::*;
+    /// # use rclrs::vendor::test_msgs;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
+    ///
     /// let service = node.create_service::<test_msgs::srv::Empty, _>(
     ///     "my_service",
     ///     |_request: test_msgs::srv::Empty_Request| {
@@ -430,8 +439,10 @@ impl NodeState {
     ///
     /// ```
     /// # use rclrs::*;
+    /// # use rclrs::vendor::test_msgs;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
+    ///
     /// let service = node.create_service::<test_msgs::srv::Empty, _>(
     ///     "my_service"
     ///     .keep_all()
@@ -468,10 +479,10 @@ impl NodeState {
     ///
     /// ```
     /// # use rclrs::*;
+    /// # use rclrs::vendor::example_interfaces::srv::*;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
     /// use std::sync::Mutex;
-    /// use example_interfaces::srv::*;
     ///
     /// let counter = Mutex::new(0usize);
     /// let service = node.create_service::<Trigger, _>(
@@ -494,10 +505,10 @@ impl NodeState {
     ///
     /// ```
     /// # use rclrs::*;
+    /// # use rclrs::vendor::example_interfaces::srv::*;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
     /// use std::sync::{Arc, Mutex};
-    /// use example_interfaces::srv::*;
     ///
     /// let counter = Arc::new(Mutex::new(0usize));
     ///
@@ -588,10 +599,10 @@ impl NodeState {
     ///
     /// ```
     /// # use rclrs::*;
+    /// # use rclrs::vendor::example_interfaces::srv::*;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node")?;
     /// use std::sync::Arc;
-    /// use example_interfaces::srv::*;
     ///
     /// let worker_a = node.create_worker(0_i64);
     /// let worker_b = node.create_worker(0_i64);
@@ -660,11 +671,9 @@ impl NodeState {
     /// Pass in only the topic name for the `options` argument to use all default subscription options:
     /// ```
     /// # use rclrs::*;
+    /// # use rclrs::vendor::test_msgs;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
-    /// # The following line of code is only needed for rclrs internal purposes,
-    /// # please use the test_msgs crate instead.
-    /// use vendor::test_msgs;
     /// let subscription = node.create_subscription(
     ///     "my_topic",
     ///     |_msg: test_msgs::msg::Empty| {
@@ -678,11 +687,10 @@ impl NodeState {
     ///
     /// ```
     /// # use rclrs::*;
+    /// # use rclrs::vendor::test_msgs;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
     /// # The following line of code is only needed for rclrs internal purposes,
-    /// # please use the test_msgs crate instead.
-    /// use vendor::test_msgs;
     /// let subscription = node.create_subscription(
     ///     "my_topic"
     ///     .keep_last(100)
@@ -723,6 +731,7 @@ impl NodeState {
     ///
     /// ```
     /// # use rclrs::*;
+    /// # use rclrs::vendor::example_interfaces;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
     /// use std::sync::Mutex;
@@ -745,6 +754,7 @@ impl NodeState {
     ///
     /// ```
     /// # use rclrs::*;
+    /// # use rclrs::vendor::example_interfaces;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
     /// use std::sync::{Arc, Mutex};
@@ -845,8 +855,10 @@ impl NodeState {
     ///
     /// ```
     /// # use rclrs::*;
+    /// # use rclrs::vendor::example_interfaces;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
+    ///
     /// use std::sync::Arc;
     ///
     /// let count_worker = node.create_worker(0_usize);

--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -662,6 +662,9 @@ impl NodeState {
     /// # use rclrs::*;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
+    /// # The following line of code is only needed for rclrs internal purposes,
+    /// # please use the test_msgs crate instead.
+    /// use vendor::test_msgs;
     /// let subscription = node.create_subscription(
     ///     "my_topic",
     ///     |_msg: test_msgs::msg::Empty| {
@@ -677,6 +680,9 @@ impl NodeState {
     /// # use rclrs::*;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
+    /// # The following line of code is only needed for rclrs internal purposes,
+    /// # please use the test_msgs crate instead.
+    /// use vendor::test_msgs;
     /// let subscription = node.create_subscription(
     ///     "my_topic"
     ///     .keep_last(100)
@@ -1094,7 +1100,7 @@ mod tests {
 
     #[test]
     fn test_topic_names_and_types() -> Result<(), RclrsError> {
-        use test_msgs::msg;
+        use crate::vendor::test_msgs::msg;
 
         let graph = construct_test_graph("test_topics_graph")?;
 

--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -244,7 +244,7 @@ impl NodeState {
     /// In some cases the payload type can be inferred by Rust:
     /// ```
     /// # use rclrs::*;
-    /// # use rclrs::vendor::example_interfaces;
+    /// # use crate::rclrs::vendor::example_interfaces;
     /// let executor = Context::default().create_basic_executor();
     /// let node = executor.create_node("my_node").unwrap();
     ///
@@ -270,7 +270,7 @@ impl NodeState {
     ///
     /// ```
     /// # use rclrs::*;
-    /// # use rclrs::vendor::example_interfaces;
+    /// # use crate::rclrs::vendor::example_interfaces;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
     /// let worker = node.create_worker::<String>(String::new());
@@ -279,7 +279,7 @@ impl NodeState {
     /// The data given to the worker can be any custom data type:
     /// ```
     /// # use rclrs::*;
-    /// # use rclrs::vendor::example_interfaces;
+    /// # use crate::rclrs::vendor::example_interfaces;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
     ///
@@ -315,7 +315,7 @@ impl NodeState {
     /// # use rclrs::*;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
-    /// # use rclrs::vendor::test_msgs;
+    /// # use crate::rclrs::vendor::test_msgs;
     /// let client = node.create_client::<test_msgs::srv::Empty>(
     ///     "my_service"
     /// )
@@ -329,7 +329,7 @@ impl NodeState {
     /// # use rclrs::*;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
-    /// # use rclrs::vendor::test_msgs;
+    /// # use crate::rclrs::vendor::test_msgs;
     /// let client = node.create_client::<test_msgs::srv::Empty>(
     ///     "my_service"
     ///     .keep_all()
@@ -362,7 +362,7 @@ impl NodeState {
     /// # use rclrs::*;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
-    /// # use rclrs::vendor::test_msgs;
+    /// # use crate::rclrs::vendor::test_msgs;
     /// let publisher = node.create_publisher::<test_msgs::msg::Empty>(
     ///     "my_topic"
     /// )
@@ -374,7 +374,7 @@ impl NodeState {
     ///
     /// ```
     /// # use rclrs::*;
-    /// # use rclrs::vendor::test_msgs;
+    /// # use crate::rclrs::vendor::test_msgs;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
     /// let publisher = node.create_publisher::<test_msgs::msg::Empty>(
@@ -421,10 +421,9 @@ impl NodeState {
     /// Pass in only the service name for the `options` argument to use all default service options:
     /// ```
     /// # use rclrs::*;
-    /// # use rclrs::vendor::test_msgs;
+    /// # use crate::rclrs::vendor::test_msgs;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
-    ///
     /// let service = node.create_service::<test_msgs::srv::Empty, _>(
     ///     "my_service",
     ///     |_request: test_msgs::srv::Empty_Request| {
@@ -439,10 +438,9 @@ impl NodeState {
     ///
     /// ```
     /// # use rclrs::*;
-    /// # use rclrs::vendor::test_msgs;
+    /// # use crate::rclrs::vendor::test_msgs;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
-    ///
     /// let service = node.create_service::<test_msgs::srv::Empty, _>(
     ///     "my_service"
     ///     .keep_all()
@@ -479,19 +477,19 @@ impl NodeState {
     ///
     /// ```
     /// # use rclrs::*;
-    /// # use rclrs::vendor::example_interfaces::srv::*;
+    /// # use crate::rclrs::vendor::example_interfaces;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
     /// use std::sync::Mutex;
     ///
     /// let counter = Mutex::new(0usize);
-    /// let service = node.create_service::<Trigger, _>(
+    /// let service = node.create_service::<example_interfaces::srv::Trigger, _>(
     ///     "trigger_counter",
-    ///     move |_request: Trigger_Request| {
+    ///     move |_request: example_interfaces::srv::Trigger_Request| {
     ///         let mut counter = counter.lock().unwrap();
     ///         *counter += 1;
     ///         println!("Triggered {} times", *counter);
-    ///         Trigger_Response {
+    ///         example_interfaces::srv::Trigger_Response {
     ///             success: true,
     ///             message: "no problems here".to_string(),
     ///         }
@@ -505,7 +503,7 @@ impl NodeState {
     ///
     /// ```
     /// # use rclrs::*;
-    /// # use rclrs::vendor::example_interfaces::srv::*;
+    /// # use crate::rclrs::vendor::example_interfaces;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
     /// use std::sync::{Arc, Mutex};
@@ -513,13 +511,13 @@ impl NodeState {
     /// let counter = Arc::new(Mutex::new(0usize));
     ///
     /// let counter_in_service = Arc::clone(&counter);
-    /// let service = node.create_service::<Trigger, _>(
+    /// let service = node.create_service::<example_interfaces::srv::Trigger, _>(
     ///     "trigger_counter",
-    ///     move |_request: Trigger_Request| {
+    ///     move |_request: example_interfaces::srv::Trigger_Request| {
     ///         let mut counter = counter_in_service.lock().unwrap();
     ///         *counter += 1;
     ///         println!("Triggered {} times", *counter);
-    ///         Trigger_Response {
+    ///         example_interfaces::srv::Trigger_Response {
     ///             success: true,
     ///             message: "no problems here".to_string(),
     ///         }
@@ -599,7 +597,7 @@ impl NodeState {
     ///
     /// ```
     /// # use rclrs::*;
-    /// # use rclrs::vendor::example_interfaces::srv::*;
+    /// # use crate::rclrs::vendor::example_interfaces;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node")?;
     /// use std::sync::Arc;
@@ -607,9 +605,9 @@ impl NodeState {
     /// let worker_a = node.create_worker(0_i64);
     /// let worker_b = node.create_worker(0_i64);
     ///
-    /// let service = node.create_async_service::<AddTwoInts, _>(
+    /// let service = node.create_async_service::<example_interfaces::srv::AddTwoInts, _>(
     ///     "add",
-    ///     move |request: AddTwoInts_Request| {
+    ///     move |request: example_interfaces::srv::AddTwoInts_Request| {
     ///         // Clone the workers so they can be captured into the async block
     ///         let worker_a = Arc::clone(&worker_a);
     ///         let worker_b = Arc::clone(&worker_b);
@@ -628,7 +626,7 @@ impl NodeState {
     ///             // Awaiting above ensures that each number from the
     ///             // request is saved in its respective worker before
     ///             // we give back a response.
-    ///             AddTwoInts_Response { sum: a + b }
+    ///             example_interfaces::srv::AddTwoInts_Response { sum: a + b }
     ///        }
     ///     }
     /// )?;
@@ -671,7 +669,7 @@ impl NodeState {
     /// Pass in only the topic name for the `options` argument to use all default subscription options:
     /// ```
     /// # use rclrs::*;
-    /// # use rclrs::vendor::test_msgs;
+    /// # use crate::rclrs::vendor::test_msgs;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
     /// let subscription = node.create_subscription(
@@ -687,7 +685,7 @@ impl NodeState {
     ///
     /// ```
     /// # use rclrs::*;
-    /// # use rclrs::vendor::test_msgs;
+    /// # use crate::rclrs::vendor::test_msgs;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
     /// let subscription = node.create_subscription(
@@ -730,7 +728,7 @@ impl NodeState {
     ///
     /// ```
     /// # use rclrs::*;
-    /// # use rclrs::vendor::example_interfaces;
+    /// # use crate::rclrs::vendor::example_interfaces;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
     /// use std::sync::Mutex;
@@ -753,7 +751,7 @@ impl NodeState {
     ///
     /// ```
     /// # use rclrs::*;
-    /// # use rclrs::vendor::example_interfaces;
+    /// # use crate::rclrs::vendor::example_interfaces;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
     /// use std::sync::{Arc, Mutex};
@@ -854,7 +852,7 @@ impl NodeState {
     ///
     /// ```
     /// # use rclrs::*;
-    /// # use rclrs::vendor::example_interfaces;
+    /// # use crate::rclrs::vendor::example_interfaces;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
     ///

--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -690,7 +690,6 @@ impl NodeState {
     /// # use rclrs::vendor::test_msgs;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
-    /// # The following line of code is only needed for rclrs internal purposes,
     /// let subscription = node.create_subscription(
     ///     "my_topic"
     ///     .keep_last(100)

--- a/rclrs/src/publisher.rs
+++ b/rclrs/src/publisher.rs
@@ -337,6 +337,7 @@ mod tests {
 
     #[test]
     fn traits() {
+        use crate::vendor::test_msgs;
         assert_send::<Publisher<test_msgs::msg::BoundedSequences>>();
         assert_sync::<Publisher<test_msgs::msg::BoundedSequences>>();
     }
@@ -344,7 +345,7 @@ mod tests {
     #[test]
     fn test_publishers() -> Result<(), RclrsError> {
         use crate::TopicEndpointInfo;
-        use test_msgs::msg;
+        use crate::vendor::test_msgs::msg;
 
         let namespace = "/test_publishers_graph";
         let graph = construct_test_graph(namespace)?;

--- a/rclrs/src/publisher.rs
+++ b/rclrs/src/publisher.rs
@@ -344,8 +344,8 @@ mod tests {
 
     #[test]
     fn test_publishers() -> Result<(), RclrsError> {
-        use crate::TopicEndpointInfo;
         use crate::vendor::test_msgs::msg;
+        use crate::TopicEndpointInfo;
 
         let namespace = "/test_publishers_graph";
         let graph = construct_test_graph(namespace)?;

--- a/rclrs/src/publisher/loaned_message.rs
+++ b/rclrs/src/publisher/loaned_message.rs
@@ -99,6 +99,7 @@ mod tests {
     #[test]
     fn traits() {
         use crate::test_helpers::*;
+        use crate::vendor::test_msgs;
 
         assert_send::<LoanedMessage<test_msgs::msg::rmw::BoundedSequences>>();
         assert_sync::<LoanedMessage<test_msgs::msg::rmw::BoundedSequences>>();

--- a/rclrs/src/service.rs
+++ b/rclrs/src/service.rs
@@ -393,6 +393,7 @@ mod tests {
 
     #[test]
     fn traits() {
+        use crate::vendor::test_msgs;
         assert_send::<Service<test_msgs::srv::Arrays>>();
         assert_sync::<Service<test_msgs::srv::Arrays>>();
     }
@@ -400,7 +401,7 @@ mod tests {
     #[test]
     fn test_services() -> Result<(), RclrsError> {
         use crate::TopicNamesAndTypes;
-        use test_msgs::srv;
+        use crate::vendor::test_msgs::srv;
 
         let namespace = "/test_services_graph";
         let graph = construct_test_graph(namespace)?;

--- a/rclrs/src/service.rs
+++ b/rclrs/src/service.rs
@@ -400,8 +400,8 @@ mod tests {
 
     #[test]
     fn test_services() -> Result<(), RclrsError> {
-        use crate::TopicNamesAndTypes;
         use crate::vendor::test_msgs::srv;
+        use crate::TopicNamesAndTypes;
 
         let namespace = "/test_services_graph";
         let graph = construct_test_graph(namespace)?;

--- a/rclrs/src/subscription.rs
+++ b/rclrs/src/subscription.rs
@@ -412,7 +412,7 @@ impl Drop for SubscriptionHandle {
 mod tests {
     use super::*;
     use crate::test_helpers::*;
-    use test_msgs::msg;
+    use crate::vendor::test_msgs::msg;
 
     #[test]
     fn traits() {
@@ -524,7 +524,7 @@ mod tests {
     #[test]
     fn test_delayed_subscription() {
         use crate::*;
-        use example_interfaces::msg::Empty;
+        use crate::vendor::example_interfaces::msg::Empty;
         use futures::{
             channel::{mpsc, oneshot},
             StreamExt,

--- a/rclrs/src/subscription.rs
+++ b/rclrs/src/subscription.rs
@@ -523,8 +523,8 @@ mod tests {
 
     #[test]
     fn test_delayed_subscription() {
-        use crate::*;
         use crate::vendor::example_interfaces::msg::Empty;
+        use crate::*;
         use futures::{
             channel::{mpsc, oneshot},
             StreamExt,

--- a/rclrs/src/subscription/into_async_subscription_callback.rs
+++ b/rclrs/src/subscription/into_async_subscription_callback.rs
@@ -103,7 +103,7 @@ where
 mod tests {
     use super::*;
 
-    type TestMessage = test_msgs::msg::BoundedSequences;
+    type TestMessage = crate::vendor::test_msgs::msg::BoundedSequences;
 
     #[test]
     fn callback_conversion() {

--- a/rclrs/src/subscription/into_node_subscription_callback.rs
+++ b/rclrs/src/subscription/into_node_subscription_callback.rs
@@ -131,7 +131,7 @@ where
 mod tests {
     use super::*;
 
-    type TestMessage = test_msgs::msg::BoundedSequences;
+    type TestMessage = crate::vendor::test_msgs::msg::BoundedSequences;
 
     #[test]
     fn callback_conversion() {

--- a/rclrs/src/subscription/readonly_loaned_message.rs
+++ b/rclrs/src/subscription/readonly_loaned_message.rs
@@ -61,6 +61,7 @@ mod tests {
     #[test]
     fn traits() {
         use crate::test_helpers::*;
+        use crate::vendor::test_msgs;
 
         assert_send::<ReadOnlyLoanedMessage<test_msgs::msg::rmw::BoundedSequences>>();
         assert_sync::<ReadOnlyLoanedMessage<test_msgs::msg::rmw::BoundedSequences>>();

--- a/rclrs/src/vendor/example_interfaces/action.rs
+++ b/rclrs/src/vendor/example_interfaces/action.rs
@@ -1,0 +1,1376 @@
+pub mod rmw {
+    #[cfg(feature = "serde")]
+    use serde::{Deserialize, Serialize};
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__action__Fibonacci_Goal(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__action__Fibonacci_Goal__init(msg: *mut Fibonacci_Goal) -> bool;
+        fn example_interfaces__action__Fibonacci_Goal__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_Goal>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__action__Fibonacci_Goal__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_Goal>,
+        );
+        fn example_interfaces__action__Fibonacci_Goal__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Fibonacci_Goal>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_Goal>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__action__Fibonacci_Goal
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Fibonacci_Goal {
+        pub order: i32,
+    }
+
+    impl Default for Fibonacci_Goal {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__action__Fibonacci_Goal__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__action__Fibonacci_Goal__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Fibonacci_Goal {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__action__Fibonacci_Goal__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__action__Fibonacci_Goal__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__action__Fibonacci_Goal__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Fibonacci_Goal {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Fibonacci_Goal
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/action/Fibonacci_Goal";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__action__Fibonacci_Goal()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__action__Fibonacci_Result(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__action__Fibonacci_Result__init(msg: *mut Fibonacci_Result) -> bool;
+        fn example_interfaces__action__Fibonacci_Result__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_Result>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__action__Fibonacci_Result__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_Result>,
+        );
+        fn example_interfaces__action__Fibonacci_Result__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Fibonacci_Result>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_Result>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__action__Fibonacci_Result
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Fibonacci_Result {
+        pub sequence: rosidl_runtime_rs::Sequence<i32>,
+    }
+
+    impl Default for Fibonacci_Result {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__action__Fibonacci_Result__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__action__Fibonacci_Result__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Fibonacci_Result {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__action__Fibonacci_Result__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__action__Fibonacci_Result__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__action__Fibonacci_Result__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Fibonacci_Result {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Fibonacci_Result
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/action/Fibonacci_Result";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__action__Fibonacci_Result()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__action__Fibonacci_Feedback(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__action__Fibonacci_Feedback__init(
+            msg: *mut Fibonacci_Feedback,
+        ) -> bool;
+        fn example_interfaces__action__Fibonacci_Feedback__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_Feedback>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__action__Fibonacci_Feedback__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_Feedback>,
+        );
+        fn example_interfaces__action__Fibonacci_Feedback__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Fibonacci_Feedback>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_Feedback>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__action__Fibonacci_Feedback
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Fibonacci_Feedback {
+        pub sequence: rosidl_runtime_rs::Sequence<i32>,
+    }
+
+    impl Default for Fibonacci_Feedback {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__action__Fibonacci_Feedback__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__action__Fibonacci_Feedback__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Fibonacci_Feedback {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__action__Fibonacci_Feedback__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__action__Fibonacci_Feedback__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__action__Fibonacci_Feedback__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Fibonacci_Feedback {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Fibonacci_Feedback
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/action/Fibonacci_Feedback";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__action__Fibonacci_Feedback()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__action__Fibonacci_FeedbackMessage(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__action__Fibonacci_FeedbackMessage__init(
+            msg: *mut Fibonacci_FeedbackMessage,
+        ) -> bool;
+        fn example_interfaces__action__Fibonacci_FeedbackMessage__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_FeedbackMessage>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__action__Fibonacci_FeedbackMessage__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_FeedbackMessage>,
+        );
+        fn example_interfaces__action__Fibonacci_FeedbackMessage__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Fibonacci_FeedbackMessage>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_FeedbackMessage>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__action__Fibonacci_FeedbackMessage
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Fibonacci_FeedbackMessage {
+        pub goal_id: crate::vendor::unique_identifier_msgs::msg::rmw::UUID,
+        pub feedback: crate::vendor::example_interfaces::action::rmw::Fibonacci_Feedback,
+    }
+
+    impl Default for Fibonacci_FeedbackMessage {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__action__Fibonacci_FeedbackMessage__init(&mut msg as *mut _)
+                {
+                    panic!("Call to example_interfaces__action__Fibonacci_FeedbackMessage__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Fibonacci_FeedbackMessage {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__action__Fibonacci_FeedbackMessage__Sequence__init(
+                    seq as *mut _,
+                    size,
+                )
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__action__Fibonacci_FeedbackMessage__Sequence__fini(seq as *mut _)
+            }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__action__Fibonacci_FeedbackMessage__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Fibonacci_FeedbackMessage {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Fibonacci_FeedbackMessage
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/action/Fibonacci_FeedbackMessage";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__action__Fibonacci_FeedbackMessage()
+            }
+        }
+    }
+
+    #[cfg(feature = "serde")]
+    use serde::{Deserialize, Serialize};
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__action__Fibonacci_SendGoal_Request(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__action__Fibonacci_SendGoal_Request__init(
+            msg: *mut Fibonacci_SendGoal_Request,
+        ) -> bool;
+        fn example_interfaces__action__Fibonacci_SendGoal_Request__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_SendGoal_Request>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__action__Fibonacci_SendGoal_Request__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_SendGoal_Request>,
+        );
+        fn example_interfaces__action__Fibonacci_SendGoal_Request__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Fibonacci_SendGoal_Request>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_SendGoal_Request>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__action__Fibonacci_SendGoal_Request
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Fibonacci_SendGoal_Request {
+        pub goal_id: crate::vendor::unique_identifier_msgs::msg::rmw::UUID,
+        pub goal: crate::vendor::example_interfaces::action::rmw::Fibonacci_Goal,
+    }
+
+    impl Default for Fibonacci_SendGoal_Request {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__action__Fibonacci_SendGoal_Request__init(&mut msg as *mut _)
+                {
+                    panic!("Call to example_interfaces__action__Fibonacci_SendGoal_Request__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Fibonacci_SendGoal_Request {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__action__Fibonacci_SendGoal_Request__Sequence__init(
+                    seq as *mut _,
+                    size,
+                )
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__action__Fibonacci_SendGoal_Request__Sequence__fini(
+                    seq as *mut _,
+                )
+            }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__action__Fibonacci_SendGoal_Request__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Fibonacci_SendGoal_Request {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Fibonacci_SendGoal_Request
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/action/Fibonacci_SendGoal_Request";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__action__Fibonacci_SendGoal_Request()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__action__Fibonacci_SendGoal_Response(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__action__Fibonacci_SendGoal_Response__init(
+            msg: *mut Fibonacci_SendGoal_Response,
+        ) -> bool;
+        fn example_interfaces__action__Fibonacci_SendGoal_Response__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_SendGoal_Response>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__action__Fibonacci_SendGoal_Response__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_SendGoal_Response>,
+        );
+        fn example_interfaces__action__Fibonacci_SendGoal_Response__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Fibonacci_SendGoal_Response>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_SendGoal_Response>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__action__Fibonacci_SendGoal_Response
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Fibonacci_SendGoal_Response {
+        pub accepted: bool,
+        pub stamp: crate::vendor::builtin_interfaces::msg::rmw::Time,
+    }
+
+    impl Default for Fibonacci_SendGoal_Response {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__action__Fibonacci_SendGoal_Response__init(
+                    &mut msg as *mut _,
+                ) {
+                    panic!("Call to example_interfaces__action__Fibonacci_SendGoal_Response__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Fibonacci_SendGoal_Response {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__action__Fibonacci_SendGoal_Response__Sequence__init(
+                    seq as *mut _,
+                    size,
+                )
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__action__Fibonacci_SendGoal_Response__Sequence__fini(
+                    seq as *mut _,
+                )
+            }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__action__Fibonacci_SendGoal_Response__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Fibonacci_SendGoal_Response {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Fibonacci_SendGoal_Response
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/action/Fibonacci_SendGoal_Response";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__action__Fibonacci_SendGoal_Response()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__action__Fibonacci_GetResult_Request(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__action__Fibonacci_GetResult_Request__init(
+            msg: *mut Fibonacci_GetResult_Request,
+        ) -> bool;
+        fn example_interfaces__action__Fibonacci_GetResult_Request__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_GetResult_Request>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__action__Fibonacci_GetResult_Request__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_GetResult_Request>,
+        );
+        fn example_interfaces__action__Fibonacci_GetResult_Request__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Fibonacci_GetResult_Request>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_GetResult_Request>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__action__Fibonacci_GetResult_Request
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Fibonacci_GetResult_Request {
+        pub goal_id: crate::vendor::unique_identifier_msgs::msg::rmw::UUID,
+    }
+
+    impl Default for Fibonacci_GetResult_Request {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__action__Fibonacci_GetResult_Request__init(
+                    &mut msg as *mut _,
+                ) {
+                    panic!("Call to example_interfaces__action__Fibonacci_GetResult_Request__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Fibonacci_GetResult_Request {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__action__Fibonacci_GetResult_Request__Sequence__init(
+                    seq as *mut _,
+                    size,
+                )
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__action__Fibonacci_GetResult_Request__Sequence__fini(
+                    seq as *mut _,
+                )
+            }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__action__Fibonacci_GetResult_Request__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Fibonacci_GetResult_Request {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Fibonacci_GetResult_Request
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/action/Fibonacci_GetResult_Request";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__action__Fibonacci_GetResult_Request()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__action__Fibonacci_GetResult_Response(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__action__Fibonacci_GetResult_Response__init(
+            msg: *mut Fibonacci_GetResult_Response,
+        ) -> bool;
+        fn example_interfaces__action__Fibonacci_GetResult_Response__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_GetResult_Response>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__action__Fibonacci_GetResult_Response__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_GetResult_Response>,
+        );
+        fn example_interfaces__action__Fibonacci_GetResult_Response__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Fibonacci_GetResult_Response>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_GetResult_Response>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__action__Fibonacci_GetResult_Response
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Fibonacci_GetResult_Response {
+        pub status: i8,
+        pub result: crate::vendor::example_interfaces::action::rmw::Fibonacci_Result,
+    }
+
+    impl Default for Fibonacci_GetResult_Response {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__action__Fibonacci_GetResult_Response__init(
+                    &mut msg as *mut _,
+                ) {
+                    panic!("Call to example_interfaces__action__Fibonacci_GetResult_Response__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Fibonacci_GetResult_Response {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__action__Fibonacci_GetResult_Response__Sequence__init(
+                    seq as *mut _,
+                    size,
+                )
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__action__Fibonacci_GetResult_Response__Sequence__fini(
+                    seq as *mut _,
+                )
+            }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__action__Fibonacci_GetResult_Response__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Fibonacci_GetResult_Response {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Fibonacci_GetResult_Response
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/action/Fibonacci_GetResult_Response";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__action__Fibonacci_GetResult_Response()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_service_type_support_handle__example_interfaces__action__Fibonacci_SendGoal(
+        ) -> *const std::ffi::c_void;
+    }
+
+    // Corresponds to example_interfaces__action__Fibonacci_SendGoal
+    pub struct Fibonacci_SendGoal;
+
+    impl rosidl_runtime_rs::Service for Fibonacci_SendGoal {
+        type Request = crate::vendor::example_interfaces::action::rmw::Fibonacci_SendGoal_Request;
+        type Response = crate::vendor::example_interfaces::action::rmw::Fibonacci_SendGoal_Response;
+
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_service_type_support_handle__example_interfaces__action__Fibonacci_SendGoal()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_service_type_support_handle__example_interfaces__action__Fibonacci_GetResult(
+        ) -> *const std::ffi::c_void;
+    }
+
+    // Corresponds to example_interfaces__action__Fibonacci_GetResult
+    pub struct Fibonacci_GetResult;
+
+    impl rosidl_runtime_rs::Service for Fibonacci_GetResult {
+        type Request = crate::vendor::example_interfaces::action::rmw::Fibonacci_GetResult_Request;
+        type Response =
+            crate::vendor::example_interfaces::action::rmw::Fibonacci_GetResult_Response;
+
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_service_type_support_handle__example_interfaces__action__Fibonacci_GetResult()
+            }
+        }
+    }
+} // mod rmw
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Fibonacci_Goal {
+    pub order: i32,
+}
+
+impl Default for Fibonacci_Goal {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::action::rmw::Fibonacci_Goal::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Fibonacci_Goal {
+    type RmwMsg = crate::vendor::example_interfaces::action::rmw::Fibonacci_Goal;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { order: msg.order })
+            }
+            std::borrow::Cow::Borrowed(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { order: msg.order })
+            }
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self { order: msg.order }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Fibonacci_Result {
+    pub sequence: Vec<i32>,
+}
+
+impl Default for Fibonacci_Result {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::action::rmw::Fibonacci_Result::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Fibonacci_Result {
+    type RmwMsg = crate::vendor::example_interfaces::action::rmw::Fibonacci_Result;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                sequence: msg.sequence.into(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                sequence: msg.sequence.as_slice().into(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            sequence: msg.sequence.into_iter().collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Fibonacci_Feedback {
+    pub sequence: Vec<i32>,
+}
+
+impl Default for Fibonacci_Feedback {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::action::rmw::Fibonacci_Feedback::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Fibonacci_Feedback {
+    type RmwMsg = crate::vendor::example_interfaces::action::rmw::Fibonacci_Feedback;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                sequence: msg.sequence.into(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                sequence: msg.sequence.as_slice().into(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            sequence: msg.sequence.into_iter().collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Fibonacci_FeedbackMessage {
+    pub goal_id: crate::vendor::unique_identifier_msgs::msg::UUID,
+    pub feedback: crate::vendor::example_interfaces::action::Fibonacci_Feedback,
+}
+
+impl Default for Fibonacci_FeedbackMessage {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::action::rmw::Fibonacci_FeedbackMessage::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Fibonacci_FeedbackMessage {
+    type RmwMsg = crate::vendor::example_interfaces::action::rmw::Fibonacci_FeedbackMessage;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                goal_id: crate::vendor::unique_identifier_msgs::msg::UUID::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.goal_id),
+                )
+                .into_owned(),
+                feedback:
+                    crate::vendor::example_interfaces::action::Fibonacci_Feedback::into_rmw_message(
+                        std::borrow::Cow::Owned(msg.feedback),
+                    )
+                    .into_owned(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                goal_id: crate::vendor::unique_identifier_msgs::msg::UUID::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.goal_id),
+                )
+                .into_owned(),
+                feedback:
+                    crate::vendor::example_interfaces::action::Fibonacci_Feedback::into_rmw_message(
+                        std::borrow::Cow::Borrowed(&msg.feedback),
+                    )
+                    .into_owned(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            goal_id: crate::vendor::unique_identifier_msgs::msg::UUID::from_rmw_message(
+                msg.goal_id,
+            ),
+            feedback:
+                crate::vendor::example_interfaces::action::Fibonacci_Feedback::from_rmw_message(
+                    msg.feedback,
+                ),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Fibonacci_SendGoal_Request {
+    pub goal_id: crate::vendor::unique_identifier_msgs::msg::UUID,
+    pub goal: crate::vendor::example_interfaces::action::Fibonacci_Goal,
+}
+
+impl Default for Fibonacci_SendGoal_Request {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::action::rmw::Fibonacci_SendGoal_Request::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Fibonacci_SendGoal_Request {
+    type RmwMsg = crate::vendor::example_interfaces::action::rmw::Fibonacci_SendGoal_Request;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                goal_id: crate::vendor::unique_identifier_msgs::msg::UUID::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.goal_id),
+                )
+                .into_owned(),
+                goal: crate::vendor::example_interfaces::action::Fibonacci_Goal::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.goal),
+                )
+                .into_owned(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                goal_id: crate::vendor::unique_identifier_msgs::msg::UUID::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.goal_id),
+                )
+                .into_owned(),
+                goal: crate::vendor::example_interfaces::action::Fibonacci_Goal::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.goal),
+                )
+                .into_owned(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            goal_id: crate::vendor::unique_identifier_msgs::msg::UUID::from_rmw_message(
+                msg.goal_id,
+            ),
+            goal: crate::vendor::example_interfaces::action::Fibonacci_Goal::from_rmw_message(
+                msg.goal,
+            ),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Fibonacci_SendGoal_Response {
+    pub accepted: bool,
+    pub stamp: crate::vendor::builtin_interfaces::msg::Time,
+}
+
+impl Default for Fibonacci_SendGoal_Response {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::action::rmw::Fibonacci_SendGoal_Response::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Fibonacci_SendGoal_Response {
+    type RmwMsg = crate::vendor::example_interfaces::action::rmw::Fibonacci_SendGoal_Response;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                accepted: msg.accepted,
+                stamp: crate::vendor::builtin_interfaces::msg::Time::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.stamp),
+                )
+                .into_owned(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                accepted: msg.accepted,
+                stamp: crate::vendor::builtin_interfaces::msg::Time::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.stamp),
+                )
+                .into_owned(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            accepted: msg.accepted,
+            stamp: crate::vendor::builtin_interfaces::msg::Time::from_rmw_message(msg.stamp),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Fibonacci_GetResult_Request {
+    pub goal_id: crate::vendor::unique_identifier_msgs::msg::UUID,
+}
+
+impl Default for Fibonacci_GetResult_Request {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::action::rmw::Fibonacci_GetResult_Request::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Fibonacci_GetResult_Request {
+    type RmwMsg = crate::vendor::example_interfaces::action::rmw::Fibonacci_GetResult_Request;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                goal_id: crate::vendor::unique_identifier_msgs::msg::UUID::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.goal_id),
+                )
+                .into_owned(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                goal_id: crate::vendor::unique_identifier_msgs::msg::UUID::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.goal_id),
+                )
+                .into_owned(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            goal_id: crate::vendor::unique_identifier_msgs::msg::UUID::from_rmw_message(
+                msg.goal_id,
+            ),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Fibonacci_GetResult_Response {
+    pub status: i8,
+    pub result: crate::vendor::example_interfaces::action::Fibonacci_Result,
+}
+
+impl Default for Fibonacci_GetResult_Response {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::action::rmw::Fibonacci_GetResult_Response::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Fibonacci_GetResult_Response {
+    type RmwMsg = crate::vendor::example_interfaces::action::rmw::Fibonacci_GetResult_Response;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                status: msg.status,
+                result:
+                    crate::vendor::example_interfaces::action::Fibonacci_Result::into_rmw_message(
+                        std::borrow::Cow::Owned(msg.result),
+                    )
+                    .into_owned(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                status: msg.status,
+                result:
+                    crate::vendor::example_interfaces::action::Fibonacci_Result::into_rmw_message(
+                        std::borrow::Cow::Borrowed(&msg.result),
+                    )
+                    .into_owned(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            status: msg.status,
+            result: crate::vendor::example_interfaces::action::Fibonacci_Result::from_rmw_message(
+                msg.result,
+            ),
+        }
+    }
+}
+
+#[link(name = "example_interfaces__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_service_type_support_handle__example_interfaces__action__Fibonacci_SendGoal(
+    ) -> *const std::ffi::c_void;
+}
+
+// Corresponds to example_interfaces__action__Fibonacci_SendGoal
+pub struct Fibonacci_SendGoal;
+
+impl rosidl_runtime_rs::Service for Fibonacci_SendGoal {
+    type Request = crate::vendor::example_interfaces::action::Fibonacci_SendGoal_Request;
+    type Response = crate::vendor::example_interfaces::action::Fibonacci_SendGoal_Response;
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        // SAFETY: No preconditions for this function.
+        unsafe {
+            rosidl_typesupport_c__get_service_type_support_handle__example_interfaces__action__Fibonacci_SendGoal()
+        }
+    }
+}
+
+#[link(name = "example_interfaces__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_service_type_support_handle__example_interfaces__action__Fibonacci_GetResult(
+    ) -> *const std::ffi::c_void;
+}
+
+// Corresponds to example_interfaces__action__Fibonacci_GetResult
+pub struct Fibonacci_GetResult;
+
+impl rosidl_runtime_rs::Service for Fibonacci_GetResult {
+    type Request = crate::vendor::example_interfaces::action::Fibonacci_GetResult_Request;
+    type Response = crate::vendor::example_interfaces::action::Fibonacci_GetResult_Response;
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        // SAFETY: No preconditions for this function.
+        unsafe {
+            rosidl_typesupport_c__get_service_type_support_handle__example_interfaces__action__Fibonacci_GetResult()
+        }
+    }
+}
+
+#[link(name = "example_interfaces__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_action_type_support_handle__example_interfaces__action__Fibonacci(
+    ) -> *const std::ffi::c_void;
+}
+
+// Corresponds to example_interfaces__action__Fibonacci
+pub struct Fibonacci;
+
+impl rosidl_runtime_rs::Action for Fibonacci {
+    type Goal = crate::vendor::example_interfaces::action::Fibonacci_Goal;
+    type Result = crate::vendor::example_interfaces::action::Fibonacci_Result;
+    type Feedback = crate::vendor::example_interfaces::action::Fibonacci_Feedback;
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        // SAFETY: No preconditions for this function.
+        unsafe {
+            rosidl_typesupport_c__get_action_type_support_handle__example_interfaces__action__Fibonacci()
+        }
+    }
+}
+
+impl rosidl_runtime_rs::ActionImpl for Fibonacci {
+    type GoalStatusMessage = crate::vendor::action_msgs::msg::rmw::GoalStatusArray;
+    type FeedbackMessage =
+        crate::vendor::example_interfaces::action::rmw::Fibonacci_FeedbackMessage;
+
+    type SendGoalService = crate::vendor::example_interfaces::action::rmw::Fibonacci_SendGoal;
+    type CancelGoalService = crate::vendor::action_msgs::srv::rmw::CancelGoal;
+    type GetResultService = crate::vendor::example_interfaces::action::rmw::Fibonacci_GetResult;
+
+    fn create_goal_request(
+        goal_id: &[u8; 16],
+        goal: crate::vendor::example_interfaces::action::rmw::Fibonacci_Goal,
+    ) -> crate::vendor::example_interfaces::action::rmw::Fibonacci_SendGoal_Request {
+        crate::vendor::example_interfaces::action::rmw::Fibonacci_SendGoal_Request {
+            goal_id: crate::vendor::unique_identifier_msgs::msg::rmw::UUID { uuid: *goal_id },
+            goal,
+        }
+    }
+
+    fn get_goal_request_uuid(
+        request: &crate::vendor::example_interfaces::action::rmw::Fibonacci_SendGoal_Request,
+    ) -> &[u8; 16] {
+        &request.goal_id.uuid
+    }
+
+    fn create_goal_response(
+        accepted: bool,
+        stamp: (i32, u32),
+    ) -> crate::vendor::example_interfaces::action::rmw::Fibonacci_SendGoal_Response {
+        crate::vendor::example_interfaces::action::rmw::Fibonacci_SendGoal_Response {
+            accepted,
+            stamp: crate::vendor::builtin_interfaces::msg::rmw::Time {
+                sec: stamp.0,
+                nanosec: stamp.1,
+            },
+        }
+    }
+
+    fn get_goal_response_accepted(
+        response: &crate::vendor::example_interfaces::action::rmw::Fibonacci_SendGoal_Response,
+    ) -> bool {
+        response.accepted
+    }
+
+    fn get_goal_response_stamp(
+        response: &crate::vendor::example_interfaces::action::rmw::Fibonacci_SendGoal_Response,
+    ) -> (i32, u32) {
+        (response.stamp.sec, response.stamp.nanosec)
+    }
+
+    fn create_feedback_message(
+        goal_id: &[u8; 16],
+        feedback: crate::vendor::example_interfaces::action::rmw::Fibonacci_Feedback,
+    ) -> crate::vendor::example_interfaces::action::rmw::Fibonacci_FeedbackMessage {
+        let mut message =
+            crate::vendor::example_interfaces::action::rmw::Fibonacci_FeedbackMessage::default();
+        message.goal_id.uuid = *goal_id;
+        message.feedback = feedback;
+        message
+    }
+
+    fn get_feedback_message_uuid(
+        feedback: &crate::vendor::example_interfaces::action::rmw::Fibonacci_FeedbackMessage,
+    ) -> &[u8; 16] {
+        &feedback.goal_id.uuid
+    }
+
+    fn get_feedback_message_feedback(
+        feedback: &crate::vendor::example_interfaces::action::rmw::Fibonacci_FeedbackMessage,
+    ) -> &crate::vendor::example_interfaces::action::rmw::Fibonacci_Feedback {
+        &feedback.feedback
+    }
+
+    fn create_result_request(
+        goal_id: &[u8; 16],
+    ) -> crate::vendor::example_interfaces::action::rmw::Fibonacci_GetResult_Request {
+        crate::vendor::example_interfaces::action::rmw::Fibonacci_GetResult_Request {
+            goal_id: crate::vendor::unique_identifier_msgs::msg::rmw::UUID { uuid: *goal_id },
+        }
+    }
+
+    fn get_result_request_uuid(
+        request: &crate::vendor::example_interfaces::action::rmw::Fibonacci_GetResult_Request,
+    ) -> &[u8; 16] {
+        &request.goal_id.uuid
+    }
+
+    fn create_result_response(
+        status: i8,
+        result: crate::vendor::example_interfaces::action::rmw::Fibonacci_Result,
+    ) -> crate::vendor::example_interfaces::action::rmw::Fibonacci_GetResult_Response {
+        crate::vendor::example_interfaces::action::rmw::Fibonacci_GetResult_Response {
+            status,
+            result,
+        }
+    }
+
+    fn get_result_response_result(
+        response: &crate::vendor::example_interfaces::action::rmw::Fibonacci_GetResult_Response,
+    ) -> &crate::vendor::example_interfaces::action::rmw::Fibonacci_Result {
+        &response.result
+    }
+
+    fn get_result_response_status(
+        response: &crate::vendor::example_interfaces::action::rmw::Fibonacci_GetResult_Response,
+    ) -> i8 {
+        response.status
+    }
+}

--- a/rclrs/src/vendor/example_interfaces/mod.rs
+++ b/rclrs/src/vendor/example_interfaces/mod.rs
@@ -1,0 +1,9 @@
+#![allow(non_camel_case_types)]
+#![allow(clippy::derive_partial_eq_without_eq)]
+#![allow(clippy::upper_case_acronyms)]
+
+pub mod msg;
+
+pub mod srv;
+
+pub mod action;

--- a/rclrs/src/vendor/example_interfaces/msg.rs
+++ b/rclrs/src/vendor/example_interfaces/msg.rs
@@ -1,0 +1,3686 @@
+pub mod rmw {
+    #[cfg(feature = "serde")]
+    use serde::{Deserialize, Serialize};
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Bool(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__msg__Bool__init(msg: *mut Bool) -> bool;
+        fn example_interfaces__msg__Bool__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Bool>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__msg__Bool__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Bool>,
+        );
+        fn example_interfaces__msg__Bool__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Bool>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Bool>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__msg__Bool
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Bool {
+        pub data: bool,
+    }
+
+    impl Default for Bool {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__msg__Bool__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__msg__Bool__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Bool {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Bool__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Bool__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Bool__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Bool {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Bool
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/msg/Bool";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Bool(
+                )
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Byte(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__msg__Byte__init(msg: *mut Byte) -> bool;
+        fn example_interfaces__msg__Byte__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Byte>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__msg__Byte__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Byte>,
+        );
+        fn example_interfaces__msg__Byte__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Byte>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Byte>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__msg__Byte
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Byte {
+        pub data: u8,
+    }
+
+    impl Default for Byte {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__msg__Byte__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__msg__Byte__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Byte {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Byte__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Byte__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Byte__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Byte {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Byte
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/msg/Byte";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Byte(
+                )
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__ByteMultiArray(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__msg__ByteMultiArray__init(msg: *mut ByteMultiArray) -> bool;
+        fn example_interfaces__msg__ByteMultiArray__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<ByteMultiArray>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__msg__ByteMultiArray__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<ByteMultiArray>,
+        );
+        fn example_interfaces__msg__ByteMultiArray__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<ByteMultiArray>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<ByteMultiArray>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__msg__ByteMultiArray
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct ByteMultiArray {
+        pub layout: crate::vendor::example_interfaces::msg::rmw::MultiArrayLayout,
+        pub data: rosidl_runtime_rs::Sequence<u8>,
+    }
+
+    impl Default for ByteMultiArray {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__msg__ByteMultiArray__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__msg__ByteMultiArray__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for ByteMultiArray {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__ByteMultiArray__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__ByteMultiArray__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__msg__ByteMultiArray__Sequence__copy(in_seq, out_seq as *mut _)
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for ByteMultiArray {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for ByteMultiArray
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/msg/ByteMultiArray";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__ByteMultiArray()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Char(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__msg__Char__init(msg: *mut Char) -> bool;
+        fn example_interfaces__msg__Char__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Char>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__msg__Char__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Char>,
+        );
+        fn example_interfaces__msg__Char__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Char>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Char>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__msg__Char
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Char {
+        pub data: u8,
+    }
+
+    impl Default for Char {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__msg__Char__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__msg__Char__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Char {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Char__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Char__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Char__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Char {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Char
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/msg/Char";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Char(
+                )
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Empty(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__msg__Empty__init(msg: *mut Empty) -> bool;
+        fn example_interfaces__msg__Empty__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Empty>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__msg__Empty__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Empty>,
+        );
+        fn example_interfaces__msg__Empty__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Empty>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Empty>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__msg__Empty
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Empty {
+        pub structure_needs_at_least_one_member: u8,
+    }
+
+    impl Default for Empty {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__msg__Empty__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__msg__Empty__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Empty {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Empty__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Empty__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Empty__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Empty {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Empty
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/msg/Empty";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Empty()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Float32(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__msg__Float32__init(msg: *mut Float32) -> bool;
+        fn example_interfaces__msg__Float32__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Float32>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__msg__Float32__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Float32>,
+        );
+        fn example_interfaces__msg__Float32__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Float32>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Float32>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__msg__Float32
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Float32 {
+        pub data: f32,
+    }
+
+    impl Default for Float32 {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__msg__Float32__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__msg__Float32__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Float32 {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Float32__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Float32__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Float32__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Float32 {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Float32
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/msg/Float32";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Float32()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Float32MultiArray(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__msg__Float32MultiArray__init(msg: *mut Float32MultiArray) -> bool;
+        fn example_interfaces__msg__Float32MultiArray__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Float32MultiArray>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__msg__Float32MultiArray__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Float32MultiArray>,
+        );
+        fn example_interfaces__msg__Float32MultiArray__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Float32MultiArray>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Float32MultiArray>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__msg__Float32MultiArray
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Float32MultiArray {
+        pub layout: crate::vendor::example_interfaces::msg::rmw::MultiArrayLayout,
+        pub data: rosidl_runtime_rs::Sequence<f32>,
+    }
+
+    impl Default for Float32MultiArray {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__msg__Float32MultiArray__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__msg__Float32MultiArray__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Float32MultiArray {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__msg__Float32MultiArray__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Float32MultiArray__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__msg__Float32MultiArray__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Float32MultiArray {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Float32MultiArray
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/msg/Float32MultiArray";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Float32MultiArray()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Float64(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__msg__Float64__init(msg: *mut Float64) -> bool;
+        fn example_interfaces__msg__Float64__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Float64>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__msg__Float64__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Float64>,
+        );
+        fn example_interfaces__msg__Float64__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Float64>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Float64>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__msg__Float64
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Float64 {
+        pub data: f64,
+    }
+
+    impl Default for Float64 {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__msg__Float64__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__msg__Float64__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Float64 {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Float64__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Float64__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Float64__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Float64 {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Float64
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/msg/Float64";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Float64()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Float64MultiArray(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__msg__Float64MultiArray__init(msg: *mut Float64MultiArray) -> bool;
+        fn example_interfaces__msg__Float64MultiArray__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Float64MultiArray>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__msg__Float64MultiArray__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Float64MultiArray>,
+        );
+        fn example_interfaces__msg__Float64MultiArray__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Float64MultiArray>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Float64MultiArray>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__msg__Float64MultiArray
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Float64MultiArray {
+        pub layout: crate::vendor::example_interfaces::msg::rmw::MultiArrayLayout,
+        pub data: rosidl_runtime_rs::Sequence<f64>,
+    }
+
+    impl Default for Float64MultiArray {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__msg__Float64MultiArray__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__msg__Float64MultiArray__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Float64MultiArray {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__msg__Float64MultiArray__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Float64MultiArray__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__msg__Float64MultiArray__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Float64MultiArray {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Float64MultiArray
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/msg/Float64MultiArray";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Float64MultiArray()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Int16(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__msg__Int16__init(msg: *mut Int16) -> bool;
+        fn example_interfaces__msg__Int16__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Int16>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__msg__Int16__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Int16>,
+        );
+        fn example_interfaces__msg__Int16__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Int16>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Int16>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__msg__Int16
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Int16 {
+        pub data: i16,
+    }
+
+    impl Default for Int16 {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__msg__Int16__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__msg__Int16__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Int16 {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Int16__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Int16__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Int16__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Int16 {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Int16
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/msg/Int16";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Int16()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Int16MultiArray(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__msg__Int16MultiArray__init(msg: *mut Int16MultiArray) -> bool;
+        fn example_interfaces__msg__Int16MultiArray__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Int16MultiArray>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__msg__Int16MultiArray__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Int16MultiArray>,
+        );
+        fn example_interfaces__msg__Int16MultiArray__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Int16MultiArray>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Int16MultiArray>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__msg__Int16MultiArray
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Int16MultiArray {
+        pub layout: crate::vendor::example_interfaces::msg::rmw::MultiArrayLayout,
+        pub data: rosidl_runtime_rs::Sequence<i16>,
+    }
+
+    impl Default for Int16MultiArray {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__msg__Int16MultiArray__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__msg__Int16MultiArray__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Int16MultiArray {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Int16MultiArray__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Int16MultiArray__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__msg__Int16MultiArray__Sequence__copy(in_seq, out_seq as *mut _)
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Int16MultiArray {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Int16MultiArray
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/msg/Int16MultiArray";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Int16MultiArray()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Int32(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__msg__Int32__init(msg: *mut Int32) -> bool;
+        fn example_interfaces__msg__Int32__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Int32>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__msg__Int32__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Int32>,
+        );
+        fn example_interfaces__msg__Int32__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Int32>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Int32>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__msg__Int32
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Int32 {
+        pub data: i32,
+    }
+
+    impl Default for Int32 {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__msg__Int32__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__msg__Int32__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Int32 {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Int32__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Int32__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Int32__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Int32 {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Int32
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/msg/Int32";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Int32()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Int32MultiArray(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__msg__Int32MultiArray__init(msg: *mut Int32MultiArray) -> bool;
+        fn example_interfaces__msg__Int32MultiArray__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Int32MultiArray>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__msg__Int32MultiArray__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Int32MultiArray>,
+        );
+        fn example_interfaces__msg__Int32MultiArray__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Int32MultiArray>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Int32MultiArray>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__msg__Int32MultiArray
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Int32MultiArray {
+        pub layout: crate::vendor::example_interfaces::msg::rmw::MultiArrayLayout,
+        pub data: rosidl_runtime_rs::Sequence<i32>,
+    }
+
+    impl Default for Int32MultiArray {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__msg__Int32MultiArray__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__msg__Int32MultiArray__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Int32MultiArray {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Int32MultiArray__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Int32MultiArray__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__msg__Int32MultiArray__Sequence__copy(in_seq, out_seq as *mut _)
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Int32MultiArray {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Int32MultiArray
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/msg/Int32MultiArray";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Int32MultiArray()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Int64(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__msg__Int64__init(msg: *mut Int64) -> bool;
+        fn example_interfaces__msg__Int64__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Int64>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__msg__Int64__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Int64>,
+        );
+        fn example_interfaces__msg__Int64__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Int64>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Int64>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__msg__Int64
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Int64 {
+        pub data: i64,
+    }
+
+    impl Default for Int64 {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__msg__Int64__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__msg__Int64__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Int64 {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Int64__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Int64__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Int64__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Int64 {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Int64
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/msg/Int64";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Int64()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Int64MultiArray(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__msg__Int64MultiArray__init(msg: *mut Int64MultiArray) -> bool;
+        fn example_interfaces__msg__Int64MultiArray__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Int64MultiArray>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__msg__Int64MultiArray__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Int64MultiArray>,
+        );
+        fn example_interfaces__msg__Int64MultiArray__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Int64MultiArray>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Int64MultiArray>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__msg__Int64MultiArray
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Int64MultiArray {
+        pub layout: crate::vendor::example_interfaces::msg::rmw::MultiArrayLayout,
+        pub data: rosidl_runtime_rs::Sequence<i64>,
+    }
+
+    impl Default for Int64MultiArray {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__msg__Int64MultiArray__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__msg__Int64MultiArray__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Int64MultiArray {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Int64MultiArray__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Int64MultiArray__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__msg__Int64MultiArray__Sequence__copy(in_seq, out_seq as *mut _)
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Int64MultiArray {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Int64MultiArray
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/msg/Int64MultiArray";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Int64MultiArray()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Int8(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__msg__Int8__init(msg: *mut Int8) -> bool;
+        fn example_interfaces__msg__Int8__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Int8>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__msg__Int8__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Int8>,
+        );
+        fn example_interfaces__msg__Int8__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Int8>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Int8>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__msg__Int8
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Int8 {
+        pub data: i8,
+    }
+
+    impl Default for Int8 {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__msg__Int8__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__msg__Int8__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Int8 {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Int8__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Int8__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Int8__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Int8 {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Int8
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/msg/Int8";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Int8(
+                )
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Int8MultiArray(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__msg__Int8MultiArray__init(msg: *mut Int8MultiArray) -> bool;
+        fn example_interfaces__msg__Int8MultiArray__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Int8MultiArray>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__msg__Int8MultiArray__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Int8MultiArray>,
+        );
+        fn example_interfaces__msg__Int8MultiArray__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Int8MultiArray>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Int8MultiArray>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__msg__Int8MultiArray
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Int8MultiArray {
+        pub layout: crate::vendor::example_interfaces::msg::rmw::MultiArrayLayout,
+        pub data: rosidl_runtime_rs::Sequence<i8>,
+    }
+
+    impl Default for Int8MultiArray {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__msg__Int8MultiArray__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__msg__Int8MultiArray__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Int8MultiArray {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Int8MultiArray__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__Int8MultiArray__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__msg__Int8MultiArray__Sequence__copy(in_seq, out_seq as *mut _)
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Int8MultiArray {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Int8MultiArray
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/msg/Int8MultiArray";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__Int8MultiArray()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__MultiArrayDimension(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__msg__MultiArrayDimension__init(
+            msg: *mut MultiArrayDimension,
+        ) -> bool;
+        fn example_interfaces__msg__MultiArrayDimension__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<MultiArrayDimension>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__msg__MultiArrayDimension__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<MultiArrayDimension>,
+        );
+        fn example_interfaces__msg__MultiArrayDimension__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<MultiArrayDimension>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<MultiArrayDimension>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__msg__MultiArrayDimension
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct MultiArrayDimension {
+        pub label: rosidl_runtime_rs::String,
+        pub size: u32,
+        pub stride: u32,
+    }
+
+    impl Default for MultiArrayDimension {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__msg__MultiArrayDimension__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__msg__MultiArrayDimension__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for MultiArrayDimension {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__msg__MultiArrayDimension__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__MultiArrayDimension__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__msg__MultiArrayDimension__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for MultiArrayDimension {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for MultiArrayDimension
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/msg/MultiArrayDimension";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__MultiArrayDimension()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__MultiArrayLayout(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__msg__MultiArrayLayout__init(msg: *mut MultiArrayLayout) -> bool;
+        fn example_interfaces__msg__MultiArrayLayout__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<MultiArrayLayout>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__msg__MultiArrayLayout__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<MultiArrayLayout>,
+        );
+        fn example_interfaces__msg__MultiArrayLayout__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<MultiArrayLayout>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<MultiArrayLayout>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__msg__MultiArrayLayout
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct MultiArrayLayout {
+        pub dim: rosidl_runtime_rs::Sequence<
+            crate::vendor::example_interfaces::msg::rmw::MultiArrayDimension,
+        >,
+        pub data_offset: u32,
+    }
+
+    impl Default for MultiArrayLayout {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__msg__MultiArrayLayout__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__msg__MultiArrayLayout__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for MultiArrayLayout {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__msg__MultiArrayLayout__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__MultiArrayLayout__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__msg__MultiArrayLayout__Sequence__copy(in_seq, out_seq as *mut _)
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for MultiArrayLayout {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for MultiArrayLayout
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/msg/MultiArrayLayout";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__MultiArrayLayout()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__String(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__msg__String__init(msg: *mut String) -> bool;
+        fn example_interfaces__msg__String__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<String>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__msg__String__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<String>,
+        );
+        fn example_interfaces__msg__String__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<String>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<String>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__msg__String
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct String {
+        pub data: rosidl_runtime_rs::String,
+    }
+
+    impl Default for String {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__msg__String__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__msg__String__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for String {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__String__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__String__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__String__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for String {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for String
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/msg/String";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__String()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__UInt16(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__msg__UInt16__init(msg: *mut UInt16) -> bool;
+        fn example_interfaces__msg__UInt16__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<UInt16>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__msg__UInt16__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<UInt16>,
+        );
+        fn example_interfaces__msg__UInt16__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<UInt16>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<UInt16>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__msg__UInt16
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct UInt16 {
+        pub data: u16,
+    }
+
+    impl Default for UInt16 {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__msg__UInt16__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__msg__UInt16__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for UInt16 {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__UInt16__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__UInt16__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__UInt16__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for UInt16 {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for UInt16
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/msg/UInt16";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__UInt16()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__UInt16MultiArray(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__msg__UInt16MultiArray__init(msg: *mut UInt16MultiArray) -> bool;
+        fn example_interfaces__msg__UInt16MultiArray__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<UInt16MultiArray>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__msg__UInt16MultiArray__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<UInt16MultiArray>,
+        );
+        fn example_interfaces__msg__UInt16MultiArray__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<UInt16MultiArray>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<UInt16MultiArray>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__msg__UInt16MultiArray
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct UInt16MultiArray {
+        pub layout: crate::vendor::example_interfaces::msg::rmw::MultiArrayLayout,
+        pub data: rosidl_runtime_rs::Sequence<u16>,
+    }
+
+    impl Default for UInt16MultiArray {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__msg__UInt16MultiArray__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__msg__UInt16MultiArray__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for UInt16MultiArray {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__msg__UInt16MultiArray__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__UInt16MultiArray__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__msg__UInt16MultiArray__Sequence__copy(in_seq, out_seq as *mut _)
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for UInt16MultiArray {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for UInt16MultiArray
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/msg/UInt16MultiArray";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__UInt16MultiArray()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__UInt32(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__msg__UInt32__init(msg: *mut UInt32) -> bool;
+        fn example_interfaces__msg__UInt32__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<UInt32>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__msg__UInt32__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<UInt32>,
+        );
+        fn example_interfaces__msg__UInt32__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<UInt32>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<UInt32>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__msg__UInt32
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct UInt32 {
+        pub data: u32,
+    }
+
+    impl Default for UInt32 {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__msg__UInt32__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__msg__UInt32__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for UInt32 {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__UInt32__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__UInt32__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__UInt32__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for UInt32 {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for UInt32
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/msg/UInt32";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__UInt32()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__UInt32MultiArray(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__msg__UInt32MultiArray__init(msg: *mut UInt32MultiArray) -> bool;
+        fn example_interfaces__msg__UInt32MultiArray__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<UInt32MultiArray>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__msg__UInt32MultiArray__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<UInt32MultiArray>,
+        );
+        fn example_interfaces__msg__UInt32MultiArray__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<UInt32MultiArray>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<UInt32MultiArray>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__msg__UInt32MultiArray
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct UInt32MultiArray {
+        pub layout: crate::vendor::example_interfaces::msg::rmw::MultiArrayLayout,
+        pub data: rosidl_runtime_rs::Sequence<u32>,
+    }
+
+    impl Default for UInt32MultiArray {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__msg__UInt32MultiArray__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__msg__UInt32MultiArray__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for UInt32MultiArray {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__msg__UInt32MultiArray__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__UInt32MultiArray__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__msg__UInt32MultiArray__Sequence__copy(in_seq, out_seq as *mut _)
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for UInt32MultiArray {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for UInt32MultiArray
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/msg/UInt32MultiArray";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__UInt32MultiArray()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__UInt64(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__msg__UInt64__init(msg: *mut UInt64) -> bool;
+        fn example_interfaces__msg__UInt64__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<UInt64>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__msg__UInt64__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<UInt64>,
+        );
+        fn example_interfaces__msg__UInt64__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<UInt64>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<UInt64>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__msg__UInt64
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct UInt64 {
+        pub data: u64,
+    }
+
+    impl Default for UInt64 {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__msg__UInt64__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__msg__UInt64__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for UInt64 {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__UInt64__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__UInt64__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__UInt64__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for UInt64 {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for UInt64
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/msg/UInt64";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__UInt64()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__UInt64MultiArray(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__msg__UInt64MultiArray__init(msg: *mut UInt64MultiArray) -> bool;
+        fn example_interfaces__msg__UInt64MultiArray__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<UInt64MultiArray>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__msg__UInt64MultiArray__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<UInt64MultiArray>,
+        );
+        fn example_interfaces__msg__UInt64MultiArray__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<UInt64MultiArray>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<UInt64MultiArray>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__msg__UInt64MultiArray
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct UInt64MultiArray {
+        pub layout: crate::vendor::example_interfaces::msg::rmw::MultiArrayLayout,
+        pub data: rosidl_runtime_rs::Sequence<u64>,
+    }
+
+    impl Default for UInt64MultiArray {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__msg__UInt64MultiArray__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__msg__UInt64MultiArray__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for UInt64MultiArray {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__msg__UInt64MultiArray__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__UInt64MultiArray__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__msg__UInt64MultiArray__Sequence__copy(in_seq, out_seq as *mut _)
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for UInt64MultiArray {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for UInt64MultiArray
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/msg/UInt64MultiArray";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__UInt64MultiArray()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__UInt8(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__msg__UInt8__init(msg: *mut UInt8) -> bool;
+        fn example_interfaces__msg__UInt8__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<UInt8>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__msg__UInt8__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<UInt8>,
+        );
+        fn example_interfaces__msg__UInt8__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<UInt8>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<UInt8>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__msg__UInt8
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct UInt8 {
+        pub data: u8,
+    }
+
+    impl Default for UInt8 {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__msg__UInt8__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__msg__UInt8__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for UInt8 {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__UInt8__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__UInt8__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__UInt8__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for UInt8 {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for UInt8
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/msg/UInt8";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__UInt8()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__UInt8MultiArray(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__msg__UInt8MultiArray__init(msg: *mut UInt8MultiArray) -> bool;
+        fn example_interfaces__msg__UInt8MultiArray__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<UInt8MultiArray>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__msg__UInt8MultiArray__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<UInt8MultiArray>,
+        );
+        fn example_interfaces__msg__UInt8MultiArray__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<UInt8MultiArray>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<UInt8MultiArray>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__msg__UInt8MultiArray
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct UInt8MultiArray {
+        pub layout: crate::vendor::example_interfaces::msg::rmw::MultiArrayLayout,
+        pub data: rosidl_runtime_rs::Sequence<u8>,
+    }
+
+    impl Default for UInt8MultiArray {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__msg__UInt8MultiArray__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__msg__UInt8MultiArray__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for UInt8MultiArray {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__UInt8MultiArray__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__UInt8MultiArray__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__msg__UInt8MultiArray__Sequence__copy(in_seq, out_seq as *mut _)
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for UInt8MultiArray {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for UInt8MultiArray
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/msg/UInt8MultiArray";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__UInt8MultiArray()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__WString(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__msg__WString__init(msg: *mut WString) -> bool;
+        fn example_interfaces__msg__WString__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<WString>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__msg__WString__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<WString>,
+        );
+        fn example_interfaces__msg__WString__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<WString>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<WString>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__msg__WString
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct WString {
+        pub data: rosidl_runtime_rs::WString,
+    }
+
+    impl Default for WString {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__msg__WString__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__msg__WString__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for WString {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__WString__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__WString__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__msg__WString__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for WString {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for WString
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/msg/WString";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__msg__WString()
+            }
+        }
+    }
+} // mod rmw
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Bool {
+    pub data: bool,
+}
+
+impl Default for Bool {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::msg::rmw::Bool::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Bool {
+    type RmwMsg = crate::vendor::example_interfaces::msg::rmw::Bool;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { data: msg.data })
+            }
+            std::borrow::Cow::Borrowed(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { data: msg.data })
+            }
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self { data: msg.data }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Byte {
+    pub data: u8,
+}
+
+impl Default for Byte {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::msg::rmw::Byte::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Byte {
+    type RmwMsg = crate::vendor::example_interfaces::msg::rmw::Byte;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { data: msg.data })
+            }
+            std::borrow::Cow::Borrowed(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { data: msg.data })
+            }
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self { data: msg.data }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct ByteMultiArray {
+    pub layout: crate::vendor::example_interfaces::msg::MultiArrayLayout,
+    pub data: Vec<u8>,
+}
+
+impl Default for ByteMultiArray {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::msg::rmw::ByteMultiArray::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for ByteMultiArray {
+    type RmwMsg = crate::vendor::example_interfaces::msg::rmw::ByteMultiArray;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.layout),
+                )
+                .into_owned(),
+                data: msg.data.into(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.layout),
+                )
+                .into_owned(),
+                data: msg.data.as_slice().into(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::from_rmw_message(
+                msg.layout,
+            ),
+            data: msg.data.into_iter().collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Char {
+    pub data: u8,
+}
+
+impl Default for Char {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::msg::rmw::Char::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Char {
+    type RmwMsg = crate::vendor::example_interfaces::msg::rmw::Char;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { data: msg.data })
+            }
+            std::borrow::Cow::Borrowed(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { data: msg.data })
+            }
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self { data: msg.data }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Empty {
+    pub structure_needs_at_least_one_member: u8,
+}
+
+impl Default for Empty {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::msg::rmw::Empty::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Empty {
+    type RmwMsg = crate::vendor::example_interfaces::msg::rmw::Empty;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                structure_needs_at_least_one_member: msg.structure_needs_at_least_one_member,
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                structure_needs_at_least_one_member: msg.structure_needs_at_least_one_member,
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            structure_needs_at_least_one_member: msg.structure_needs_at_least_one_member,
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Float32 {
+    pub data: f32,
+}
+
+impl Default for Float32 {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::msg::rmw::Float32::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Float32 {
+    type RmwMsg = crate::vendor::example_interfaces::msg::rmw::Float32;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { data: msg.data })
+            }
+            std::borrow::Cow::Borrowed(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { data: msg.data })
+            }
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self { data: msg.data }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Float32MultiArray {
+    pub layout: crate::vendor::example_interfaces::msg::MultiArrayLayout,
+    pub data: Vec<f32>,
+}
+
+impl Default for Float32MultiArray {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::msg::rmw::Float32MultiArray::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Float32MultiArray {
+    type RmwMsg = crate::vendor::example_interfaces::msg::rmw::Float32MultiArray;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.layout),
+                )
+                .into_owned(),
+                data: msg.data.into(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.layout),
+                )
+                .into_owned(),
+                data: msg.data.as_slice().into(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::from_rmw_message(
+                msg.layout,
+            ),
+            data: msg.data.into_iter().collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Float64 {
+    pub data: f64,
+}
+
+impl Default for Float64 {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::msg::rmw::Float64::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Float64 {
+    type RmwMsg = crate::vendor::example_interfaces::msg::rmw::Float64;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { data: msg.data })
+            }
+            std::borrow::Cow::Borrowed(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { data: msg.data })
+            }
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self { data: msg.data }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Float64MultiArray {
+    pub layout: crate::vendor::example_interfaces::msg::MultiArrayLayout,
+    pub data: Vec<f64>,
+}
+
+impl Default for Float64MultiArray {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::msg::rmw::Float64MultiArray::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Float64MultiArray {
+    type RmwMsg = crate::vendor::example_interfaces::msg::rmw::Float64MultiArray;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.layout),
+                )
+                .into_owned(),
+                data: msg.data.into(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.layout),
+                )
+                .into_owned(),
+                data: msg.data.as_slice().into(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::from_rmw_message(
+                msg.layout,
+            ),
+            data: msg.data.into_iter().collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Int16 {
+    pub data: i16,
+}
+
+impl Default for Int16 {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::msg::rmw::Int16::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Int16 {
+    type RmwMsg = crate::vendor::example_interfaces::msg::rmw::Int16;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { data: msg.data })
+            }
+            std::borrow::Cow::Borrowed(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { data: msg.data })
+            }
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self { data: msg.data }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Int16MultiArray {
+    pub layout: crate::vendor::example_interfaces::msg::MultiArrayLayout,
+    pub data: Vec<i16>,
+}
+
+impl Default for Int16MultiArray {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::msg::rmw::Int16MultiArray::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Int16MultiArray {
+    type RmwMsg = crate::vendor::example_interfaces::msg::rmw::Int16MultiArray;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.layout),
+                )
+                .into_owned(),
+                data: msg.data.into(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.layout),
+                )
+                .into_owned(),
+                data: msg.data.as_slice().into(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::from_rmw_message(
+                msg.layout,
+            ),
+            data: msg.data.into_iter().collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Int32 {
+    pub data: i32,
+}
+
+impl Default for Int32 {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::msg::rmw::Int32::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Int32 {
+    type RmwMsg = crate::vendor::example_interfaces::msg::rmw::Int32;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { data: msg.data })
+            }
+            std::borrow::Cow::Borrowed(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { data: msg.data })
+            }
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self { data: msg.data }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Int32MultiArray {
+    pub layout: crate::vendor::example_interfaces::msg::MultiArrayLayout,
+    pub data: Vec<i32>,
+}
+
+impl Default for Int32MultiArray {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::msg::rmw::Int32MultiArray::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Int32MultiArray {
+    type RmwMsg = crate::vendor::example_interfaces::msg::rmw::Int32MultiArray;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.layout),
+                )
+                .into_owned(),
+                data: msg.data.into(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.layout),
+                )
+                .into_owned(),
+                data: msg.data.as_slice().into(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::from_rmw_message(
+                msg.layout,
+            ),
+            data: msg.data.into_iter().collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Int64 {
+    pub data: i64,
+}
+
+impl Default for Int64 {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::msg::rmw::Int64::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Int64 {
+    type RmwMsg = crate::vendor::example_interfaces::msg::rmw::Int64;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { data: msg.data })
+            }
+            std::borrow::Cow::Borrowed(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { data: msg.data })
+            }
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self { data: msg.data }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Int64MultiArray {
+    pub layout: crate::vendor::example_interfaces::msg::MultiArrayLayout,
+    pub data: Vec<i64>,
+}
+
+impl Default for Int64MultiArray {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::msg::rmw::Int64MultiArray::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Int64MultiArray {
+    type RmwMsg = crate::vendor::example_interfaces::msg::rmw::Int64MultiArray;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.layout),
+                )
+                .into_owned(),
+                data: msg.data.into(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.layout),
+                )
+                .into_owned(),
+                data: msg.data.as_slice().into(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::from_rmw_message(
+                msg.layout,
+            ),
+            data: msg.data.into_iter().collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Int8 {
+    pub data: i8,
+}
+
+impl Default for Int8 {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::msg::rmw::Int8::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Int8 {
+    type RmwMsg = crate::vendor::example_interfaces::msg::rmw::Int8;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { data: msg.data })
+            }
+            std::borrow::Cow::Borrowed(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { data: msg.data })
+            }
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self { data: msg.data }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Int8MultiArray {
+    pub layout: crate::vendor::example_interfaces::msg::MultiArrayLayout,
+    pub data: Vec<i8>,
+}
+
+impl Default for Int8MultiArray {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::msg::rmw::Int8MultiArray::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Int8MultiArray {
+    type RmwMsg = crate::vendor::example_interfaces::msg::rmw::Int8MultiArray;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.layout),
+                )
+                .into_owned(),
+                data: msg.data.into(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.layout),
+                )
+                .into_owned(),
+                data: msg.data.as_slice().into(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::from_rmw_message(
+                msg.layout,
+            ),
+            data: msg.data.into_iter().collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct MultiArrayDimension {
+    pub label: std::string::String,
+    pub size: u32,
+    pub stride: u32,
+}
+
+impl Default for MultiArrayDimension {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::msg::rmw::MultiArrayDimension::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for MultiArrayDimension {
+    type RmwMsg = crate::vendor::example_interfaces::msg::rmw::MultiArrayDimension;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                label: msg.label.as_str().into(),
+                size: msg.size,
+                stride: msg.stride,
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                label: msg.label.as_str().into(),
+                size: msg.size,
+                stride: msg.stride,
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            label: msg.label.to_string(),
+            size: msg.size,
+            stride: msg.stride,
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct MultiArrayLayout {
+    pub dim: Vec<crate::vendor::example_interfaces::msg::MultiArrayDimension>,
+    pub data_offset: u32,
+}
+
+impl Default for MultiArrayLayout {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::msg::rmw::MultiArrayLayout::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for MultiArrayLayout {
+    type RmwMsg = crate::vendor::example_interfaces::msg::rmw::MultiArrayLayout;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+      std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+        dim: msg.dim
+          .into_iter()
+          .map(|elem| crate::vendor::example_interfaces::msg::MultiArrayDimension::into_rmw_message(std::borrow::Cow::Owned(elem)).into_owned())
+          .collect(),
+        data_offset: msg.data_offset,
+      }),
+      std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+        dim: msg.dim
+          .iter()
+          .map(|elem| crate::vendor::example_interfaces::msg::MultiArrayDimension::into_rmw_message(std::borrow::Cow::Borrowed(elem)).into_owned())
+          .collect(),
+      data_offset: msg.data_offset,
+      })
+    }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            dim: msg
+                .dim
+                .into_iter()
+                .map(crate::vendor::example_interfaces::msg::MultiArrayDimension::from_rmw_message)
+                .collect(),
+            data_offset: msg.data_offset,
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct String {
+    pub data: std::string::String,
+}
+
+impl Default for String {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::msg::rmw::String::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for String {
+    type RmwMsg = crate::vendor::example_interfaces::msg::rmw::String;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                data: msg.data.as_str().into(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                data: msg.data.as_str().into(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            data: msg.data.to_string(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct UInt16 {
+    pub data: u16,
+}
+
+impl Default for UInt16 {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::msg::rmw::UInt16::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for UInt16 {
+    type RmwMsg = crate::vendor::example_interfaces::msg::rmw::UInt16;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { data: msg.data })
+            }
+            std::borrow::Cow::Borrowed(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { data: msg.data })
+            }
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self { data: msg.data }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct UInt16MultiArray {
+    pub layout: crate::vendor::example_interfaces::msg::MultiArrayLayout,
+    pub data: Vec<u16>,
+}
+
+impl Default for UInt16MultiArray {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::msg::rmw::UInt16MultiArray::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for UInt16MultiArray {
+    type RmwMsg = crate::vendor::example_interfaces::msg::rmw::UInt16MultiArray;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.layout),
+                )
+                .into_owned(),
+                data: msg.data.into(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.layout),
+                )
+                .into_owned(),
+                data: msg.data.as_slice().into(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::from_rmw_message(
+                msg.layout,
+            ),
+            data: msg.data.into_iter().collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct UInt32 {
+    pub data: u32,
+}
+
+impl Default for UInt32 {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::msg::rmw::UInt32::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for UInt32 {
+    type RmwMsg = crate::vendor::example_interfaces::msg::rmw::UInt32;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { data: msg.data })
+            }
+            std::borrow::Cow::Borrowed(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { data: msg.data })
+            }
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self { data: msg.data }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct UInt32MultiArray {
+    pub layout: crate::vendor::example_interfaces::msg::MultiArrayLayout,
+    pub data: Vec<u32>,
+}
+
+impl Default for UInt32MultiArray {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::msg::rmw::UInt32MultiArray::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for UInt32MultiArray {
+    type RmwMsg = crate::vendor::example_interfaces::msg::rmw::UInt32MultiArray;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.layout),
+                )
+                .into_owned(),
+                data: msg.data.into(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.layout),
+                )
+                .into_owned(),
+                data: msg.data.as_slice().into(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::from_rmw_message(
+                msg.layout,
+            ),
+            data: msg.data.into_iter().collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct UInt64 {
+    pub data: u64,
+}
+
+impl Default for UInt64 {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::msg::rmw::UInt64::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for UInt64 {
+    type RmwMsg = crate::vendor::example_interfaces::msg::rmw::UInt64;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { data: msg.data })
+            }
+            std::borrow::Cow::Borrowed(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { data: msg.data })
+            }
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self { data: msg.data }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct UInt64MultiArray {
+    pub layout: crate::vendor::example_interfaces::msg::MultiArrayLayout,
+    pub data: Vec<u64>,
+}
+
+impl Default for UInt64MultiArray {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::msg::rmw::UInt64MultiArray::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for UInt64MultiArray {
+    type RmwMsg = crate::vendor::example_interfaces::msg::rmw::UInt64MultiArray;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.layout),
+                )
+                .into_owned(),
+                data: msg.data.into(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.layout),
+                )
+                .into_owned(),
+                data: msg.data.as_slice().into(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::from_rmw_message(
+                msg.layout,
+            ),
+            data: msg.data.into_iter().collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct UInt8 {
+    pub data: u8,
+}
+
+impl Default for UInt8 {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::msg::rmw::UInt8::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for UInt8 {
+    type RmwMsg = crate::vendor::example_interfaces::msg::rmw::UInt8;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { data: msg.data })
+            }
+            std::borrow::Cow::Borrowed(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { data: msg.data })
+            }
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self { data: msg.data }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct UInt8MultiArray {
+    pub layout: crate::vendor::example_interfaces::msg::MultiArrayLayout,
+    pub data: Vec<u8>,
+}
+
+impl Default for UInt8MultiArray {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::msg::rmw::UInt8MultiArray::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for UInt8MultiArray {
+    type RmwMsg = crate::vendor::example_interfaces::msg::rmw::UInt8MultiArray;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.layout),
+                )
+                .into_owned(),
+                data: msg.data.into(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.layout),
+                )
+                .into_owned(),
+                data: msg.data.as_slice().into(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            layout: crate::vendor::example_interfaces::msg::MultiArrayLayout::from_rmw_message(
+                msg.layout,
+            ),
+            data: msg.data.into_iter().collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct WString {
+    pub data: std::string::String,
+}
+
+impl Default for WString {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::msg::rmw::WString::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for WString {
+    type RmwMsg = crate::vendor::example_interfaces::msg::rmw::WString;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                data: msg.data.as_str().into(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                data: msg.data.as_str().into(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            data: msg.data.to_string(),
+        }
+    }
+}

--- a/rclrs/src/vendor/example_interfaces/srv.rs
+++ b/rclrs/src/vendor/example_interfaces/srv.rs
@@ -1,0 +1,888 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct AddTwoInts_Request {
+    pub a: i64,
+    pub b: i64,
+}
+
+impl Default for AddTwoInts_Request {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::srv::rmw::AddTwoInts_Request::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for AddTwoInts_Request {
+    type RmwMsg = crate::vendor::example_interfaces::srv::rmw::AddTwoInts_Request;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { a: msg.a, b: msg.b })
+            }
+            std::borrow::Cow::Borrowed(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { a: msg.a, b: msg.b })
+            }
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self { a: msg.a, b: msg.b }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct AddTwoInts_Response {
+    pub sum: i64,
+}
+
+impl Default for AddTwoInts_Response {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::srv::rmw::AddTwoInts_Response::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for AddTwoInts_Response {
+    type RmwMsg = crate::vendor::example_interfaces::srv::rmw::AddTwoInts_Response;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg { sum: msg.sum }),
+            std::borrow::Cow::Borrowed(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { sum: msg.sum })
+            }
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self { sum: msg.sum }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct SetBool_Request {
+    pub data: bool,
+}
+
+impl Default for SetBool_Request {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::srv::rmw::SetBool_Request::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for SetBool_Request {
+    type RmwMsg = crate::vendor::example_interfaces::srv::rmw::SetBool_Request;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { data: msg.data })
+            }
+            std::borrow::Cow::Borrowed(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { data: msg.data })
+            }
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self { data: msg.data }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct SetBool_Response {
+    pub success: bool,
+    pub message: std::string::String,
+}
+
+impl Default for SetBool_Response {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::srv::rmw::SetBool_Response::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for SetBool_Response {
+    type RmwMsg = crate::vendor::example_interfaces::srv::rmw::SetBool_Response;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                success: msg.success,
+                message: msg.message.as_str().into(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                success: msg.success,
+                message: msg.message.as_str().into(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            success: msg.success,
+            message: msg.message.to_string(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Trigger_Request {
+    pub structure_needs_at_least_one_member: u8,
+}
+
+impl Default for Trigger_Request {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::srv::rmw::Trigger_Request::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Trigger_Request {
+    type RmwMsg = crate::vendor::example_interfaces::srv::rmw::Trigger_Request;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                structure_needs_at_least_one_member: msg.structure_needs_at_least_one_member,
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                structure_needs_at_least_one_member: msg.structure_needs_at_least_one_member,
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            structure_needs_at_least_one_member: msg.structure_needs_at_least_one_member,
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Trigger_Response {
+    pub success: bool,
+    pub message: std::string::String,
+}
+
+impl Default for Trigger_Response {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::example_interfaces::srv::rmw::Trigger_Response::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Trigger_Response {
+    type RmwMsg = crate::vendor::example_interfaces::srv::rmw::Trigger_Response;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                success: msg.success,
+                message: msg.message.as_str().into(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                success: msg.success,
+                message: msg.message.as_str().into(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            success: msg.success,
+            message: msg.message.to_string(),
+        }
+    }
+}
+
+#[link(name = "example_interfaces__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_service_type_support_handle__example_interfaces__srv__AddTwoInts(
+    ) -> *const std::ffi::c_void;
+}
+
+// Corresponds to example_interfaces__srv__AddTwoInts
+pub struct AddTwoInts;
+
+impl rosidl_runtime_rs::Service for AddTwoInts {
+    type Request = crate::vendor::example_interfaces::srv::AddTwoInts_Request;
+    type Response = crate::vendor::example_interfaces::srv::AddTwoInts_Response;
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        // SAFETY: No preconditions for this function.
+        unsafe {
+            rosidl_typesupport_c__get_service_type_support_handle__example_interfaces__srv__AddTwoInts()
+        }
+    }
+}
+
+#[link(name = "example_interfaces__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_service_type_support_handle__example_interfaces__srv__SetBool(
+    ) -> *const std::ffi::c_void;
+}
+
+// Corresponds to example_interfaces__srv__SetBool
+pub struct SetBool;
+
+impl rosidl_runtime_rs::Service for SetBool {
+    type Request = crate::vendor::example_interfaces::srv::SetBool_Request;
+    type Response = crate::vendor::example_interfaces::srv::SetBool_Response;
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        // SAFETY: No preconditions for this function.
+        unsafe {
+            rosidl_typesupport_c__get_service_type_support_handle__example_interfaces__srv__SetBool(
+            )
+        }
+    }
+}
+
+#[link(name = "example_interfaces__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_service_type_support_handle__example_interfaces__srv__Trigger(
+    ) -> *const std::ffi::c_void;
+}
+
+// Corresponds to example_interfaces__srv__Trigger
+pub struct Trigger;
+
+impl rosidl_runtime_rs::Service for Trigger {
+    type Request = crate::vendor::example_interfaces::srv::Trigger_Request;
+    type Response = crate::vendor::example_interfaces::srv::Trigger_Response;
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        // SAFETY: No preconditions for this function.
+        unsafe {
+            rosidl_typesupport_c__get_service_type_support_handle__example_interfaces__srv__Trigger(
+            )
+        }
+    }
+}
+
+pub mod rmw {
+
+    #[cfg(feature = "serde")]
+    use serde::{Deserialize, Serialize};
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__srv__AddTwoInts_Request(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__srv__AddTwoInts_Request__init(msg: *mut AddTwoInts_Request) -> bool;
+        fn example_interfaces__srv__AddTwoInts_Request__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<AddTwoInts_Request>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__srv__AddTwoInts_Request__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<AddTwoInts_Request>,
+        );
+        fn example_interfaces__srv__AddTwoInts_Request__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<AddTwoInts_Request>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<AddTwoInts_Request>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__srv__AddTwoInts_Request
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct AddTwoInts_Request {
+        pub a: i64,
+        pub b: i64,
+    }
+
+    impl Default for AddTwoInts_Request {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__srv__AddTwoInts_Request__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__srv__AddTwoInts_Request__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for AddTwoInts_Request {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__srv__AddTwoInts_Request__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__srv__AddTwoInts_Request__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__srv__AddTwoInts_Request__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for AddTwoInts_Request {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for AddTwoInts_Request
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/srv/AddTwoInts_Request";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__srv__AddTwoInts_Request()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__srv__AddTwoInts_Response(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__srv__AddTwoInts_Response__init(
+            msg: *mut AddTwoInts_Response,
+        ) -> bool;
+        fn example_interfaces__srv__AddTwoInts_Response__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<AddTwoInts_Response>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__srv__AddTwoInts_Response__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<AddTwoInts_Response>,
+        );
+        fn example_interfaces__srv__AddTwoInts_Response__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<AddTwoInts_Response>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<AddTwoInts_Response>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__srv__AddTwoInts_Response
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct AddTwoInts_Response {
+        pub sum: i64,
+    }
+
+    impl Default for AddTwoInts_Response {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__srv__AddTwoInts_Response__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__srv__AddTwoInts_Response__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for AddTwoInts_Response {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__srv__AddTwoInts_Response__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__srv__AddTwoInts_Response__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__srv__AddTwoInts_Response__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for AddTwoInts_Response {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for AddTwoInts_Response
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/srv/AddTwoInts_Response";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__srv__AddTwoInts_Response()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__srv__SetBool_Request(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__srv__SetBool_Request__init(msg: *mut SetBool_Request) -> bool;
+        fn example_interfaces__srv__SetBool_Request__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<SetBool_Request>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__srv__SetBool_Request__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<SetBool_Request>,
+        );
+        fn example_interfaces__srv__SetBool_Request__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<SetBool_Request>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<SetBool_Request>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__srv__SetBool_Request
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct SetBool_Request {
+        pub data: bool,
+    }
+
+    impl Default for SetBool_Request {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__srv__SetBool_Request__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__srv__SetBool_Request__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for SetBool_Request {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__srv__SetBool_Request__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__srv__SetBool_Request__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__srv__SetBool_Request__Sequence__copy(in_seq, out_seq as *mut _)
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for SetBool_Request {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for SetBool_Request
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/srv/SetBool_Request";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__srv__SetBool_Request()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__srv__SetBool_Response(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__srv__SetBool_Response__init(msg: *mut SetBool_Response) -> bool;
+        fn example_interfaces__srv__SetBool_Response__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<SetBool_Response>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__srv__SetBool_Response__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<SetBool_Response>,
+        );
+        fn example_interfaces__srv__SetBool_Response__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<SetBool_Response>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<SetBool_Response>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__srv__SetBool_Response
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct SetBool_Response {
+        pub success: bool,
+        pub message: rosidl_runtime_rs::String,
+    }
+
+    impl Default for SetBool_Response {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__srv__SetBool_Response__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__srv__SetBool_Response__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for SetBool_Response {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__srv__SetBool_Response__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__srv__SetBool_Response__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__srv__SetBool_Response__Sequence__copy(in_seq, out_seq as *mut _)
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for SetBool_Response {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for SetBool_Response
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/srv/SetBool_Response";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__srv__SetBool_Response()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__srv__Trigger_Request(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__srv__Trigger_Request__init(msg: *mut Trigger_Request) -> bool;
+        fn example_interfaces__srv__Trigger_Request__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Trigger_Request>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__srv__Trigger_Request__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Trigger_Request>,
+        );
+        fn example_interfaces__srv__Trigger_Request__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Trigger_Request>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Trigger_Request>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__srv__Trigger_Request
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Trigger_Request {
+        pub structure_needs_at_least_one_member: u8,
+    }
+
+    impl Default for Trigger_Request {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__srv__Trigger_Request__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__srv__Trigger_Request__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Trigger_Request {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__srv__Trigger_Request__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__srv__Trigger_Request__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__srv__Trigger_Request__Sequence__copy(in_seq, out_seq as *mut _)
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Trigger_Request {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Trigger_Request
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/srv/Trigger_Request";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__srv__Trigger_Request()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__srv__Trigger_Response(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "example_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn example_interfaces__srv__Trigger_Response__init(msg: *mut Trigger_Response) -> bool;
+        fn example_interfaces__srv__Trigger_Response__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Trigger_Response>,
+            size: usize,
+        ) -> bool;
+        fn example_interfaces__srv__Trigger_Response__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Trigger_Response>,
+        );
+        fn example_interfaces__srv__Trigger_Response__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Trigger_Response>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Trigger_Response>,
+        ) -> bool;
+    }
+
+    // Corresponds to example_interfaces__srv__Trigger_Response
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Trigger_Response {
+        pub success: bool,
+        pub message: rosidl_runtime_rs::String,
+    }
+
+    impl Default for Trigger_Response {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !example_interfaces__srv__Trigger_Response__init(&mut msg as *mut _) {
+                    panic!("Call to example_interfaces__srv__Trigger_Response__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Trigger_Response {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__srv__Trigger_Response__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { example_interfaces__srv__Trigger_Response__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                example_interfaces__srv__Trigger_Response__Sequence__copy(in_seq, out_seq as *mut _)
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Trigger_Response {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Trigger_Response
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "example_interfaces/srv/Trigger_Response";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__example_interfaces__srv__Trigger_Response()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_service_type_support_handle__example_interfaces__srv__AddTwoInts(
+        ) -> *const std::ffi::c_void;
+    }
+
+    // Corresponds to example_interfaces__srv__AddTwoInts
+    pub struct AddTwoInts;
+
+    impl rosidl_runtime_rs::Service for AddTwoInts {
+        type Request = crate::vendor::example_interfaces::srv::rmw::AddTwoInts_Request;
+        type Response = crate::vendor::example_interfaces::srv::rmw::AddTwoInts_Response;
+
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_service_type_support_handle__example_interfaces__srv__AddTwoInts()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_service_type_support_handle__example_interfaces__srv__SetBool(
+        ) -> *const std::ffi::c_void;
+    }
+
+    // Corresponds to example_interfaces__srv__SetBool
+    pub struct SetBool;
+
+    impl rosidl_runtime_rs::Service for SetBool {
+        type Request = crate::vendor::example_interfaces::srv::rmw::SetBool_Request;
+        type Response = crate::vendor::example_interfaces::srv::rmw::SetBool_Response;
+
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_service_type_support_handle__example_interfaces__srv__SetBool()
+            }
+        }
+    }
+
+    #[link(name = "example_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_service_type_support_handle__example_interfaces__srv__Trigger(
+        ) -> *const std::ffi::c_void;
+    }
+
+    // Corresponds to example_interfaces__srv__Trigger
+    pub struct Trigger;
+
+    impl rosidl_runtime_rs::Service for Trigger {
+        type Request = crate::vendor::example_interfaces::srv::rmw::Trigger_Request;
+        type Response = crate::vendor::example_interfaces::srv::rmw::Trigger_Response;
+
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_service_type_support_handle__example_interfaces__srv__Trigger()
+            }
+        }
+    }
+} // mod rmw

--- a/rclrs/src/vendor/mod.rs
+++ b/rclrs/src/vendor/mod.rs
@@ -1,5 +1,6 @@
 //! Created by vendor_interfaces.py
 #![allow(dead_code)]
+#![allow(missing_docs)]
 
 pub mod action_msgs;
 pub mod builtin_interfaces;

--- a/rclrs/src/vendor/mod.rs
+++ b/rclrs/src/vendor/mod.rs
@@ -3,6 +3,8 @@
 
 pub mod action_msgs;
 pub mod builtin_interfaces;
+pub mod example_interfaces;
 pub mod rcl_interfaces;
 pub mod rosgraph_msgs;
+pub mod test_msgs;
 pub mod unique_identifier_msgs;

--- a/rclrs/src/vendor/rcl_interfaces/msg.rs
+++ b/rclrs/src/vendor/rcl_interfaces/msg.rs
@@ -1036,6 +1036,196 @@ pub mod rmw {
             }
         }
     }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__msg__LoggerLevel(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn rcl_interfaces__msg__LoggerLevel__init(msg: *mut LoggerLevel) -> bool;
+        fn rcl_interfaces__msg__LoggerLevel__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<LoggerLevel>,
+            size: usize,
+        ) -> bool;
+        fn rcl_interfaces__msg__LoggerLevel__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<LoggerLevel>,
+        );
+        fn rcl_interfaces__msg__LoggerLevel__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<LoggerLevel>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<LoggerLevel>,
+        ) -> bool;
+    }
+
+    // Corresponds to rcl_interfaces__msg__LoggerLevel
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct LoggerLevel {
+        pub name: rosidl_runtime_rs::String,
+        pub level: u32,
+    }
+
+    impl LoggerLevel {
+        pub const LOG_LEVEL_UNKNOWN: u8 = 0;
+        pub const LOG_LEVEL_DEBUG: u8 = 10;
+        pub const LOG_LEVEL_INFO: u8 = 20;
+        pub const LOG_LEVEL_WARN: u8 = 30;
+        pub const LOG_LEVEL_ERROR: u8 = 40;
+        pub const LOG_LEVEL_FATAL: u8 = 50;
+    }
+
+    impl Default for LoggerLevel {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !rcl_interfaces__msg__LoggerLevel__init(&mut msg as *mut _) {
+                    panic!("Call to rcl_interfaces__msg__LoggerLevel__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for LoggerLevel {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__msg__LoggerLevel__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__msg__LoggerLevel__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__msg__LoggerLevel__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for LoggerLevel {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for LoggerLevel
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "rcl_interfaces/msg/LoggerLevel";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__msg__LoggerLevel()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__msg__SetLoggerLevelsResult(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn rcl_interfaces__msg__SetLoggerLevelsResult__init(
+            msg: *mut SetLoggerLevelsResult,
+        ) -> bool;
+        fn rcl_interfaces__msg__SetLoggerLevelsResult__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<SetLoggerLevelsResult>,
+            size: usize,
+        ) -> bool;
+        fn rcl_interfaces__msg__SetLoggerLevelsResult__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<SetLoggerLevelsResult>,
+        );
+        fn rcl_interfaces__msg__SetLoggerLevelsResult__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<SetLoggerLevelsResult>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<SetLoggerLevelsResult>,
+        ) -> bool;
+    }
+
+    // Corresponds to rcl_interfaces__msg__SetLoggerLevelsResult
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct SetLoggerLevelsResult {
+        pub successful: bool,
+        pub reason: rosidl_runtime_rs::String,
+    }
+
+    impl Default for SetLoggerLevelsResult {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !rcl_interfaces__msg__SetLoggerLevelsResult__init(&mut msg as *mut _) {
+                    panic!("Call to rcl_interfaces__msg__SetLoggerLevelsResult__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for SetLoggerLevelsResult {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__msg__SetLoggerLevelsResult__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__msg__SetLoggerLevelsResult__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__msg__SetLoggerLevelsResult__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for SetLoggerLevelsResult {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for SetLoggerLevelsResult
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "rcl_interfaces/msg/SetLoggerLevelsResult";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__msg__SetLoggerLevelsResult()
+            }
+        }
+    }
 } // mod rmw
 
 #[cfg(feature = "serde")]
@@ -1757,6 +1947,93 @@ impl Default for SetParametersResult {
 
 impl rosidl_runtime_rs::Message for SetParametersResult {
     type RmwMsg = crate::vendor::rcl_interfaces::msg::rmw::SetParametersResult;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                successful: msg.successful,
+                reason: msg.reason.as_str().into(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                successful: msg.successful,
+                reason: msg.reason.as_str().into(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            successful: msg.successful,
+            reason: msg.reason.to_string(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct LoggerLevel {
+    pub name: std::string::String,
+    pub level: u32,
+}
+
+impl LoggerLevel {
+    pub const LOG_LEVEL_UNKNOWN: u8 = 0;
+    pub const LOG_LEVEL_DEBUG: u8 = 10;
+    pub const LOG_LEVEL_INFO: u8 = 20;
+    pub const LOG_LEVEL_WARN: u8 = 30;
+    pub const LOG_LEVEL_ERROR: u8 = 40;
+    pub const LOG_LEVEL_FATAL: u8 = 50;
+}
+
+impl Default for LoggerLevel {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::rcl_interfaces::msg::rmw::LoggerLevel::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for LoggerLevel {
+    type RmwMsg = crate::vendor::rcl_interfaces::msg::rmw::LoggerLevel;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                name: msg.name.as_str().into(),
+                level: msg.level,
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                name: msg.name.as_str().into(),
+                level: msg.level,
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            name: msg.name.to_string(),
+            level: msg.level,
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct SetLoggerLevelsResult {
+    pub successful: bool,
+    pub reason: std::string::String,
+}
+
+impl Default for SetLoggerLevelsResult {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::rcl_interfaces::msg::rmw::SetLoggerLevelsResult::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for SetLoggerLevelsResult {
+    type RmwMsg = crate::vendor::rcl_interfaces::msg::rmw::SetLoggerLevelsResult;
 
     fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
         match msg_cow {

--- a/rclrs/src/vendor/rcl_interfaces/srv.rs
+++ b/rclrs/src/vendor/rcl_interfaces/srv.rs
@@ -579,6 +579,216 @@ impl rosidl_runtime_rs::Message for SetParameters_Response {
     }
 }
 
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct GetLoggerLevels_Request {
+    pub names: Vec<std::string::String>,
+}
+
+impl Default for GetLoggerLevels_Request {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::rcl_interfaces::srv::rmw::GetLoggerLevels_Request::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for GetLoggerLevels_Request {
+    type RmwMsg = crate::vendor::rcl_interfaces::srv::rmw::GetLoggerLevels_Request;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                names: msg
+                    .names
+                    .into_iter()
+                    .map(|elem| elem.as_str().into())
+                    .collect(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                names: msg.names.iter().map(|elem| elem.as_str().into()).collect(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            names: msg.names.into_iter().map(|elem| elem.to_string()).collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct GetLoggerLevels_Response {
+    pub levels: Vec<crate::vendor::rcl_interfaces::msg::LoggerLevel>,
+}
+
+impl Default for GetLoggerLevels_Response {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::rcl_interfaces::srv::rmw::GetLoggerLevels_Response::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for GetLoggerLevels_Response {
+    type RmwMsg = crate::vendor::rcl_interfaces::srv::rmw::GetLoggerLevels_Response;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                levels: msg
+                    .levels
+                    .into_iter()
+                    .map(|elem| {
+                        crate::vendor::rcl_interfaces::msg::LoggerLevel::into_rmw_message(
+                            std::borrow::Cow::Owned(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                levels: msg
+                    .levels
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::rcl_interfaces::msg::LoggerLevel::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            levels: msg
+                .levels
+                .into_iter()
+                .map(crate::vendor::rcl_interfaces::msg::LoggerLevel::from_rmw_message)
+                .collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct SetLoggerLevels_Request {
+    pub levels: Vec<crate::vendor::rcl_interfaces::msg::LoggerLevel>,
+}
+
+impl Default for SetLoggerLevels_Request {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::rcl_interfaces::srv::rmw::SetLoggerLevels_Request::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for SetLoggerLevels_Request {
+    type RmwMsg = crate::vendor::rcl_interfaces::srv::rmw::SetLoggerLevels_Request;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                levels: msg
+                    .levels
+                    .into_iter()
+                    .map(|elem| {
+                        crate::vendor::rcl_interfaces::msg::LoggerLevel::into_rmw_message(
+                            std::borrow::Cow::Owned(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                levels: msg
+                    .levels
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::rcl_interfaces::msg::LoggerLevel::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            levels: msg
+                .levels
+                .into_iter()
+                .map(crate::vendor::rcl_interfaces::msg::LoggerLevel::from_rmw_message)
+                .collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct SetLoggerLevels_Response {
+    pub results: Vec<crate::vendor::rcl_interfaces::msg::SetLoggerLevelsResult>,
+}
+
+impl Default for SetLoggerLevels_Response {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::rcl_interfaces::srv::rmw::SetLoggerLevels_Response::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for SetLoggerLevels_Response {
+    type RmwMsg = crate::vendor::rcl_interfaces::srv::rmw::SetLoggerLevels_Response;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                results: msg
+                    .results
+                    .into_iter()
+                    .map(|elem| {
+                        crate::vendor::rcl_interfaces::msg::SetLoggerLevelsResult::into_rmw_message(
+                            std::borrow::Cow::Owned(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                results: msg
+                    .results
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::rcl_interfaces::msg::SetLoggerLevelsResult::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            results: msg
+                .results
+                .into_iter()
+                .map(crate::vendor::rcl_interfaces::msg::SetLoggerLevelsResult::from_rmw_message)
+                .collect(),
+        }
+    }
+}
+
 #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
 extern "C" {
     fn rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__DescribeParameters(
@@ -701,6 +911,48 @@ impl rosidl_runtime_rs::Service for SetParameters {
         // SAFETY: No preconditions for this function.
         unsafe {
             rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__SetParameters()
+        }
+    }
+}
+
+#[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__GetLoggerLevels(
+    ) -> *const std::ffi::c_void;
+}
+
+// Corresponds to rcl_interfaces__srv__GetLoggerLevels
+pub struct GetLoggerLevels;
+
+impl rosidl_runtime_rs::Service for GetLoggerLevels {
+    type Request = crate::vendor::rcl_interfaces::srv::GetLoggerLevels_Request;
+    type Response = crate::vendor::rcl_interfaces::srv::GetLoggerLevels_Response;
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        // SAFETY: No preconditions for this function.
+        unsafe {
+            rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__GetLoggerLevels()
+        }
+    }
+}
+
+#[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__SetLoggerLevels(
+    ) -> *const std::ffi::c_void;
+}
+
+// Corresponds to rcl_interfaces__srv__SetLoggerLevels
+pub struct SetLoggerLevels;
+
+impl rosidl_runtime_rs::Service for SetLoggerLevels {
+    type Request = crate::vendor::rcl_interfaces::srv::SetLoggerLevels_Request;
+    type Response = crate::vendor::rcl_interfaces::srv::SetLoggerLevels_Response;
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        // SAFETY: No preconditions for this function.
+        unsafe {
+            rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__SetLoggerLevels()
         }
     }
 }
@@ -1878,6 +2130,386 @@ pub mod rmw {
 
     #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
     extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__GetLoggerLevels_Request(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn rcl_interfaces__srv__GetLoggerLevels_Request__init(
+            msg: *mut GetLoggerLevels_Request,
+        ) -> bool;
+        fn rcl_interfaces__srv__GetLoggerLevels_Request__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<GetLoggerLevels_Request>,
+            size: usize,
+        ) -> bool;
+        fn rcl_interfaces__srv__GetLoggerLevels_Request__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<GetLoggerLevels_Request>,
+        );
+        fn rcl_interfaces__srv__GetLoggerLevels_Request__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<GetLoggerLevels_Request>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<GetLoggerLevels_Request>,
+        ) -> bool;
+    }
+
+    // Corresponds to rcl_interfaces__srv__GetLoggerLevels_Request
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct GetLoggerLevels_Request {
+        pub names: rosidl_runtime_rs::Sequence<rosidl_runtime_rs::String>,
+    }
+
+    impl Default for GetLoggerLevels_Request {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !rcl_interfaces__srv__GetLoggerLevels_Request__init(&mut msg as *mut _) {
+                    panic!("Call to rcl_interfaces__srv__GetLoggerLevels_Request__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for GetLoggerLevels_Request {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__GetLoggerLevels_Request__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__srv__GetLoggerLevels_Request__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__GetLoggerLevels_Request__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for GetLoggerLevels_Request {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for GetLoggerLevels_Request
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "rcl_interfaces/srv/GetLoggerLevels_Request";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__GetLoggerLevels_Request()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__GetLoggerLevels_Response(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn rcl_interfaces__srv__GetLoggerLevels_Response__init(
+            msg: *mut GetLoggerLevels_Response,
+        ) -> bool;
+        fn rcl_interfaces__srv__GetLoggerLevels_Response__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<GetLoggerLevels_Response>,
+            size: usize,
+        ) -> bool;
+        fn rcl_interfaces__srv__GetLoggerLevels_Response__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<GetLoggerLevels_Response>,
+        );
+        fn rcl_interfaces__srv__GetLoggerLevels_Response__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<GetLoggerLevels_Response>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<GetLoggerLevels_Response>,
+        ) -> bool;
+    }
+
+    // Corresponds to rcl_interfaces__srv__GetLoggerLevels_Response
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct GetLoggerLevels_Response {
+        pub levels:
+            rosidl_runtime_rs::Sequence<crate::vendor::rcl_interfaces::msg::rmw::LoggerLevel>,
+    }
+
+    impl Default for GetLoggerLevels_Response {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !rcl_interfaces__srv__GetLoggerLevels_Response__init(&mut msg as *mut _) {
+                    panic!("Call to rcl_interfaces__srv__GetLoggerLevels_Response__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for GetLoggerLevels_Response {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__GetLoggerLevels_Response__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__srv__GetLoggerLevels_Response__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__GetLoggerLevels_Response__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for GetLoggerLevels_Response {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for GetLoggerLevels_Response
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "rcl_interfaces/srv/GetLoggerLevels_Response";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__GetLoggerLevels_Response()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__SetLoggerLevels_Request(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn rcl_interfaces__srv__SetLoggerLevels_Request__init(
+            msg: *mut SetLoggerLevels_Request,
+        ) -> bool;
+        fn rcl_interfaces__srv__SetLoggerLevels_Request__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<SetLoggerLevels_Request>,
+            size: usize,
+        ) -> bool;
+        fn rcl_interfaces__srv__SetLoggerLevels_Request__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<SetLoggerLevels_Request>,
+        );
+        fn rcl_interfaces__srv__SetLoggerLevels_Request__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<SetLoggerLevels_Request>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<SetLoggerLevels_Request>,
+        ) -> bool;
+    }
+
+    // Corresponds to rcl_interfaces__srv__SetLoggerLevels_Request
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct SetLoggerLevels_Request {
+        pub levels:
+            rosidl_runtime_rs::Sequence<crate::vendor::rcl_interfaces::msg::rmw::LoggerLevel>,
+    }
+
+    impl Default for SetLoggerLevels_Request {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !rcl_interfaces__srv__SetLoggerLevels_Request__init(&mut msg as *mut _) {
+                    panic!("Call to rcl_interfaces__srv__SetLoggerLevels_Request__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for SetLoggerLevels_Request {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__SetLoggerLevels_Request__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__srv__SetLoggerLevels_Request__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__SetLoggerLevels_Request__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for SetLoggerLevels_Request {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for SetLoggerLevels_Request
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "rcl_interfaces/srv/SetLoggerLevels_Request";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__SetLoggerLevels_Request()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__SetLoggerLevels_Response(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_generator_c")]
+    extern "C" {
+        fn rcl_interfaces__srv__SetLoggerLevels_Response__init(
+            msg: *mut SetLoggerLevels_Response,
+        ) -> bool;
+        fn rcl_interfaces__srv__SetLoggerLevels_Response__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<SetLoggerLevels_Response>,
+            size: usize,
+        ) -> bool;
+        fn rcl_interfaces__srv__SetLoggerLevels_Response__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<SetLoggerLevels_Response>,
+        );
+        fn rcl_interfaces__srv__SetLoggerLevels_Response__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<SetLoggerLevels_Response>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<SetLoggerLevels_Response>,
+        ) -> bool;
+    }
+
+    // Corresponds to rcl_interfaces__srv__SetLoggerLevels_Response
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct SetLoggerLevels_Response {
+        pub results: rosidl_runtime_rs::Sequence<
+            crate::vendor::rcl_interfaces::msg::rmw::SetLoggerLevelsResult,
+        >,
+    }
+
+    impl Default for SetLoggerLevels_Response {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !rcl_interfaces__srv__SetLoggerLevels_Response__init(&mut msg as *mut _) {
+                    panic!("Call to rcl_interfaces__srv__SetLoggerLevels_Response__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for SetLoggerLevels_Response {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__SetLoggerLevels_Response__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { rcl_interfaces__srv__SetLoggerLevels_Response__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                rcl_interfaces__srv__SetLoggerLevels_Response__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for SetLoggerLevels_Response {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for SetLoggerLevels_Response
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "rcl_interfaces/srv/SetLoggerLevels_Response";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__rcl_interfaces__srv__SetLoggerLevels_Response()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
         fn rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__DescribeParameters(
         ) -> *const std::ffi::c_void;
     }
@@ -1998,6 +2630,48 @@ pub mod rmw {
             // SAFETY: No preconditions for this function.
             unsafe {
                 rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__SetParameters()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__GetLoggerLevels(
+        ) -> *const std::ffi::c_void;
+    }
+
+    // Corresponds to rcl_interfaces__srv__GetLoggerLevels
+    pub struct GetLoggerLevels;
+
+    impl rosidl_runtime_rs::Service for GetLoggerLevels {
+        type Request = crate::vendor::rcl_interfaces::srv::rmw::GetLoggerLevels_Request;
+        type Response = crate::vendor::rcl_interfaces::srv::rmw::GetLoggerLevels_Response;
+
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__GetLoggerLevels()
+            }
+        }
+    }
+
+    #[link(name = "rcl_interfaces__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__SetLoggerLevels(
+        ) -> *const std::ffi::c_void;
+    }
+
+    // Corresponds to rcl_interfaces__srv__SetLoggerLevels
+    pub struct SetLoggerLevels;
+
+    impl rosidl_runtime_rs::Service for SetLoggerLevels {
+        type Request = crate::vendor::rcl_interfaces::srv::rmw::SetLoggerLevels_Request;
+        type Response = crate::vendor::rcl_interfaces::srv::rmw::SetLoggerLevels_Response;
+
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_service_type_support_handle__rcl_interfaces__srv__SetLoggerLevels()
             }
         }
     }

--- a/rclrs/src/vendor/test_msgs/action.rs
+++ b/rclrs/src/vendor/test_msgs/action.rs
@@ -1,0 +1,2750 @@
+pub mod rmw {
+    #[cfg(feature = "serde")]
+    use serde::{Deserialize, Serialize};
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__Fibonacci_Goal(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__action__Fibonacci_Goal__init(msg: *mut Fibonacci_Goal) -> bool;
+        fn test_msgs__action__Fibonacci_Goal__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_Goal>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__action__Fibonacci_Goal__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_Goal>,
+        );
+        fn test_msgs__action__Fibonacci_Goal__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Fibonacci_Goal>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_Goal>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__action__Fibonacci_Goal
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Fibonacci_Goal {
+        pub order: i32,
+    }
+
+    impl Default for Fibonacci_Goal {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__action__Fibonacci_Goal__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__action__Fibonacci_Goal__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Fibonacci_Goal {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__action__Fibonacci_Goal__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__action__Fibonacci_Goal__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__action__Fibonacci_Goal__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Fibonacci_Goal {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Fibonacci_Goal
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/action/Fibonacci_Goal";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__Fibonacci_Goal()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__Fibonacci_Result(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__action__Fibonacci_Result__init(msg: *mut Fibonacci_Result) -> bool;
+        fn test_msgs__action__Fibonacci_Result__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_Result>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__action__Fibonacci_Result__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_Result>,
+        );
+        fn test_msgs__action__Fibonacci_Result__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Fibonacci_Result>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_Result>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__action__Fibonacci_Result
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Fibonacci_Result {
+        pub sequence: rosidl_runtime_rs::Sequence<i32>,
+    }
+
+    impl Default for Fibonacci_Result {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__action__Fibonacci_Result__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__action__Fibonacci_Result__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Fibonacci_Result {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__action__Fibonacci_Result__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__action__Fibonacci_Result__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__Fibonacci_Result__Sequence__copy(in_seq, out_seq as *mut _)
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Fibonacci_Result {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Fibonacci_Result
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/action/Fibonacci_Result";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__Fibonacci_Result()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__Fibonacci_Feedback(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__action__Fibonacci_Feedback__init(msg: *mut Fibonacci_Feedback) -> bool;
+        fn test_msgs__action__Fibonacci_Feedback__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_Feedback>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__action__Fibonacci_Feedback__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_Feedback>,
+        );
+        fn test_msgs__action__Fibonacci_Feedback__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Fibonacci_Feedback>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_Feedback>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__action__Fibonacci_Feedback
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Fibonacci_Feedback {
+        pub sequence: rosidl_runtime_rs::Sequence<i32>,
+    }
+
+    impl Default for Fibonacci_Feedback {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__action__Fibonacci_Feedback__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__action__Fibonacci_Feedback__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Fibonacci_Feedback {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__action__Fibonacci_Feedback__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__action__Fibonacci_Feedback__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__Fibonacci_Feedback__Sequence__copy(in_seq, out_seq as *mut _)
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Fibonacci_Feedback {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Fibonacci_Feedback
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/action/Fibonacci_Feedback";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__Fibonacci_Feedback()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__Fibonacci_FeedbackMessage(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__action__Fibonacci_FeedbackMessage__init(
+            msg: *mut Fibonacci_FeedbackMessage,
+        ) -> bool;
+        fn test_msgs__action__Fibonacci_FeedbackMessage__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_FeedbackMessage>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__action__Fibonacci_FeedbackMessage__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_FeedbackMessage>,
+        );
+        fn test_msgs__action__Fibonacci_FeedbackMessage__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Fibonacci_FeedbackMessage>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_FeedbackMessage>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__action__Fibonacci_FeedbackMessage
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Fibonacci_FeedbackMessage {
+        pub goal_id: crate::vendor::unique_identifier_msgs::msg::rmw::UUID,
+        pub feedback: crate::vendor::test_msgs::action::rmw::Fibonacci_Feedback,
+    }
+
+    impl Default for Fibonacci_FeedbackMessage {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__action__Fibonacci_FeedbackMessage__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__action__Fibonacci_FeedbackMessage__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Fibonacci_FeedbackMessage {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__Fibonacci_FeedbackMessage__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__action__Fibonacci_FeedbackMessage__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__Fibonacci_FeedbackMessage__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Fibonacci_FeedbackMessage {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Fibonacci_FeedbackMessage
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/action/Fibonacci_FeedbackMessage";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__Fibonacci_FeedbackMessage()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__NestedMessage_Goal(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__action__NestedMessage_Goal__init(msg: *mut NestedMessage_Goal) -> bool;
+        fn test_msgs__action__NestedMessage_Goal__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<NestedMessage_Goal>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__action__NestedMessage_Goal__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<NestedMessage_Goal>,
+        );
+        fn test_msgs__action__NestedMessage_Goal__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<NestedMessage_Goal>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<NestedMessage_Goal>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__action__NestedMessage_Goal
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct NestedMessage_Goal {
+        pub nested_field_no_pkg: crate::vendor::test_msgs::msg::rmw::Builtins,
+        pub nested_field: crate::vendor::test_msgs::msg::rmw::BasicTypes,
+        pub nested_different_pkg: crate::vendor::builtin_interfaces::msg::rmw::Time,
+    }
+
+    impl Default for NestedMessage_Goal {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__action__NestedMessage_Goal__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__action__NestedMessage_Goal__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for NestedMessage_Goal {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__action__NestedMessage_Goal__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__action__NestedMessage_Goal__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__NestedMessage_Goal__Sequence__copy(in_seq, out_seq as *mut _)
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for NestedMessage_Goal {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for NestedMessage_Goal
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/action/NestedMessage_Goal";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__NestedMessage_Goal()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__NestedMessage_Result(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__action__NestedMessage_Result__init(msg: *mut NestedMessage_Result) -> bool;
+        fn test_msgs__action__NestedMessage_Result__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<NestedMessage_Result>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__action__NestedMessage_Result__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<NestedMessage_Result>,
+        );
+        fn test_msgs__action__NestedMessage_Result__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<NestedMessage_Result>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<NestedMessage_Result>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__action__NestedMessage_Result
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct NestedMessage_Result {
+        pub nested_field_no_pkg: crate::vendor::test_msgs::msg::rmw::Builtins,
+        pub nested_field: crate::vendor::test_msgs::msg::rmw::BasicTypes,
+        pub nested_different_pkg: crate::vendor::builtin_interfaces::msg::rmw::Time,
+    }
+
+    impl Default for NestedMessage_Result {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__action__NestedMessage_Result__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__action__NestedMessage_Result__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for NestedMessage_Result {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__action__NestedMessage_Result__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__action__NestedMessage_Result__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__NestedMessage_Result__Sequence__copy(in_seq, out_seq as *mut _)
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for NestedMessage_Result {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for NestedMessage_Result
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/action/NestedMessage_Result";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__NestedMessage_Result()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__NestedMessage_Feedback(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__action__NestedMessage_Feedback__init(
+            msg: *mut NestedMessage_Feedback,
+        ) -> bool;
+        fn test_msgs__action__NestedMessage_Feedback__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<NestedMessage_Feedback>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__action__NestedMessage_Feedback__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<NestedMessage_Feedback>,
+        );
+        fn test_msgs__action__NestedMessage_Feedback__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<NestedMessage_Feedback>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<NestedMessage_Feedback>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__action__NestedMessage_Feedback
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct NestedMessage_Feedback {
+        pub nested_field_no_pkg: crate::vendor::test_msgs::msg::rmw::Builtins,
+        pub nested_field: crate::vendor::test_msgs::msg::rmw::BasicTypes,
+        pub nested_different_pkg: crate::vendor::builtin_interfaces::msg::rmw::Time,
+    }
+
+    impl Default for NestedMessage_Feedback {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__action__NestedMessage_Feedback__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__action__NestedMessage_Feedback__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for NestedMessage_Feedback {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__NestedMessage_Feedback__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__action__NestedMessage_Feedback__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__NestedMessage_Feedback__Sequence__copy(in_seq, out_seq as *mut _)
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for NestedMessage_Feedback {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for NestedMessage_Feedback
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/action/NestedMessage_Feedback";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__NestedMessage_Feedback()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__NestedMessage_FeedbackMessage(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__action__NestedMessage_FeedbackMessage__init(
+            msg: *mut NestedMessage_FeedbackMessage,
+        ) -> bool;
+        fn test_msgs__action__NestedMessage_FeedbackMessage__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<NestedMessage_FeedbackMessage>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__action__NestedMessage_FeedbackMessage__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<NestedMessage_FeedbackMessage>,
+        );
+        fn test_msgs__action__NestedMessage_FeedbackMessage__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<NestedMessage_FeedbackMessage>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<NestedMessage_FeedbackMessage>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__action__NestedMessage_FeedbackMessage
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct NestedMessage_FeedbackMessage {
+        pub goal_id: crate::vendor::unique_identifier_msgs::msg::rmw::UUID,
+        pub feedback: crate::vendor::test_msgs::action::rmw::NestedMessage_Feedback,
+    }
+
+    impl Default for NestedMessage_FeedbackMessage {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__action__NestedMessage_FeedbackMessage__init(&mut msg as *mut _) {
+                    panic!(
+                        "Call to test_msgs__action__NestedMessage_FeedbackMessage__init() failed"
+                    );
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for NestedMessage_FeedbackMessage {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__NestedMessage_FeedbackMessage__Sequence__init(
+                    seq as *mut _,
+                    size,
+                )
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__NestedMessage_FeedbackMessage__Sequence__fini(seq as *mut _)
+            }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__NestedMessage_FeedbackMessage__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for NestedMessage_FeedbackMessage {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for NestedMessage_FeedbackMessage
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/action/NestedMessage_FeedbackMessage";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__NestedMessage_FeedbackMessage()
+            }
+        }
+    }
+
+    #[cfg(feature = "serde")]
+    use serde::{Deserialize, Serialize};
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__Fibonacci_SendGoal_Request(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__action__Fibonacci_SendGoal_Request__init(
+            msg: *mut Fibonacci_SendGoal_Request,
+        ) -> bool;
+        fn test_msgs__action__Fibonacci_SendGoal_Request__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_SendGoal_Request>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__action__Fibonacci_SendGoal_Request__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_SendGoal_Request>,
+        );
+        fn test_msgs__action__Fibonacci_SendGoal_Request__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Fibonacci_SendGoal_Request>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_SendGoal_Request>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__action__Fibonacci_SendGoal_Request
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Fibonacci_SendGoal_Request {
+        pub goal_id: crate::vendor::unique_identifier_msgs::msg::rmw::UUID,
+        pub goal: crate::vendor::test_msgs::action::rmw::Fibonacci_Goal,
+    }
+
+    impl Default for Fibonacci_SendGoal_Request {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__action__Fibonacci_SendGoal_Request__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__action__Fibonacci_SendGoal_Request__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Fibonacci_SendGoal_Request {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__Fibonacci_SendGoal_Request__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__action__Fibonacci_SendGoal_Request__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__Fibonacci_SendGoal_Request__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Fibonacci_SendGoal_Request {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Fibonacci_SendGoal_Request
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/action/Fibonacci_SendGoal_Request";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__Fibonacci_SendGoal_Request()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__Fibonacci_SendGoal_Response(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__action__Fibonacci_SendGoal_Response__init(
+            msg: *mut Fibonacci_SendGoal_Response,
+        ) -> bool;
+        fn test_msgs__action__Fibonacci_SendGoal_Response__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_SendGoal_Response>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__action__Fibonacci_SendGoal_Response__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_SendGoal_Response>,
+        );
+        fn test_msgs__action__Fibonacci_SendGoal_Response__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Fibonacci_SendGoal_Response>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_SendGoal_Response>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__action__Fibonacci_SendGoal_Response
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Fibonacci_SendGoal_Response {
+        pub accepted: bool,
+        pub stamp: crate::vendor::builtin_interfaces::msg::rmw::Time,
+    }
+
+    impl Default for Fibonacci_SendGoal_Response {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__action__Fibonacci_SendGoal_Response__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__action__Fibonacci_SendGoal_Response__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Fibonacci_SendGoal_Response {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__Fibonacci_SendGoal_Response__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__action__Fibonacci_SendGoal_Response__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__Fibonacci_SendGoal_Response__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Fibonacci_SendGoal_Response {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Fibonacci_SendGoal_Response
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/action/Fibonacci_SendGoal_Response";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__Fibonacci_SendGoal_Response()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__Fibonacci_GetResult_Request(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__action__Fibonacci_GetResult_Request__init(
+            msg: *mut Fibonacci_GetResult_Request,
+        ) -> bool;
+        fn test_msgs__action__Fibonacci_GetResult_Request__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_GetResult_Request>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__action__Fibonacci_GetResult_Request__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_GetResult_Request>,
+        );
+        fn test_msgs__action__Fibonacci_GetResult_Request__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Fibonacci_GetResult_Request>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_GetResult_Request>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__action__Fibonacci_GetResult_Request
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Fibonacci_GetResult_Request {
+        pub goal_id: crate::vendor::unique_identifier_msgs::msg::rmw::UUID,
+    }
+
+    impl Default for Fibonacci_GetResult_Request {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__action__Fibonacci_GetResult_Request__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__action__Fibonacci_GetResult_Request__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Fibonacci_GetResult_Request {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__Fibonacci_GetResult_Request__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__action__Fibonacci_GetResult_Request__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__Fibonacci_GetResult_Request__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Fibonacci_GetResult_Request {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Fibonacci_GetResult_Request
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/action/Fibonacci_GetResult_Request";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__Fibonacci_GetResult_Request()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__Fibonacci_GetResult_Response(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__action__Fibonacci_GetResult_Response__init(
+            msg: *mut Fibonacci_GetResult_Response,
+        ) -> bool;
+        fn test_msgs__action__Fibonacci_GetResult_Response__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_GetResult_Response>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__action__Fibonacci_GetResult_Response__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_GetResult_Response>,
+        );
+        fn test_msgs__action__Fibonacci_GetResult_Response__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Fibonacci_GetResult_Response>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Fibonacci_GetResult_Response>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__action__Fibonacci_GetResult_Response
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Fibonacci_GetResult_Response {
+        pub status: i8,
+        pub result: crate::vendor::test_msgs::action::rmw::Fibonacci_Result,
+    }
+
+    impl Default for Fibonacci_GetResult_Response {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__action__Fibonacci_GetResult_Response__init(&mut msg as *mut _) {
+                    panic!(
+                        "Call to test_msgs__action__Fibonacci_GetResult_Response__init() failed"
+                    );
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Fibonacci_GetResult_Response {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__Fibonacci_GetResult_Response__Sequence__init(seq as *mut _, size)
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__Fibonacci_GetResult_Response__Sequence__fini(seq as *mut _)
+            }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__Fibonacci_GetResult_Response__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Fibonacci_GetResult_Response {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Fibonacci_GetResult_Response
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/action/Fibonacci_GetResult_Response";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__Fibonacci_GetResult_Response()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__NestedMessage_SendGoal_Request(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__action__NestedMessage_SendGoal_Request__init(
+            msg: *mut NestedMessage_SendGoal_Request,
+        ) -> bool;
+        fn test_msgs__action__NestedMessage_SendGoal_Request__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<NestedMessage_SendGoal_Request>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__action__NestedMessage_SendGoal_Request__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<NestedMessage_SendGoal_Request>,
+        );
+        fn test_msgs__action__NestedMessage_SendGoal_Request__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<NestedMessage_SendGoal_Request>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<NestedMessage_SendGoal_Request>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__action__NestedMessage_SendGoal_Request
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct NestedMessage_SendGoal_Request {
+        pub goal_id: crate::vendor::unique_identifier_msgs::msg::rmw::UUID,
+        pub goal: crate::vendor::test_msgs::action::rmw::NestedMessage_Goal,
+    }
+
+    impl Default for NestedMessage_SendGoal_Request {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__action__NestedMessage_SendGoal_Request__init(&mut msg as *mut _) {
+                    panic!(
+                        "Call to test_msgs__action__NestedMessage_SendGoal_Request__init() failed"
+                    );
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for NestedMessage_SendGoal_Request {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__NestedMessage_SendGoal_Request__Sequence__init(
+                    seq as *mut _,
+                    size,
+                )
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__NestedMessage_SendGoal_Request__Sequence__fini(seq as *mut _)
+            }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__NestedMessage_SendGoal_Request__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for NestedMessage_SendGoal_Request {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for NestedMessage_SendGoal_Request
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/action/NestedMessage_SendGoal_Request";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__NestedMessage_SendGoal_Request()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__NestedMessage_SendGoal_Response(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__action__NestedMessage_SendGoal_Response__init(
+            msg: *mut NestedMessage_SendGoal_Response,
+        ) -> bool;
+        fn test_msgs__action__NestedMessage_SendGoal_Response__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<NestedMessage_SendGoal_Response>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__action__NestedMessage_SendGoal_Response__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<NestedMessage_SendGoal_Response>,
+        );
+        fn test_msgs__action__NestedMessage_SendGoal_Response__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<NestedMessage_SendGoal_Response>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<NestedMessage_SendGoal_Response>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__action__NestedMessage_SendGoal_Response
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct NestedMessage_SendGoal_Response {
+        pub accepted: bool,
+        pub stamp: crate::vendor::builtin_interfaces::msg::rmw::Time,
+    }
+
+    impl Default for NestedMessage_SendGoal_Response {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__action__NestedMessage_SendGoal_Response__init(&mut msg as *mut _) {
+                    panic!(
+                        "Call to test_msgs__action__NestedMessage_SendGoal_Response__init() failed"
+                    );
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for NestedMessage_SendGoal_Response {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__NestedMessage_SendGoal_Response__Sequence__init(
+                    seq as *mut _,
+                    size,
+                )
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__NestedMessage_SendGoal_Response__Sequence__fini(seq as *mut _)
+            }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__NestedMessage_SendGoal_Response__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for NestedMessage_SendGoal_Response {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for NestedMessage_SendGoal_Response
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/action/NestedMessage_SendGoal_Response";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__NestedMessage_SendGoal_Response()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__NestedMessage_GetResult_Request(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__action__NestedMessage_GetResult_Request__init(
+            msg: *mut NestedMessage_GetResult_Request,
+        ) -> bool;
+        fn test_msgs__action__NestedMessage_GetResult_Request__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<NestedMessage_GetResult_Request>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__action__NestedMessage_GetResult_Request__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<NestedMessage_GetResult_Request>,
+        );
+        fn test_msgs__action__NestedMessage_GetResult_Request__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<NestedMessage_GetResult_Request>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<NestedMessage_GetResult_Request>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__action__NestedMessage_GetResult_Request
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct NestedMessage_GetResult_Request {
+        pub goal_id: crate::vendor::unique_identifier_msgs::msg::rmw::UUID,
+    }
+
+    impl Default for NestedMessage_GetResult_Request {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__action__NestedMessage_GetResult_Request__init(&mut msg as *mut _) {
+                    panic!(
+                        "Call to test_msgs__action__NestedMessage_GetResult_Request__init() failed"
+                    );
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for NestedMessage_GetResult_Request {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__NestedMessage_GetResult_Request__Sequence__init(
+                    seq as *mut _,
+                    size,
+                )
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__NestedMessage_GetResult_Request__Sequence__fini(seq as *mut _)
+            }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__NestedMessage_GetResult_Request__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for NestedMessage_GetResult_Request {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for NestedMessage_GetResult_Request
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/action/NestedMessage_GetResult_Request";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__NestedMessage_GetResult_Request()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__NestedMessage_GetResult_Response(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__action__NestedMessage_GetResult_Response__init(
+            msg: *mut NestedMessage_GetResult_Response,
+        ) -> bool;
+        fn test_msgs__action__NestedMessage_GetResult_Response__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<NestedMessage_GetResult_Response>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__action__NestedMessage_GetResult_Response__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<NestedMessage_GetResult_Response>,
+        );
+        fn test_msgs__action__NestedMessage_GetResult_Response__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<NestedMessage_GetResult_Response>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<NestedMessage_GetResult_Response>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__action__NestedMessage_GetResult_Response
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct NestedMessage_GetResult_Response {
+        pub status: i8,
+        pub result: crate::vendor::test_msgs::action::rmw::NestedMessage_Result,
+    }
+
+    impl Default for NestedMessage_GetResult_Response {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__action__NestedMessage_GetResult_Response__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__action__NestedMessage_GetResult_Response__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for NestedMessage_GetResult_Response {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__NestedMessage_GetResult_Response__Sequence__init(
+                    seq as *mut _,
+                    size,
+                )
+            }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__NestedMessage_GetResult_Response__Sequence__fini(seq as *mut _)
+            }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__action__NestedMessage_GetResult_Response__Sequence__copy(
+                    in_seq,
+                    out_seq as *mut _,
+                )
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for NestedMessage_GetResult_Response {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for NestedMessage_GetResult_Response
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/action/NestedMessage_GetResult_Response";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__action__NestedMessage_GetResult_Response()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_service_type_support_handle__test_msgs__action__Fibonacci_SendGoal(
+        ) -> *const std::ffi::c_void;
+    }
+
+    // Corresponds to test_msgs__action__Fibonacci_SendGoal
+    pub struct Fibonacci_SendGoal;
+
+    impl rosidl_runtime_rs::Service for Fibonacci_SendGoal {
+        type Request = crate::vendor::test_msgs::action::rmw::Fibonacci_SendGoal_Request;
+        type Response = crate::vendor::test_msgs::action::rmw::Fibonacci_SendGoal_Response;
+
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_service_type_support_handle__test_msgs__action__Fibonacci_SendGoal()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_service_type_support_handle__test_msgs__action__Fibonacci_GetResult(
+        ) -> *const std::ffi::c_void;
+    }
+
+    // Corresponds to test_msgs__action__Fibonacci_GetResult
+    pub struct Fibonacci_GetResult;
+
+    impl rosidl_runtime_rs::Service for Fibonacci_GetResult {
+        type Request = crate::vendor::test_msgs::action::rmw::Fibonacci_GetResult_Request;
+        type Response = crate::vendor::test_msgs::action::rmw::Fibonacci_GetResult_Response;
+
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_service_type_support_handle__test_msgs__action__Fibonacci_GetResult()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_service_type_support_handle__test_msgs__action__NestedMessage_SendGoal(
+        ) -> *const std::ffi::c_void;
+    }
+
+    // Corresponds to test_msgs__action__NestedMessage_SendGoal
+    pub struct NestedMessage_SendGoal;
+
+    impl rosidl_runtime_rs::Service for NestedMessage_SendGoal {
+        type Request = crate::vendor::test_msgs::action::rmw::NestedMessage_SendGoal_Request;
+        type Response = crate::vendor::test_msgs::action::rmw::NestedMessage_SendGoal_Response;
+
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_service_type_support_handle__test_msgs__action__NestedMessage_SendGoal()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_service_type_support_handle__test_msgs__action__NestedMessage_GetResult(
+        ) -> *const std::ffi::c_void;
+    }
+
+    // Corresponds to test_msgs__action__NestedMessage_GetResult
+    pub struct NestedMessage_GetResult;
+
+    impl rosidl_runtime_rs::Service for NestedMessage_GetResult {
+        type Request = crate::vendor::test_msgs::action::rmw::NestedMessage_GetResult_Request;
+        type Response = crate::vendor::test_msgs::action::rmw::NestedMessage_GetResult_Response;
+
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_service_type_support_handle__test_msgs__action__NestedMessage_GetResult()
+            }
+        }
+    }
+} // mod rmw
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Fibonacci_Goal {
+    pub order: i32,
+}
+
+impl Default for Fibonacci_Goal {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::action::rmw::Fibonacci_Goal::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Fibonacci_Goal {
+    type RmwMsg = crate::vendor::test_msgs::action::rmw::Fibonacci_Goal;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { order: msg.order })
+            }
+            std::borrow::Cow::Borrowed(msg) => {
+                std::borrow::Cow::Owned(Self::RmwMsg { order: msg.order })
+            }
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self { order: msg.order }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Fibonacci_Result {
+    pub sequence: Vec<i32>,
+}
+
+impl Default for Fibonacci_Result {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::action::rmw::Fibonacci_Result::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Fibonacci_Result {
+    type RmwMsg = crate::vendor::test_msgs::action::rmw::Fibonacci_Result;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                sequence: msg.sequence.into(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                sequence: msg.sequence.as_slice().into(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            sequence: msg.sequence.into_iter().collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Fibonacci_Feedback {
+    pub sequence: Vec<i32>,
+}
+
+impl Default for Fibonacci_Feedback {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::action::rmw::Fibonacci_Feedback::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Fibonacci_Feedback {
+    type RmwMsg = crate::vendor::test_msgs::action::rmw::Fibonacci_Feedback;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                sequence: msg.sequence.into(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                sequence: msg.sequence.as_slice().into(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            sequence: msg.sequence.into_iter().collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Fibonacci_FeedbackMessage {
+    pub goal_id: crate::vendor::unique_identifier_msgs::msg::UUID,
+    pub feedback: crate::vendor::test_msgs::action::Fibonacci_Feedback,
+}
+
+impl Default for Fibonacci_FeedbackMessage {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::action::rmw::Fibonacci_FeedbackMessage::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Fibonacci_FeedbackMessage {
+    type RmwMsg = crate::vendor::test_msgs::action::rmw::Fibonacci_FeedbackMessage;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                goal_id: crate::vendor::unique_identifier_msgs::msg::UUID::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.goal_id),
+                )
+                .into_owned(),
+                feedback: crate::vendor::test_msgs::action::Fibonacci_Feedback::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.feedback),
+                )
+                .into_owned(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                goal_id: crate::vendor::unique_identifier_msgs::msg::UUID::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.goal_id),
+                )
+                .into_owned(),
+                feedback: crate::vendor::test_msgs::action::Fibonacci_Feedback::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.feedback),
+                )
+                .into_owned(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            goal_id: crate::vendor::unique_identifier_msgs::msg::UUID::from_rmw_message(
+                msg.goal_id,
+            ),
+            feedback: crate::vendor::test_msgs::action::Fibonacci_Feedback::from_rmw_message(
+                msg.feedback,
+            ),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct NestedMessage_Goal {
+    pub nested_field_no_pkg: crate::vendor::test_msgs::msg::Builtins,
+    pub nested_field: crate::vendor::test_msgs::msg::BasicTypes,
+    pub nested_different_pkg: crate::vendor::builtin_interfaces::msg::Time,
+}
+
+impl Default for NestedMessage_Goal {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::action::rmw::NestedMessage_Goal::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for NestedMessage_Goal {
+    type RmwMsg = crate::vendor::test_msgs::action::rmw::NestedMessage_Goal;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                nested_field_no_pkg: crate::vendor::test_msgs::msg::Builtins::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.nested_field_no_pkg),
+                )
+                .into_owned(),
+                nested_field: crate::vendor::test_msgs::msg::BasicTypes::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.nested_field),
+                )
+                .into_owned(),
+                nested_different_pkg:
+                    crate::vendor::builtin_interfaces::msg::Time::into_rmw_message(
+                        std::borrow::Cow::Owned(msg.nested_different_pkg),
+                    )
+                    .into_owned(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                nested_field_no_pkg: crate::vendor::test_msgs::msg::Builtins::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.nested_field_no_pkg),
+                )
+                .into_owned(),
+                nested_field: crate::vendor::test_msgs::msg::BasicTypes::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.nested_field),
+                )
+                .into_owned(),
+                nested_different_pkg:
+                    crate::vendor::builtin_interfaces::msg::Time::into_rmw_message(
+                        std::borrow::Cow::Borrowed(&msg.nested_different_pkg),
+                    )
+                    .into_owned(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            nested_field_no_pkg: crate::vendor::test_msgs::msg::Builtins::from_rmw_message(
+                msg.nested_field_no_pkg,
+            ),
+            nested_field: crate::vendor::test_msgs::msg::BasicTypes::from_rmw_message(
+                msg.nested_field,
+            ),
+            nested_different_pkg: crate::vendor::builtin_interfaces::msg::Time::from_rmw_message(
+                msg.nested_different_pkg,
+            ),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct NestedMessage_Result {
+    pub nested_field_no_pkg: crate::vendor::test_msgs::msg::Builtins,
+    pub nested_field: crate::vendor::test_msgs::msg::BasicTypes,
+    pub nested_different_pkg: crate::vendor::builtin_interfaces::msg::Time,
+}
+
+impl Default for NestedMessage_Result {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::action::rmw::NestedMessage_Result::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for NestedMessage_Result {
+    type RmwMsg = crate::vendor::test_msgs::action::rmw::NestedMessage_Result;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                nested_field_no_pkg: crate::vendor::test_msgs::msg::Builtins::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.nested_field_no_pkg),
+                )
+                .into_owned(),
+                nested_field: crate::vendor::test_msgs::msg::BasicTypes::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.nested_field),
+                )
+                .into_owned(),
+                nested_different_pkg:
+                    crate::vendor::builtin_interfaces::msg::Time::into_rmw_message(
+                        std::borrow::Cow::Owned(msg.nested_different_pkg),
+                    )
+                    .into_owned(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                nested_field_no_pkg: crate::vendor::test_msgs::msg::Builtins::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.nested_field_no_pkg),
+                )
+                .into_owned(),
+                nested_field: crate::vendor::test_msgs::msg::BasicTypes::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.nested_field),
+                )
+                .into_owned(),
+                nested_different_pkg:
+                    crate::vendor::builtin_interfaces::msg::Time::into_rmw_message(
+                        std::borrow::Cow::Borrowed(&msg.nested_different_pkg),
+                    )
+                    .into_owned(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            nested_field_no_pkg: crate::vendor::test_msgs::msg::Builtins::from_rmw_message(
+                msg.nested_field_no_pkg,
+            ),
+            nested_field: crate::vendor::test_msgs::msg::BasicTypes::from_rmw_message(
+                msg.nested_field,
+            ),
+            nested_different_pkg: crate::vendor::builtin_interfaces::msg::Time::from_rmw_message(
+                msg.nested_different_pkg,
+            ),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct NestedMessage_Feedback {
+    pub nested_field_no_pkg: crate::vendor::test_msgs::msg::Builtins,
+    pub nested_field: crate::vendor::test_msgs::msg::BasicTypes,
+    pub nested_different_pkg: crate::vendor::builtin_interfaces::msg::Time,
+}
+
+impl Default for NestedMessage_Feedback {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::action::rmw::NestedMessage_Feedback::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for NestedMessage_Feedback {
+    type RmwMsg = crate::vendor::test_msgs::action::rmw::NestedMessage_Feedback;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                nested_field_no_pkg: crate::vendor::test_msgs::msg::Builtins::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.nested_field_no_pkg),
+                )
+                .into_owned(),
+                nested_field: crate::vendor::test_msgs::msg::BasicTypes::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.nested_field),
+                )
+                .into_owned(),
+                nested_different_pkg:
+                    crate::vendor::builtin_interfaces::msg::Time::into_rmw_message(
+                        std::borrow::Cow::Owned(msg.nested_different_pkg),
+                    )
+                    .into_owned(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                nested_field_no_pkg: crate::vendor::test_msgs::msg::Builtins::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.nested_field_no_pkg),
+                )
+                .into_owned(),
+                nested_field: crate::vendor::test_msgs::msg::BasicTypes::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.nested_field),
+                )
+                .into_owned(),
+                nested_different_pkg:
+                    crate::vendor::builtin_interfaces::msg::Time::into_rmw_message(
+                        std::borrow::Cow::Borrowed(&msg.nested_different_pkg),
+                    )
+                    .into_owned(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            nested_field_no_pkg: crate::vendor::test_msgs::msg::Builtins::from_rmw_message(
+                msg.nested_field_no_pkg,
+            ),
+            nested_field: crate::vendor::test_msgs::msg::BasicTypes::from_rmw_message(
+                msg.nested_field,
+            ),
+            nested_different_pkg: crate::vendor::builtin_interfaces::msg::Time::from_rmw_message(
+                msg.nested_different_pkg,
+            ),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct NestedMessage_FeedbackMessage {
+    pub goal_id: crate::vendor::unique_identifier_msgs::msg::UUID,
+    pub feedback: crate::vendor::test_msgs::action::NestedMessage_Feedback,
+}
+
+impl Default for NestedMessage_FeedbackMessage {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::action::rmw::NestedMessage_FeedbackMessage::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for NestedMessage_FeedbackMessage {
+    type RmwMsg = crate::vendor::test_msgs::action::rmw::NestedMessage_FeedbackMessage;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                goal_id: crate::vendor::unique_identifier_msgs::msg::UUID::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.goal_id),
+                )
+                .into_owned(),
+                feedback:
+                    crate::vendor::test_msgs::action::NestedMessage_Feedback::into_rmw_message(
+                        std::borrow::Cow::Owned(msg.feedback),
+                    )
+                    .into_owned(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                goal_id: crate::vendor::unique_identifier_msgs::msg::UUID::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.goal_id),
+                )
+                .into_owned(),
+                feedback:
+                    crate::vendor::test_msgs::action::NestedMessage_Feedback::into_rmw_message(
+                        std::borrow::Cow::Borrowed(&msg.feedback),
+                    )
+                    .into_owned(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            goal_id: crate::vendor::unique_identifier_msgs::msg::UUID::from_rmw_message(
+                msg.goal_id,
+            ),
+            feedback: crate::vendor::test_msgs::action::NestedMessage_Feedback::from_rmw_message(
+                msg.feedback,
+            ),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Fibonacci_SendGoal_Request {
+    pub goal_id: crate::vendor::unique_identifier_msgs::msg::UUID,
+    pub goal: crate::vendor::test_msgs::action::Fibonacci_Goal,
+}
+
+impl Default for Fibonacci_SendGoal_Request {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::action::rmw::Fibonacci_SendGoal_Request::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Fibonacci_SendGoal_Request {
+    type RmwMsg = crate::vendor::test_msgs::action::rmw::Fibonacci_SendGoal_Request;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                goal_id: crate::vendor::unique_identifier_msgs::msg::UUID::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.goal_id),
+                )
+                .into_owned(),
+                goal: crate::vendor::test_msgs::action::Fibonacci_Goal::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.goal),
+                )
+                .into_owned(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                goal_id: crate::vendor::unique_identifier_msgs::msg::UUID::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.goal_id),
+                )
+                .into_owned(),
+                goal: crate::vendor::test_msgs::action::Fibonacci_Goal::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.goal),
+                )
+                .into_owned(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            goal_id: crate::vendor::unique_identifier_msgs::msg::UUID::from_rmw_message(
+                msg.goal_id,
+            ),
+            goal: crate::vendor::test_msgs::action::Fibonacci_Goal::from_rmw_message(msg.goal),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Fibonacci_SendGoal_Response {
+    pub accepted: bool,
+    pub stamp: crate::vendor::builtin_interfaces::msg::Time,
+}
+
+impl Default for Fibonacci_SendGoal_Response {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::action::rmw::Fibonacci_SendGoal_Response::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Fibonacci_SendGoal_Response {
+    type RmwMsg = crate::vendor::test_msgs::action::rmw::Fibonacci_SendGoal_Response;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                accepted: msg.accepted,
+                stamp: crate::vendor::builtin_interfaces::msg::Time::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.stamp),
+                )
+                .into_owned(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                accepted: msg.accepted,
+                stamp: crate::vendor::builtin_interfaces::msg::Time::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.stamp),
+                )
+                .into_owned(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            accepted: msg.accepted,
+            stamp: crate::vendor::builtin_interfaces::msg::Time::from_rmw_message(msg.stamp),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Fibonacci_GetResult_Request {
+    pub goal_id: crate::vendor::unique_identifier_msgs::msg::UUID,
+}
+
+impl Default for Fibonacci_GetResult_Request {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::action::rmw::Fibonacci_GetResult_Request::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Fibonacci_GetResult_Request {
+    type RmwMsg = crate::vendor::test_msgs::action::rmw::Fibonacci_GetResult_Request;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                goal_id: crate::vendor::unique_identifier_msgs::msg::UUID::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.goal_id),
+                )
+                .into_owned(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                goal_id: crate::vendor::unique_identifier_msgs::msg::UUID::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.goal_id),
+                )
+                .into_owned(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            goal_id: crate::vendor::unique_identifier_msgs::msg::UUID::from_rmw_message(
+                msg.goal_id,
+            ),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Fibonacci_GetResult_Response {
+    pub status: i8,
+    pub result: crate::vendor::test_msgs::action::Fibonacci_Result,
+}
+
+impl Default for Fibonacci_GetResult_Response {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::action::rmw::Fibonacci_GetResult_Response::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Fibonacci_GetResult_Response {
+    type RmwMsg = crate::vendor::test_msgs::action::rmw::Fibonacci_GetResult_Response;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                status: msg.status,
+                result: crate::vendor::test_msgs::action::Fibonacci_Result::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.result),
+                )
+                .into_owned(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                status: msg.status,
+                result: crate::vendor::test_msgs::action::Fibonacci_Result::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.result),
+                )
+                .into_owned(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            status: msg.status,
+            result: crate::vendor::test_msgs::action::Fibonacci_Result::from_rmw_message(
+                msg.result,
+            ),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct NestedMessage_SendGoal_Request {
+    pub goal_id: crate::vendor::unique_identifier_msgs::msg::UUID,
+    pub goal: crate::vendor::test_msgs::action::NestedMessage_Goal,
+}
+
+impl Default for NestedMessage_SendGoal_Request {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::action::rmw::NestedMessage_SendGoal_Request::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for NestedMessage_SendGoal_Request {
+    type RmwMsg = crate::vendor::test_msgs::action::rmw::NestedMessage_SendGoal_Request;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                goal_id: crate::vendor::unique_identifier_msgs::msg::UUID::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.goal_id),
+                )
+                .into_owned(),
+                goal: crate::vendor::test_msgs::action::NestedMessage_Goal::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.goal),
+                )
+                .into_owned(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                goal_id: crate::vendor::unique_identifier_msgs::msg::UUID::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.goal_id),
+                )
+                .into_owned(),
+                goal: crate::vendor::test_msgs::action::NestedMessage_Goal::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.goal),
+                )
+                .into_owned(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            goal_id: crate::vendor::unique_identifier_msgs::msg::UUID::from_rmw_message(
+                msg.goal_id,
+            ),
+            goal: crate::vendor::test_msgs::action::NestedMessage_Goal::from_rmw_message(msg.goal),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct NestedMessage_SendGoal_Response {
+    pub accepted: bool,
+    pub stamp: crate::vendor::builtin_interfaces::msg::Time,
+}
+
+impl Default for NestedMessage_SendGoal_Response {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::action::rmw::NestedMessage_SendGoal_Response::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for NestedMessage_SendGoal_Response {
+    type RmwMsg = crate::vendor::test_msgs::action::rmw::NestedMessage_SendGoal_Response;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                accepted: msg.accepted,
+                stamp: crate::vendor::builtin_interfaces::msg::Time::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.stamp),
+                )
+                .into_owned(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                accepted: msg.accepted,
+                stamp: crate::vendor::builtin_interfaces::msg::Time::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.stamp),
+                )
+                .into_owned(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            accepted: msg.accepted,
+            stamp: crate::vendor::builtin_interfaces::msg::Time::from_rmw_message(msg.stamp),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct NestedMessage_GetResult_Request {
+    pub goal_id: crate::vendor::unique_identifier_msgs::msg::UUID,
+}
+
+impl Default for NestedMessage_GetResult_Request {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::action::rmw::NestedMessage_GetResult_Request::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for NestedMessage_GetResult_Request {
+    type RmwMsg = crate::vendor::test_msgs::action::rmw::NestedMessage_GetResult_Request;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                goal_id: crate::vendor::unique_identifier_msgs::msg::UUID::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.goal_id),
+                )
+                .into_owned(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                goal_id: crate::vendor::unique_identifier_msgs::msg::UUID::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.goal_id),
+                )
+                .into_owned(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            goal_id: crate::vendor::unique_identifier_msgs::msg::UUID::from_rmw_message(
+                msg.goal_id,
+            ),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct NestedMessage_GetResult_Response {
+    pub status: i8,
+    pub result: crate::vendor::test_msgs::action::NestedMessage_Result,
+}
+
+impl Default for NestedMessage_GetResult_Response {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::action::rmw::NestedMessage_GetResult_Response::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for NestedMessage_GetResult_Response {
+    type RmwMsg = crate::vendor::test_msgs::action::rmw::NestedMessage_GetResult_Response;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                status: msg.status,
+                result: crate::vendor::test_msgs::action::NestedMessage_Result::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.result),
+                )
+                .into_owned(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                status: msg.status,
+                result: crate::vendor::test_msgs::action::NestedMessage_Result::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.result),
+                )
+                .into_owned(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            status: msg.status,
+            result: crate::vendor::test_msgs::action::NestedMessage_Result::from_rmw_message(
+                msg.result,
+            ),
+        }
+    }
+}
+
+#[link(name = "test_msgs__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_service_type_support_handle__test_msgs__action__Fibonacci_SendGoal(
+    ) -> *const std::ffi::c_void;
+}
+
+// Corresponds to test_msgs__action__Fibonacci_SendGoal
+pub struct Fibonacci_SendGoal;
+
+impl rosidl_runtime_rs::Service for Fibonacci_SendGoal {
+    type Request = crate::vendor::test_msgs::action::Fibonacci_SendGoal_Request;
+    type Response = crate::vendor::test_msgs::action::Fibonacci_SendGoal_Response;
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        // SAFETY: No preconditions for this function.
+        unsafe {
+            rosidl_typesupport_c__get_service_type_support_handle__test_msgs__action__Fibonacci_SendGoal()
+        }
+    }
+}
+
+#[link(name = "test_msgs__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_service_type_support_handle__test_msgs__action__Fibonacci_GetResult(
+    ) -> *const std::ffi::c_void;
+}
+
+// Corresponds to test_msgs__action__Fibonacci_GetResult
+pub struct Fibonacci_GetResult;
+
+impl rosidl_runtime_rs::Service for Fibonacci_GetResult {
+    type Request = crate::vendor::test_msgs::action::Fibonacci_GetResult_Request;
+    type Response = crate::vendor::test_msgs::action::Fibonacci_GetResult_Response;
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        // SAFETY: No preconditions for this function.
+        unsafe {
+            rosidl_typesupport_c__get_service_type_support_handle__test_msgs__action__Fibonacci_GetResult()
+        }
+    }
+}
+
+#[link(name = "test_msgs__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_service_type_support_handle__test_msgs__action__NestedMessage_SendGoal(
+    ) -> *const std::ffi::c_void;
+}
+
+// Corresponds to test_msgs__action__NestedMessage_SendGoal
+pub struct NestedMessage_SendGoal;
+
+impl rosidl_runtime_rs::Service for NestedMessage_SendGoal {
+    type Request = crate::vendor::test_msgs::action::NestedMessage_SendGoal_Request;
+    type Response = crate::vendor::test_msgs::action::NestedMessage_SendGoal_Response;
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        // SAFETY: No preconditions for this function.
+        unsafe {
+            rosidl_typesupport_c__get_service_type_support_handle__test_msgs__action__NestedMessage_SendGoal()
+        }
+    }
+}
+
+#[link(name = "test_msgs__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_service_type_support_handle__test_msgs__action__NestedMessage_GetResult(
+    ) -> *const std::ffi::c_void;
+}
+
+// Corresponds to test_msgs__action__NestedMessage_GetResult
+pub struct NestedMessage_GetResult;
+
+impl rosidl_runtime_rs::Service for NestedMessage_GetResult {
+    type Request = crate::vendor::test_msgs::action::NestedMessage_GetResult_Request;
+    type Response = crate::vendor::test_msgs::action::NestedMessage_GetResult_Response;
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        // SAFETY: No preconditions for this function.
+        unsafe {
+            rosidl_typesupport_c__get_service_type_support_handle__test_msgs__action__NestedMessage_GetResult()
+        }
+    }
+}
+
+#[link(name = "test_msgs__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_action_type_support_handle__test_msgs__action__Fibonacci(
+    ) -> *const std::ffi::c_void;
+}
+
+// Corresponds to test_msgs__action__Fibonacci
+pub struct Fibonacci;
+
+impl rosidl_runtime_rs::Action for Fibonacci {
+    type Goal = crate::vendor::test_msgs::action::Fibonacci_Goal;
+    type Result = crate::vendor::test_msgs::action::Fibonacci_Result;
+    type Feedback = crate::vendor::test_msgs::action::Fibonacci_Feedback;
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        // SAFETY: No preconditions for this function.
+        unsafe {
+            rosidl_typesupport_c__get_action_type_support_handle__test_msgs__action__Fibonacci()
+        }
+    }
+}
+
+impl rosidl_runtime_rs::ActionImpl for Fibonacci {
+    type GoalStatusMessage = crate::vendor::action_msgs::msg::rmw::GoalStatusArray;
+    type FeedbackMessage = crate::vendor::test_msgs::action::rmw::Fibonacci_FeedbackMessage;
+
+    type SendGoalService = crate::vendor::test_msgs::action::rmw::Fibonacci_SendGoal;
+    type CancelGoalService = crate::vendor::action_msgs::srv::rmw::CancelGoal;
+    type GetResultService = crate::vendor::test_msgs::action::rmw::Fibonacci_GetResult;
+
+    fn create_goal_request(
+        goal_id: &[u8; 16],
+        goal: crate::vendor::test_msgs::action::rmw::Fibonacci_Goal,
+    ) -> crate::vendor::test_msgs::action::rmw::Fibonacci_SendGoal_Request {
+        crate::vendor::test_msgs::action::rmw::Fibonacci_SendGoal_Request {
+            goal_id: crate::vendor::unique_identifier_msgs::msg::rmw::UUID { uuid: *goal_id },
+            goal,
+        }
+    }
+
+    fn get_goal_request_uuid(
+        request: &crate::vendor::test_msgs::action::rmw::Fibonacci_SendGoal_Request,
+    ) -> &[u8; 16] {
+        &request.goal_id.uuid
+    }
+
+    fn create_goal_response(
+        accepted: bool,
+        stamp: (i32, u32),
+    ) -> crate::vendor::test_msgs::action::rmw::Fibonacci_SendGoal_Response {
+        crate::vendor::test_msgs::action::rmw::Fibonacci_SendGoal_Response {
+            accepted,
+            stamp: crate::vendor::builtin_interfaces::msg::rmw::Time {
+                sec: stamp.0,
+                nanosec: stamp.1,
+            },
+        }
+    }
+
+    fn get_goal_response_accepted(
+        response: &crate::vendor::test_msgs::action::rmw::Fibonacci_SendGoal_Response,
+    ) -> bool {
+        response.accepted
+    }
+
+    fn get_goal_response_stamp(
+        response: &crate::vendor::test_msgs::action::rmw::Fibonacci_SendGoal_Response,
+    ) -> (i32, u32) {
+        (response.stamp.sec, response.stamp.nanosec)
+    }
+
+    fn create_feedback_message(
+        goal_id: &[u8; 16],
+        feedback: crate::vendor::test_msgs::action::rmw::Fibonacci_Feedback,
+    ) -> crate::vendor::test_msgs::action::rmw::Fibonacci_FeedbackMessage {
+        let mut message =
+            crate::vendor::test_msgs::action::rmw::Fibonacci_FeedbackMessage::default();
+        message.goal_id.uuid = *goal_id;
+        message.feedback = feedback;
+        message
+    }
+
+    fn get_feedback_message_uuid(
+        feedback: &crate::vendor::test_msgs::action::rmw::Fibonacci_FeedbackMessage,
+    ) -> &[u8; 16] {
+        &feedback.goal_id.uuid
+    }
+
+    fn get_feedback_message_feedback(
+        feedback: &crate::vendor::test_msgs::action::rmw::Fibonacci_FeedbackMessage,
+    ) -> &crate::vendor::test_msgs::action::rmw::Fibonacci_Feedback {
+        &feedback.feedback
+    }
+
+    fn create_result_request(
+        goal_id: &[u8; 16],
+    ) -> crate::vendor::test_msgs::action::rmw::Fibonacci_GetResult_Request {
+        crate::vendor::test_msgs::action::rmw::Fibonacci_GetResult_Request {
+            goal_id: crate::vendor::unique_identifier_msgs::msg::rmw::UUID { uuid: *goal_id },
+        }
+    }
+
+    fn get_result_request_uuid(
+        request: &crate::vendor::test_msgs::action::rmw::Fibonacci_GetResult_Request,
+    ) -> &[u8; 16] {
+        &request.goal_id.uuid
+    }
+
+    fn create_result_response(
+        status: i8,
+        result: crate::vendor::test_msgs::action::rmw::Fibonacci_Result,
+    ) -> crate::vendor::test_msgs::action::rmw::Fibonacci_GetResult_Response {
+        crate::vendor::test_msgs::action::rmw::Fibonacci_GetResult_Response { status, result }
+    }
+
+    fn get_result_response_result(
+        response: &crate::vendor::test_msgs::action::rmw::Fibonacci_GetResult_Response,
+    ) -> &crate::vendor::test_msgs::action::rmw::Fibonacci_Result {
+        &response.result
+    }
+
+    fn get_result_response_status(
+        response: &crate::vendor::test_msgs::action::rmw::Fibonacci_GetResult_Response,
+    ) -> i8 {
+        response.status
+    }
+}
+
+#[link(name = "test_msgs__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_action_type_support_handle__test_msgs__action__NestedMessage(
+    ) -> *const std::ffi::c_void;
+}
+
+// Corresponds to test_msgs__action__NestedMessage
+pub struct NestedMessage;
+
+impl rosidl_runtime_rs::Action for NestedMessage {
+    type Goal = crate::vendor::test_msgs::action::NestedMessage_Goal;
+    type Result = crate::vendor::test_msgs::action::NestedMessage_Result;
+    type Feedback = crate::vendor::test_msgs::action::NestedMessage_Feedback;
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        // SAFETY: No preconditions for this function.
+        unsafe {
+            rosidl_typesupport_c__get_action_type_support_handle__test_msgs__action__NestedMessage()
+        }
+    }
+}
+
+impl rosidl_runtime_rs::ActionImpl for NestedMessage {
+    type GoalStatusMessage = crate::vendor::action_msgs::msg::rmw::GoalStatusArray;
+    type FeedbackMessage = crate::vendor::test_msgs::action::rmw::NestedMessage_FeedbackMessage;
+
+    type SendGoalService = crate::vendor::test_msgs::action::rmw::NestedMessage_SendGoal;
+    type CancelGoalService = crate::vendor::action_msgs::srv::rmw::CancelGoal;
+    type GetResultService = crate::vendor::test_msgs::action::rmw::NestedMessage_GetResult;
+
+    fn create_goal_request(
+        goal_id: &[u8; 16],
+        goal: crate::vendor::test_msgs::action::rmw::NestedMessage_Goal,
+    ) -> crate::vendor::test_msgs::action::rmw::NestedMessage_SendGoal_Request {
+        crate::vendor::test_msgs::action::rmw::NestedMessage_SendGoal_Request {
+            goal_id: crate::vendor::unique_identifier_msgs::msg::rmw::UUID { uuid: *goal_id },
+            goal,
+        }
+    }
+
+    fn get_goal_request_uuid(
+        request: &crate::vendor::test_msgs::action::rmw::NestedMessage_SendGoal_Request,
+    ) -> &[u8; 16] {
+        &request.goal_id.uuid
+    }
+
+    fn create_goal_response(
+        accepted: bool,
+        stamp: (i32, u32),
+    ) -> crate::vendor::test_msgs::action::rmw::NestedMessage_SendGoal_Response {
+        crate::vendor::test_msgs::action::rmw::NestedMessage_SendGoal_Response {
+            accepted,
+            stamp: crate::vendor::builtin_interfaces::msg::rmw::Time {
+                sec: stamp.0,
+                nanosec: stamp.1,
+            },
+        }
+    }
+
+    fn get_goal_response_accepted(
+        response: &crate::vendor::test_msgs::action::rmw::NestedMessage_SendGoal_Response,
+    ) -> bool {
+        response.accepted
+    }
+
+    fn get_goal_response_stamp(
+        response: &crate::vendor::test_msgs::action::rmw::NestedMessage_SendGoal_Response,
+    ) -> (i32, u32) {
+        (response.stamp.sec, response.stamp.nanosec)
+    }
+
+    fn create_feedback_message(
+        goal_id: &[u8; 16],
+        feedback: crate::vendor::test_msgs::action::rmw::NestedMessage_Feedback,
+    ) -> crate::vendor::test_msgs::action::rmw::NestedMessage_FeedbackMessage {
+        let mut message =
+            crate::vendor::test_msgs::action::rmw::NestedMessage_FeedbackMessage::default();
+        message.goal_id.uuid = *goal_id;
+        message.feedback = feedback;
+        message
+    }
+
+    fn get_feedback_message_uuid(
+        feedback: &crate::vendor::test_msgs::action::rmw::NestedMessage_FeedbackMessage,
+    ) -> &[u8; 16] {
+        &feedback.goal_id.uuid
+    }
+
+    fn get_feedback_message_feedback(
+        feedback: &crate::vendor::test_msgs::action::rmw::NestedMessage_FeedbackMessage,
+    ) -> &crate::vendor::test_msgs::action::rmw::NestedMessage_Feedback {
+        &feedback.feedback
+    }
+
+    fn create_result_request(
+        goal_id: &[u8; 16],
+    ) -> crate::vendor::test_msgs::action::rmw::NestedMessage_GetResult_Request {
+        crate::vendor::test_msgs::action::rmw::NestedMessage_GetResult_Request {
+            goal_id: crate::vendor::unique_identifier_msgs::msg::rmw::UUID { uuid: *goal_id },
+        }
+    }
+
+    fn get_result_request_uuid(
+        request: &crate::vendor::test_msgs::action::rmw::NestedMessage_GetResult_Request,
+    ) -> &[u8; 16] {
+        &request.goal_id.uuid
+    }
+
+    fn create_result_response(
+        status: i8,
+        result: crate::vendor::test_msgs::action::rmw::NestedMessage_Result,
+    ) -> crate::vendor::test_msgs::action::rmw::NestedMessage_GetResult_Response {
+        crate::vendor::test_msgs::action::rmw::NestedMessage_GetResult_Response { status, result }
+    }
+
+    fn get_result_response_result(
+        response: &crate::vendor::test_msgs::action::rmw::NestedMessage_GetResult_Response,
+    ) -> &crate::vendor::test_msgs::action::rmw::NestedMessage_Result {
+        &response.result
+    }
+
+    fn get_result_response_status(
+        response: &crate::vendor::test_msgs::action::rmw::NestedMessage_GetResult_Response,
+    ) -> i8 {
+        response.status
+    }
+}

--- a/rclrs/src/vendor/test_msgs/mod.rs
+++ b/rclrs/src/vendor/test_msgs/mod.rs
@@ -1,0 +1,9 @@
+#![allow(non_camel_case_types)]
+#![allow(clippy::derive_partial_eq_without_eq)]
+#![allow(clippy::upper_case_acronyms)]
+
+pub mod msg;
+
+pub mod srv;
+
+pub mod action;

--- a/rclrs/src/vendor/test_msgs/msg.rs
+++ b/rclrs/src/vendor/test_msgs/msg.rs
@@ -1,0 +1,3344 @@
+pub mod rmw {
+    #[cfg(feature = "serde")]
+    use serde::{Deserialize, Serialize};
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__KeyedLong(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__msg__KeyedLong__init(msg: *mut KeyedLong) -> bool;
+        fn test_msgs__msg__KeyedLong__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<KeyedLong>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__msg__KeyedLong__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<KeyedLong>,
+        );
+        fn test_msgs__msg__KeyedLong__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<KeyedLong>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<KeyedLong>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__msg__KeyedLong
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct KeyedLong {
+        pub key: i32,
+        pub value: i32,
+    }
+
+    impl Default for KeyedLong {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__msg__KeyedLong__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__msg__KeyedLong__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for KeyedLong {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__KeyedLong__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__KeyedLong__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__KeyedLong__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for KeyedLong {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for KeyedLong
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/msg/KeyedLong";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__KeyedLong()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__KeyedString(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__msg__KeyedString__init(msg: *mut KeyedString) -> bool;
+        fn test_msgs__msg__KeyedString__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<KeyedString>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__msg__KeyedString__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<KeyedString>,
+        );
+        fn test_msgs__msg__KeyedString__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<KeyedString>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<KeyedString>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__msg__KeyedString
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct KeyedString {
+        pub key: rosidl_runtime_rs::String,
+        pub value: rosidl_runtime_rs::String,
+    }
+
+    impl Default for KeyedString {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__msg__KeyedString__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__msg__KeyedString__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for KeyedString {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__KeyedString__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__KeyedString__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__KeyedString__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for KeyedString {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for KeyedString
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/msg/KeyedString";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__KeyedString()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__NonKeyedWithNestedKey(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__msg__NonKeyedWithNestedKey__init(msg: *mut NonKeyedWithNestedKey) -> bool;
+        fn test_msgs__msg__NonKeyedWithNestedKey__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<NonKeyedWithNestedKey>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__msg__NonKeyedWithNestedKey__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<NonKeyedWithNestedKey>,
+        );
+        fn test_msgs__msg__NonKeyedWithNestedKey__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<NonKeyedWithNestedKey>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<NonKeyedWithNestedKey>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__msg__NonKeyedWithNestedKey
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct NonKeyedWithNestedKey {
+        pub nested_data: crate::vendor::test_msgs::msg::rmw::KeyedString,
+        pub some_int: i32,
+    }
+
+    impl Default for NonKeyedWithNestedKey {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__msg__NonKeyedWithNestedKey__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__msg__NonKeyedWithNestedKey__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for NonKeyedWithNestedKey {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__NonKeyedWithNestedKey__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__NonKeyedWithNestedKey__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__msg__NonKeyedWithNestedKey__Sequence__copy(in_seq, out_seq as *mut _)
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for NonKeyedWithNestedKey {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for NonKeyedWithNestedKey
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/msg/NonKeyedWithNestedKey";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__NonKeyedWithNestedKey()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__ComplexNestedKey(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__msg__ComplexNestedKey__init(msg: *mut ComplexNestedKey) -> bool;
+        fn test_msgs__msg__ComplexNestedKey__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<ComplexNestedKey>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__msg__ComplexNestedKey__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<ComplexNestedKey>,
+        );
+        fn test_msgs__msg__ComplexNestedKey__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<ComplexNestedKey>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<ComplexNestedKey>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__msg__ComplexNestedKey
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct ComplexNestedKey {
+        pub uint32_key: u32,
+        pub nested_keys: crate::vendor::test_msgs::msg::rmw::NonKeyedWithNestedKey,
+        pub float64_value: f64,
+    }
+
+    impl Default for ComplexNestedKey {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__msg__ComplexNestedKey__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__msg__ComplexNestedKey__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for ComplexNestedKey {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__ComplexNestedKey__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__ComplexNestedKey__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__ComplexNestedKey__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for ComplexNestedKey {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for ComplexNestedKey
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/msg/ComplexNestedKey";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__ComplexNestedKey()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__Arrays(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__msg__Arrays__init(msg: *mut Arrays) -> bool;
+        fn test_msgs__msg__Arrays__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Arrays>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__msg__Arrays__Sequence__fini(seq: *mut rosidl_runtime_rs::Sequence<Arrays>);
+        fn test_msgs__msg__Arrays__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Arrays>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Arrays>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__msg__Arrays
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Arrays {
+        pub bool_values: [bool; 3],
+        pub byte_values: [u8; 3],
+        pub char_values: [u8; 3],
+        pub float32_values: [f32; 3],
+        pub float64_values: [f64; 3],
+        pub int8_values: [i8; 3],
+        pub uint8_values: [u8; 3],
+        pub int16_values: [i16; 3],
+        pub uint16_values: [u16; 3],
+        pub int32_values: [i32; 3],
+        pub uint32_values: [u32; 3],
+        pub int64_values: [i64; 3],
+        pub uint64_values: [u64; 3],
+        pub string_values: [rosidl_runtime_rs::String; 3],
+        pub basic_types_values: [crate::vendor::test_msgs::msg::rmw::BasicTypes; 3],
+        pub constants_values: [crate::vendor::test_msgs::msg::rmw::Constants; 3],
+        pub defaults_values: [crate::vendor::test_msgs::msg::rmw::Defaults; 3],
+        pub bool_values_default: [bool; 3],
+        pub byte_values_default: [u8; 3],
+        pub char_values_default: [u8; 3],
+        pub float32_values_default: [f32; 3],
+        pub float64_values_default: [f64; 3],
+        pub int8_values_default: [i8; 3],
+        pub uint8_values_default: [u8; 3],
+        pub int16_values_default: [i16; 3],
+        pub uint16_values_default: [u16; 3],
+        pub int32_values_default: [i32; 3],
+        pub uint32_values_default: [u32; 3],
+        pub int64_values_default: [i64; 3],
+        pub uint64_values_default: [u64; 3],
+        pub string_values_default: [rosidl_runtime_rs::String; 3],
+        pub alignment_check: i32,
+    }
+
+    impl Default for Arrays {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__msg__Arrays__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__msg__Arrays__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Arrays {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__Arrays__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__Arrays__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__Arrays__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Arrays {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Arrays
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/msg/Arrays";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__Arrays()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__BasicTypes(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__msg__BasicTypes__init(msg: *mut BasicTypes) -> bool;
+        fn test_msgs__msg__BasicTypes__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<BasicTypes>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__msg__BasicTypes__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<BasicTypes>,
+        );
+        fn test_msgs__msg__BasicTypes__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<BasicTypes>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<BasicTypes>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__msg__BasicTypes
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct BasicTypes {
+        pub bool_value: bool,
+        pub byte_value: u8,
+        pub char_value: u8,
+        pub float32_value: f32,
+        pub float64_value: f64,
+        pub int8_value: i8,
+        pub uint8_value: u8,
+        pub int16_value: i16,
+        pub uint16_value: u16,
+        pub int32_value: i32,
+        pub uint32_value: u32,
+        pub int64_value: i64,
+        pub uint64_value: u64,
+    }
+
+    impl Default for BasicTypes {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__msg__BasicTypes__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__msg__BasicTypes__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for BasicTypes {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__BasicTypes__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__BasicTypes__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__BasicTypes__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for BasicTypes {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for BasicTypes
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/msg/BasicTypes";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__BasicTypes()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__BoundedPlainSequences(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__msg__BoundedPlainSequences__init(msg: *mut BoundedPlainSequences) -> bool;
+        fn test_msgs__msg__BoundedPlainSequences__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<BoundedPlainSequences>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__msg__BoundedPlainSequences__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<BoundedPlainSequences>,
+        );
+        fn test_msgs__msg__BoundedPlainSequences__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<BoundedPlainSequences>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<BoundedPlainSequences>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__msg__BoundedPlainSequences
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct BoundedPlainSequences {
+        pub bool_values: rosidl_runtime_rs::BoundedSequence<bool, 3>,
+        pub byte_values: rosidl_runtime_rs::BoundedSequence<u8, 3>,
+        pub char_values: rosidl_runtime_rs::BoundedSequence<u8, 3>,
+        pub float32_values: rosidl_runtime_rs::BoundedSequence<f32, 3>,
+        pub float64_values: rosidl_runtime_rs::BoundedSequence<f64, 3>,
+        pub int8_values: rosidl_runtime_rs::BoundedSequence<i8, 3>,
+        pub uint8_values: rosidl_runtime_rs::BoundedSequence<u8, 3>,
+        pub int16_values: rosidl_runtime_rs::BoundedSequence<i16, 3>,
+        pub uint16_values: rosidl_runtime_rs::BoundedSequence<u16, 3>,
+        pub int32_values: rosidl_runtime_rs::BoundedSequence<i32, 3>,
+        pub uint32_values: rosidl_runtime_rs::BoundedSequence<u32, 3>,
+        pub int64_values: rosidl_runtime_rs::BoundedSequence<i64, 3>,
+        pub uint64_values: rosidl_runtime_rs::BoundedSequence<u64, 3>,
+        pub basic_types_values:
+            rosidl_runtime_rs::BoundedSequence<crate::vendor::test_msgs::msg::rmw::BasicTypes, 3>,
+        pub constants_values:
+            rosidl_runtime_rs::BoundedSequence<crate::vendor::test_msgs::msg::rmw::Constants, 3>,
+        pub defaults_values:
+            rosidl_runtime_rs::BoundedSequence<crate::vendor::test_msgs::msg::rmw::Defaults, 3>,
+        pub bool_values_default: rosidl_runtime_rs::BoundedSequence<bool, 3>,
+        pub byte_values_default: rosidl_runtime_rs::BoundedSequence<u8, 3>,
+        pub char_values_default: rosidl_runtime_rs::BoundedSequence<u8, 3>,
+        pub float32_values_default: rosidl_runtime_rs::BoundedSequence<f32, 3>,
+        pub float64_values_default: rosidl_runtime_rs::BoundedSequence<f64, 3>,
+        pub int8_values_default: rosidl_runtime_rs::BoundedSequence<i8, 3>,
+        pub uint8_values_default: rosidl_runtime_rs::BoundedSequence<u8, 3>,
+        pub int16_values_default: rosidl_runtime_rs::BoundedSequence<i16, 3>,
+        pub uint16_values_default: rosidl_runtime_rs::BoundedSequence<u16, 3>,
+        pub int32_values_default: rosidl_runtime_rs::BoundedSequence<i32, 3>,
+        pub uint32_values_default: rosidl_runtime_rs::BoundedSequence<u32, 3>,
+        pub int64_values_default: rosidl_runtime_rs::BoundedSequence<i64, 3>,
+        pub uint64_values_default: rosidl_runtime_rs::BoundedSequence<u64, 3>,
+        pub alignment_check: i32,
+    }
+
+    impl Default for BoundedPlainSequences {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__msg__BoundedPlainSequences__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__msg__BoundedPlainSequences__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for BoundedPlainSequences {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__BoundedPlainSequences__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__BoundedPlainSequences__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__msg__BoundedPlainSequences__Sequence__copy(in_seq, out_seq as *mut _)
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for BoundedPlainSequences {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for BoundedPlainSequences
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/msg/BoundedPlainSequences";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__BoundedPlainSequences()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__BoundedSequences(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__msg__BoundedSequences__init(msg: *mut BoundedSequences) -> bool;
+        fn test_msgs__msg__BoundedSequences__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<BoundedSequences>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__msg__BoundedSequences__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<BoundedSequences>,
+        );
+        fn test_msgs__msg__BoundedSequences__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<BoundedSequences>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<BoundedSequences>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__msg__BoundedSequences
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct BoundedSequences {
+        pub bool_values: rosidl_runtime_rs::BoundedSequence<bool, 3>,
+        pub byte_values: rosidl_runtime_rs::BoundedSequence<u8, 3>,
+        pub char_values: rosidl_runtime_rs::BoundedSequence<u8, 3>,
+        pub float32_values: rosidl_runtime_rs::BoundedSequence<f32, 3>,
+        pub float64_values: rosidl_runtime_rs::BoundedSequence<f64, 3>,
+        pub int8_values: rosidl_runtime_rs::BoundedSequence<i8, 3>,
+        pub uint8_values: rosidl_runtime_rs::BoundedSequence<u8, 3>,
+        pub int16_values: rosidl_runtime_rs::BoundedSequence<i16, 3>,
+        pub uint16_values: rosidl_runtime_rs::BoundedSequence<u16, 3>,
+        pub int32_values: rosidl_runtime_rs::BoundedSequence<i32, 3>,
+        pub uint32_values: rosidl_runtime_rs::BoundedSequence<u32, 3>,
+        pub int64_values: rosidl_runtime_rs::BoundedSequence<i64, 3>,
+        pub uint64_values: rosidl_runtime_rs::BoundedSequence<u64, 3>,
+        pub string_values: rosidl_runtime_rs::BoundedSequence<rosidl_runtime_rs::String, 3>,
+        pub basic_types_values:
+            rosidl_runtime_rs::BoundedSequence<crate::vendor::test_msgs::msg::rmw::BasicTypes, 3>,
+        pub constants_values:
+            rosidl_runtime_rs::BoundedSequence<crate::vendor::test_msgs::msg::rmw::Constants, 3>,
+        pub defaults_values:
+            rosidl_runtime_rs::BoundedSequence<crate::vendor::test_msgs::msg::rmw::Defaults, 3>,
+        pub bool_values_default: rosidl_runtime_rs::BoundedSequence<bool, 3>,
+        pub byte_values_default: rosidl_runtime_rs::BoundedSequence<u8, 3>,
+        pub char_values_default: rosidl_runtime_rs::BoundedSequence<u8, 3>,
+        pub float32_values_default: rosidl_runtime_rs::BoundedSequence<f32, 3>,
+        pub float64_values_default: rosidl_runtime_rs::BoundedSequence<f64, 3>,
+        pub int8_values_default: rosidl_runtime_rs::BoundedSequence<i8, 3>,
+        pub uint8_values_default: rosidl_runtime_rs::BoundedSequence<u8, 3>,
+        pub int16_values_default: rosidl_runtime_rs::BoundedSequence<i16, 3>,
+        pub uint16_values_default: rosidl_runtime_rs::BoundedSequence<u16, 3>,
+        pub int32_values_default: rosidl_runtime_rs::BoundedSequence<i32, 3>,
+        pub uint32_values_default: rosidl_runtime_rs::BoundedSequence<u32, 3>,
+        pub int64_values_default: rosidl_runtime_rs::BoundedSequence<i64, 3>,
+        pub uint64_values_default: rosidl_runtime_rs::BoundedSequence<u64, 3>,
+        pub string_values_default: rosidl_runtime_rs::BoundedSequence<rosidl_runtime_rs::String, 3>,
+        pub alignment_check: i32,
+    }
+
+    impl Default for BoundedSequences {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__msg__BoundedSequences__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__msg__BoundedSequences__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for BoundedSequences {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__BoundedSequences__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__BoundedSequences__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__BoundedSequences__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for BoundedSequences {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for BoundedSequences
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/msg/BoundedSequences";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__BoundedSequences()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__Constants(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__msg__Constants__init(msg: *mut Constants) -> bool;
+        fn test_msgs__msg__Constants__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Constants>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__msg__Constants__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Constants>,
+        );
+        fn test_msgs__msg__Constants__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Constants>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Constants>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__msg__Constants
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Constants {
+        pub structure_needs_at_least_one_member: u8,
+    }
+
+    impl Constants {
+        pub const BOOL_CONST: bool = true;
+        pub const BYTE_CONST: u8 = 50;
+        pub const CHAR_CONST: u8 = 100;
+        pub const FLOAT32_CONST: f32 = 1.125;
+        pub const FLOAT64_CONST: f64 = 1.125;
+        pub const INT8_CONST: i8 = -50;
+        pub const UINT8_CONST: u8 = 200;
+        pub const INT16_CONST: i16 = -1000;
+        pub const UINT16_CONST: u16 = 2000;
+        pub const INT32_CONST: i32 = -30000;
+        pub const UINT32_CONST: u32 = 60000;
+        pub const INT64_CONST: i64 = -40000000;
+        pub const UINT64_CONST: u64 = 50000000;
+    }
+
+    impl Default for Constants {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__msg__Constants__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__msg__Constants__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Constants {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__Constants__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__Constants__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__Constants__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Constants {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Constants
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/msg/Constants";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__Constants()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__Defaults(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__msg__Defaults__init(msg: *mut Defaults) -> bool;
+        fn test_msgs__msg__Defaults__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Defaults>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__msg__Defaults__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Defaults>,
+        );
+        fn test_msgs__msg__Defaults__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Defaults>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Defaults>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__msg__Defaults
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Defaults {
+        pub bool_value: bool,
+        pub byte_value: u8,
+        pub char_value: u8,
+        pub float32_value: f32,
+        pub float64_value: f64,
+        pub int8_value: i8,
+        pub uint8_value: u8,
+        pub int16_value: i16,
+        pub uint16_value: u16,
+        pub int32_value: i32,
+        pub uint32_value: u32,
+        pub int64_value: i64,
+        pub uint64_value: u64,
+    }
+
+    impl Default for Defaults {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__msg__Defaults__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__msg__Defaults__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Defaults {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__Defaults__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__Defaults__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__Defaults__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Defaults {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Defaults
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/msg/Defaults";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__Defaults()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__Empty(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__msg__Empty__init(msg: *mut Empty) -> bool;
+        fn test_msgs__msg__Empty__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Empty>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__msg__Empty__Sequence__fini(seq: *mut rosidl_runtime_rs::Sequence<Empty>);
+        fn test_msgs__msg__Empty__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Empty>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Empty>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__msg__Empty
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Empty {
+        pub structure_needs_at_least_one_member: u8,
+    }
+
+    impl Default for Empty {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__msg__Empty__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__msg__Empty__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Empty {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__Empty__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__Empty__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__Empty__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Empty {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Empty
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/msg/Empty";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__Empty()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__MultiNested(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__msg__MultiNested__init(msg: *mut MultiNested) -> bool;
+        fn test_msgs__msg__MultiNested__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<MultiNested>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__msg__MultiNested__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<MultiNested>,
+        );
+        fn test_msgs__msg__MultiNested__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<MultiNested>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<MultiNested>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__msg__MultiNested
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct MultiNested {
+        pub array_of_arrays: [crate::vendor::test_msgs::msg::rmw::Arrays; 3],
+        pub array_of_bounded_sequences: [crate::vendor::test_msgs::msg::rmw::BoundedSequences; 3],
+        pub array_of_unbounded_sequences:
+            [crate::vendor::test_msgs::msg::rmw::UnboundedSequences; 3],
+        pub bounded_sequence_of_arrays:
+            rosidl_runtime_rs::BoundedSequence<crate::vendor::test_msgs::msg::rmw::Arrays, 3>,
+        pub bounded_sequence_of_bounded_sequences: rosidl_runtime_rs::BoundedSequence<
+            crate::vendor::test_msgs::msg::rmw::BoundedSequences,
+            3,
+        >,
+        pub bounded_sequence_of_unbounded_sequences: rosidl_runtime_rs::BoundedSequence<
+            crate::vendor::test_msgs::msg::rmw::UnboundedSequences,
+            3,
+        >,
+        pub unbounded_sequence_of_arrays:
+            rosidl_runtime_rs::Sequence<crate::vendor::test_msgs::msg::rmw::Arrays>,
+        pub unbounded_sequence_of_bounded_sequences:
+            rosidl_runtime_rs::Sequence<crate::vendor::test_msgs::msg::rmw::BoundedSequences>,
+        pub unbounded_sequence_of_unbounded_sequences:
+            rosidl_runtime_rs::Sequence<crate::vendor::test_msgs::msg::rmw::UnboundedSequences>,
+    }
+
+    impl Default for MultiNested {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__msg__MultiNested__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__msg__MultiNested__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for MultiNested {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__MultiNested__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__MultiNested__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__MultiNested__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for MultiNested {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for MultiNested
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/msg/MultiNested";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__MultiNested()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__Nested(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__msg__Nested__init(msg: *mut Nested) -> bool;
+        fn test_msgs__msg__Nested__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Nested>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__msg__Nested__Sequence__fini(seq: *mut rosidl_runtime_rs::Sequence<Nested>);
+        fn test_msgs__msg__Nested__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Nested>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Nested>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__msg__Nested
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Nested {
+        pub basic_types_value: crate::vendor::test_msgs::msg::rmw::BasicTypes,
+    }
+
+    impl Default for Nested {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__msg__Nested__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__msg__Nested__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Nested {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__Nested__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__Nested__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__Nested__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Nested {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Nested
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/msg/Nested";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__Nested()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__Strings(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__msg__Strings__init(msg: *mut Strings) -> bool;
+        fn test_msgs__msg__Strings__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Strings>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__msg__Strings__Sequence__fini(seq: *mut rosidl_runtime_rs::Sequence<Strings>);
+        fn test_msgs__msg__Strings__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Strings>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Strings>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__msg__Strings
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Strings {
+        pub string_value: rosidl_runtime_rs::String,
+        pub string_value_default1: rosidl_runtime_rs::String,
+        pub string_value_default2: rosidl_runtime_rs::String,
+        pub string_value_default3: rosidl_runtime_rs::String,
+        pub string_value_default4: rosidl_runtime_rs::String,
+        pub string_value_default5: rosidl_runtime_rs::String,
+        pub bounded_string_value: rosidl_runtime_rs::BoundedString<22>,
+        pub bounded_string_value_default1: rosidl_runtime_rs::BoundedString<22>,
+        pub bounded_string_value_default2: rosidl_runtime_rs::BoundedString<22>,
+        pub bounded_string_value_default3: rosidl_runtime_rs::BoundedString<22>,
+        pub bounded_string_value_default4: rosidl_runtime_rs::BoundedString<22>,
+        pub bounded_string_value_default5: rosidl_runtime_rs::BoundedString<22>,
+    }
+
+    impl Strings {
+        pub const STRING_CONST: &'static str = "Hello world!";
+    }
+
+    impl Default for Strings {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__msg__Strings__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__msg__Strings__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Strings {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__Strings__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__Strings__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__Strings__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Strings {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Strings
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/msg/Strings";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__Strings()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__UnboundedSequences(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__msg__UnboundedSequences__init(msg: *mut UnboundedSequences) -> bool;
+        fn test_msgs__msg__UnboundedSequences__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<UnboundedSequences>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__msg__UnboundedSequences__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<UnboundedSequences>,
+        );
+        fn test_msgs__msg__UnboundedSequences__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<UnboundedSequences>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<UnboundedSequences>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__msg__UnboundedSequences
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct UnboundedSequences {
+        pub bool_values: rosidl_runtime_rs::Sequence<bool>,
+        pub byte_values: rosidl_runtime_rs::Sequence<u8>,
+        pub char_values: rosidl_runtime_rs::Sequence<u8>,
+        pub float32_values: rosidl_runtime_rs::Sequence<f32>,
+        pub float64_values: rosidl_runtime_rs::Sequence<f64>,
+        pub int8_values: rosidl_runtime_rs::Sequence<i8>,
+        pub uint8_values: rosidl_runtime_rs::Sequence<u8>,
+        pub int16_values: rosidl_runtime_rs::Sequence<i16>,
+        pub uint16_values: rosidl_runtime_rs::Sequence<u16>,
+        pub int32_values: rosidl_runtime_rs::Sequence<i32>,
+        pub uint32_values: rosidl_runtime_rs::Sequence<u32>,
+        pub int64_values: rosidl_runtime_rs::Sequence<i64>,
+        pub uint64_values: rosidl_runtime_rs::Sequence<u64>,
+        pub string_values: rosidl_runtime_rs::Sequence<rosidl_runtime_rs::String>,
+        pub basic_types_values:
+            rosidl_runtime_rs::Sequence<crate::vendor::test_msgs::msg::rmw::BasicTypes>,
+        pub constants_values:
+            rosidl_runtime_rs::Sequence<crate::vendor::test_msgs::msg::rmw::Constants>,
+        pub defaults_values:
+            rosidl_runtime_rs::Sequence<crate::vendor::test_msgs::msg::rmw::Defaults>,
+        pub bool_values_default: rosidl_runtime_rs::Sequence<bool>,
+        pub byte_values_default: rosidl_runtime_rs::Sequence<u8>,
+        pub char_values_default: rosidl_runtime_rs::Sequence<u8>,
+        pub float32_values_default: rosidl_runtime_rs::Sequence<f32>,
+        pub float64_values_default: rosidl_runtime_rs::Sequence<f64>,
+        pub int8_values_default: rosidl_runtime_rs::Sequence<i8>,
+        pub uint8_values_default: rosidl_runtime_rs::Sequence<u8>,
+        pub int16_values_default: rosidl_runtime_rs::Sequence<i16>,
+        pub uint16_values_default: rosidl_runtime_rs::Sequence<u16>,
+        pub int32_values_default: rosidl_runtime_rs::Sequence<i32>,
+        pub uint32_values_default: rosidl_runtime_rs::Sequence<u32>,
+        pub int64_values_default: rosidl_runtime_rs::Sequence<i64>,
+        pub uint64_values_default: rosidl_runtime_rs::Sequence<u64>,
+        pub string_values_default: rosidl_runtime_rs::Sequence<rosidl_runtime_rs::String>,
+        pub alignment_check: i32,
+    }
+
+    impl Default for UnboundedSequences {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__msg__UnboundedSequences__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__msg__UnboundedSequences__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for UnboundedSequences {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__UnboundedSequences__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__UnboundedSequences__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__UnboundedSequences__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for UnboundedSequences {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for UnboundedSequences
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/msg/UnboundedSequences";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__UnboundedSequences()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__WStrings(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__msg__WStrings__init(msg: *mut WStrings) -> bool;
+        fn test_msgs__msg__WStrings__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<WStrings>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__msg__WStrings__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<WStrings>,
+        );
+        fn test_msgs__msg__WStrings__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<WStrings>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<WStrings>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__msg__WStrings
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct WStrings {
+        pub wstring_value: rosidl_runtime_rs::WString,
+        pub wstring_value_default1: rosidl_runtime_rs::WString,
+        pub wstring_value_default2: rosidl_runtime_rs::WString,
+        pub wstring_value_default3: rosidl_runtime_rs::WString,
+        pub array_of_wstrings: [rosidl_runtime_rs::WString; 3],
+        pub bounded_sequence_of_wstrings:
+            rosidl_runtime_rs::BoundedSequence<rosidl_runtime_rs::WString, 3>,
+        pub unbounded_sequence_of_wstrings: rosidl_runtime_rs::Sequence<rosidl_runtime_rs::WString>,
+    }
+
+    impl Default for WStrings {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__msg__WStrings__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__msg__WStrings__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for WStrings {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__WStrings__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__WStrings__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__WStrings__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for WStrings {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for WStrings
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/msg/WStrings";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__WStrings()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__Builtins(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__msg__Builtins__init(msg: *mut Builtins) -> bool;
+        fn test_msgs__msg__Builtins__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Builtins>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__msg__Builtins__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Builtins>,
+        );
+        fn test_msgs__msg__Builtins__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Builtins>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Builtins>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__msg__Builtins
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Builtins {
+        pub duration_value: crate::vendor::builtin_interfaces::msg::rmw::Duration,
+        pub time_value: crate::vendor::builtin_interfaces::msg::rmw::Time,
+    }
+
+    impl Default for Builtins {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__msg__Builtins__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__msg__Builtins__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Builtins {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__Builtins__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__Builtins__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__msg__Builtins__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Builtins {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Builtins
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/msg/Builtins";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__msg__Builtins()
+            }
+        }
+    }
+} // mod rmw
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct KeyedLong {
+    pub key: i32,
+    pub value: i32,
+}
+
+impl Default for KeyedLong {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::msg::rmw::KeyedLong::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for KeyedLong {
+    type RmwMsg = crate::vendor::test_msgs::msg::rmw::KeyedLong;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                key: msg.key,
+                value: msg.value,
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                key: msg.key,
+                value: msg.value,
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            key: msg.key,
+            value: msg.value,
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct KeyedString {
+    pub key: std::string::String,
+    pub value: std::string::String,
+}
+
+impl Default for KeyedString {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::msg::rmw::KeyedString::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for KeyedString {
+    type RmwMsg = crate::vendor::test_msgs::msg::rmw::KeyedString;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                key: msg.key.as_str().into(),
+                value: msg.value.as_str().into(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                key: msg.key.as_str().into(),
+                value: msg.value.as_str().into(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            key: msg.key.to_string(),
+            value: msg.value.to_string(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct NonKeyedWithNestedKey {
+    pub nested_data: crate::vendor::test_msgs::msg::KeyedString,
+    pub some_int: i32,
+}
+
+impl Default for NonKeyedWithNestedKey {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::msg::rmw::NonKeyedWithNestedKey::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for NonKeyedWithNestedKey {
+    type RmwMsg = crate::vendor::test_msgs::msg::rmw::NonKeyedWithNestedKey;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                nested_data: crate::vendor::test_msgs::msg::KeyedString::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.nested_data),
+                )
+                .into_owned(),
+                some_int: msg.some_int,
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                nested_data: crate::vendor::test_msgs::msg::KeyedString::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.nested_data),
+                )
+                .into_owned(),
+                some_int: msg.some_int,
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            nested_data: crate::vendor::test_msgs::msg::KeyedString::from_rmw_message(
+                msg.nested_data,
+            ),
+            some_int: msg.some_int,
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct ComplexNestedKey {
+    pub uint32_key: u32,
+    pub nested_keys: crate::vendor::test_msgs::msg::NonKeyedWithNestedKey,
+    pub float64_value: f64,
+}
+
+impl Default for ComplexNestedKey {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::msg::rmw::ComplexNestedKey::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for ComplexNestedKey {
+    type RmwMsg = crate::vendor::test_msgs::msg::rmw::ComplexNestedKey;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                uint32_key: msg.uint32_key,
+                nested_keys:
+                    crate::vendor::test_msgs::msg::NonKeyedWithNestedKey::into_rmw_message(
+                        std::borrow::Cow::Owned(msg.nested_keys),
+                    )
+                    .into_owned(),
+                float64_value: msg.float64_value,
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                uint32_key: msg.uint32_key,
+                nested_keys:
+                    crate::vendor::test_msgs::msg::NonKeyedWithNestedKey::into_rmw_message(
+                        std::borrow::Cow::Borrowed(&msg.nested_keys),
+                    )
+                    .into_owned(),
+                float64_value: msg.float64_value,
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            uint32_key: msg.uint32_key,
+            nested_keys: crate::vendor::test_msgs::msg::NonKeyedWithNestedKey::from_rmw_message(
+                msg.nested_keys,
+            ),
+            float64_value: msg.float64_value,
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Arrays {
+    pub bool_values: [bool; 3],
+    pub byte_values: [u8; 3],
+    pub char_values: [u8; 3],
+    pub float32_values: [f32; 3],
+    pub float64_values: [f64; 3],
+    pub int8_values: [i8; 3],
+    pub uint8_values: [u8; 3],
+    pub int16_values: [i16; 3],
+    pub uint16_values: [u16; 3],
+    pub int32_values: [i32; 3],
+    pub uint32_values: [u32; 3],
+    pub int64_values: [i64; 3],
+    pub uint64_values: [u64; 3],
+    pub string_values: [std::string::String; 3],
+    pub basic_types_values: [crate::vendor::test_msgs::msg::BasicTypes; 3],
+    pub constants_values: [crate::vendor::test_msgs::msg::Constants; 3],
+    pub defaults_values: [crate::vendor::test_msgs::msg::Defaults; 3],
+    pub bool_values_default: [bool; 3],
+    pub byte_values_default: [u8; 3],
+    pub char_values_default: [u8; 3],
+    pub float32_values_default: [f32; 3],
+    pub float64_values_default: [f64; 3],
+    pub int8_values_default: [i8; 3],
+    pub uint8_values_default: [u8; 3],
+    pub int16_values_default: [i16; 3],
+    pub uint16_values_default: [u16; 3],
+    pub int32_values_default: [i32; 3],
+    pub uint32_values_default: [u32; 3],
+    pub int64_values_default: [i64; 3],
+    pub uint64_values_default: [u64; 3],
+    pub string_values_default: [std::string::String; 3],
+    pub alignment_check: i32,
+}
+
+impl Default for Arrays {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::msg::rmw::Arrays::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Arrays {
+    type RmwMsg = crate::vendor::test_msgs::msg::rmw::Arrays;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                bool_values: msg.bool_values,
+                byte_values: msg.byte_values,
+                char_values: msg.char_values,
+                float32_values: msg.float32_values,
+                float64_values: msg.float64_values,
+                int8_values: msg.int8_values,
+                uint8_values: msg.uint8_values,
+                int16_values: msg.int16_values,
+                uint16_values: msg.uint16_values,
+                int32_values: msg.int32_values,
+                uint32_values: msg.uint32_values,
+                int64_values: msg.int64_values,
+                uint64_values: msg.uint64_values,
+                string_values: msg.string_values.map(|elem| elem.as_str().into()),
+                basic_types_values: msg.basic_types_values.map(|elem| {
+                    crate::vendor::test_msgs::msg::BasicTypes::into_rmw_message(
+                        std::borrow::Cow::Owned(elem),
+                    )
+                    .into_owned()
+                }),
+                constants_values: msg.constants_values.map(|elem| {
+                    crate::vendor::test_msgs::msg::Constants::into_rmw_message(
+                        std::borrow::Cow::Owned(elem),
+                    )
+                    .into_owned()
+                }),
+                defaults_values: msg.defaults_values.map(|elem| {
+                    crate::vendor::test_msgs::msg::Defaults::into_rmw_message(
+                        std::borrow::Cow::Owned(elem),
+                    )
+                    .into_owned()
+                }),
+                bool_values_default: msg.bool_values_default,
+                byte_values_default: msg.byte_values_default,
+                char_values_default: msg.char_values_default,
+                float32_values_default: msg.float32_values_default,
+                float64_values_default: msg.float64_values_default,
+                int8_values_default: msg.int8_values_default,
+                uint8_values_default: msg.uint8_values_default,
+                int16_values_default: msg.int16_values_default,
+                uint16_values_default: msg.uint16_values_default,
+                int32_values_default: msg.int32_values_default,
+                uint32_values_default: msg.uint32_values_default,
+                int64_values_default: msg.int64_values_default,
+                uint64_values_default: msg.uint64_values_default,
+                string_values_default: msg.string_values_default.map(|elem| elem.as_str().into()),
+                alignment_check: msg.alignment_check,
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                bool_values: msg.bool_values,
+                byte_values: msg.byte_values,
+                char_values: msg.char_values,
+                float32_values: msg.float32_values,
+                float64_values: msg.float64_values,
+                int8_values: msg.int8_values,
+                uint8_values: msg.uint8_values,
+                int16_values: msg.int16_values,
+                uint16_values: msg.uint16_values,
+                int32_values: msg.int32_values,
+                uint32_values: msg.uint32_values,
+                int64_values: msg.int64_values,
+                uint64_values: msg.uint64_values,
+                string_values: msg
+                    .string_values
+                    .iter()
+                    .map(|elem| elem.as_str().into())
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .unwrap(),
+                basic_types_values: msg
+                    .basic_types_values
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::test_msgs::msg::BasicTypes::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .unwrap(),
+                constants_values: msg
+                    .constants_values
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::test_msgs::msg::Constants::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .unwrap(),
+                defaults_values: msg
+                    .defaults_values
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::test_msgs::msg::Defaults::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .unwrap(),
+                bool_values_default: msg.bool_values_default,
+                byte_values_default: msg.byte_values_default,
+                char_values_default: msg.char_values_default,
+                float32_values_default: msg.float32_values_default,
+                float64_values_default: msg.float64_values_default,
+                int8_values_default: msg.int8_values_default,
+                uint8_values_default: msg.uint8_values_default,
+                int16_values_default: msg.int16_values_default,
+                uint16_values_default: msg.uint16_values_default,
+                int32_values_default: msg.int32_values_default,
+                uint32_values_default: msg.uint32_values_default,
+                int64_values_default: msg.int64_values_default,
+                uint64_values_default: msg.uint64_values_default,
+                string_values_default: msg
+                    .string_values_default
+                    .iter()
+                    .map(|elem| elem.as_str().into())
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .unwrap(),
+                alignment_check: msg.alignment_check,
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            bool_values: msg.bool_values,
+            byte_values: msg.byte_values,
+            char_values: msg.char_values,
+            float32_values: msg.float32_values,
+            float64_values: msg.float64_values,
+            int8_values: msg.int8_values,
+            uint8_values: msg.uint8_values,
+            int16_values: msg.int16_values,
+            uint16_values: msg.uint16_values,
+            int32_values: msg.int32_values,
+            uint32_values: msg.uint32_values,
+            int64_values: msg.int64_values,
+            uint64_values: msg.uint64_values,
+            string_values: msg.string_values.map(|elem| elem.to_string()),
+            basic_types_values: msg
+                .basic_types_values
+                .map(crate::vendor::test_msgs::msg::BasicTypes::from_rmw_message),
+            constants_values: msg
+                .constants_values
+                .map(crate::vendor::test_msgs::msg::Constants::from_rmw_message),
+            defaults_values: msg
+                .defaults_values
+                .map(crate::vendor::test_msgs::msg::Defaults::from_rmw_message),
+            bool_values_default: msg.bool_values_default,
+            byte_values_default: msg.byte_values_default,
+            char_values_default: msg.char_values_default,
+            float32_values_default: msg.float32_values_default,
+            float64_values_default: msg.float64_values_default,
+            int8_values_default: msg.int8_values_default,
+            uint8_values_default: msg.uint8_values_default,
+            int16_values_default: msg.int16_values_default,
+            uint16_values_default: msg.uint16_values_default,
+            int32_values_default: msg.int32_values_default,
+            uint32_values_default: msg.uint32_values_default,
+            int64_values_default: msg.int64_values_default,
+            uint64_values_default: msg.uint64_values_default,
+            string_values_default: msg.string_values_default.map(|elem| elem.to_string()),
+            alignment_check: msg.alignment_check,
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct BasicTypes {
+    pub bool_value: bool,
+    pub byte_value: u8,
+    pub char_value: u8,
+    pub float32_value: f32,
+    pub float64_value: f64,
+    pub int8_value: i8,
+    pub uint8_value: u8,
+    pub int16_value: i16,
+    pub uint16_value: u16,
+    pub int32_value: i32,
+    pub uint32_value: u32,
+    pub int64_value: i64,
+    pub uint64_value: u64,
+}
+
+impl Default for BasicTypes {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::msg::rmw::BasicTypes::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for BasicTypes {
+    type RmwMsg = crate::vendor::test_msgs::msg::rmw::BasicTypes;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                bool_value: msg.bool_value,
+                byte_value: msg.byte_value,
+                char_value: msg.char_value,
+                float32_value: msg.float32_value,
+                float64_value: msg.float64_value,
+                int8_value: msg.int8_value,
+                uint8_value: msg.uint8_value,
+                int16_value: msg.int16_value,
+                uint16_value: msg.uint16_value,
+                int32_value: msg.int32_value,
+                uint32_value: msg.uint32_value,
+                int64_value: msg.int64_value,
+                uint64_value: msg.uint64_value,
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                bool_value: msg.bool_value,
+                byte_value: msg.byte_value,
+                char_value: msg.char_value,
+                float32_value: msg.float32_value,
+                float64_value: msg.float64_value,
+                int8_value: msg.int8_value,
+                uint8_value: msg.uint8_value,
+                int16_value: msg.int16_value,
+                uint16_value: msg.uint16_value,
+                int32_value: msg.int32_value,
+                uint32_value: msg.uint32_value,
+                int64_value: msg.int64_value,
+                uint64_value: msg.uint64_value,
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            bool_value: msg.bool_value,
+            byte_value: msg.byte_value,
+            char_value: msg.char_value,
+            float32_value: msg.float32_value,
+            float64_value: msg.float64_value,
+            int8_value: msg.int8_value,
+            uint8_value: msg.uint8_value,
+            int16_value: msg.int16_value,
+            uint16_value: msg.uint16_value,
+            int32_value: msg.int32_value,
+            uint32_value: msg.uint32_value,
+            int64_value: msg.int64_value,
+            uint64_value: msg.uint64_value,
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct BoundedPlainSequences {
+    pub bool_values: rosidl_runtime_rs::BoundedSequence<bool, 3>,
+    pub byte_values: rosidl_runtime_rs::BoundedSequence<u8, 3>,
+    pub char_values: rosidl_runtime_rs::BoundedSequence<u8, 3>,
+    pub float32_values: rosidl_runtime_rs::BoundedSequence<f32, 3>,
+    pub float64_values: rosidl_runtime_rs::BoundedSequence<f64, 3>,
+    pub int8_values: rosidl_runtime_rs::BoundedSequence<i8, 3>,
+    pub uint8_values: rosidl_runtime_rs::BoundedSequence<u8, 3>,
+    pub int16_values: rosidl_runtime_rs::BoundedSequence<i16, 3>,
+    pub uint16_values: rosidl_runtime_rs::BoundedSequence<u16, 3>,
+    pub int32_values: rosidl_runtime_rs::BoundedSequence<i32, 3>,
+    pub uint32_values: rosidl_runtime_rs::BoundedSequence<u32, 3>,
+    pub int64_values: rosidl_runtime_rs::BoundedSequence<i64, 3>,
+    pub uint64_values: rosidl_runtime_rs::BoundedSequence<u64, 3>,
+    pub basic_types_values:
+        rosidl_runtime_rs::BoundedSequence<crate::vendor::test_msgs::msg::rmw::BasicTypes, 3>,
+    pub constants_values:
+        rosidl_runtime_rs::BoundedSequence<crate::vendor::test_msgs::msg::rmw::Constants, 3>,
+    pub defaults_values:
+        rosidl_runtime_rs::BoundedSequence<crate::vendor::test_msgs::msg::rmw::Defaults, 3>,
+    pub bool_values_default: rosidl_runtime_rs::BoundedSequence<bool, 3>,
+    pub byte_values_default: rosidl_runtime_rs::BoundedSequence<u8, 3>,
+    pub char_values_default: rosidl_runtime_rs::BoundedSequence<u8, 3>,
+    pub float32_values_default: rosidl_runtime_rs::BoundedSequence<f32, 3>,
+    pub float64_values_default: rosidl_runtime_rs::BoundedSequence<f64, 3>,
+    pub int8_values_default: rosidl_runtime_rs::BoundedSequence<i8, 3>,
+    pub uint8_values_default: rosidl_runtime_rs::BoundedSequence<u8, 3>,
+    pub int16_values_default: rosidl_runtime_rs::BoundedSequence<i16, 3>,
+    pub uint16_values_default: rosidl_runtime_rs::BoundedSequence<u16, 3>,
+    pub int32_values_default: rosidl_runtime_rs::BoundedSequence<i32, 3>,
+    pub uint32_values_default: rosidl_runtime_rs::BoundedSequence<u32, 3>,
+    pub int64_values_default: rosidl_runtime_rs::BoundedSequence<i64, 3>,
+    pub uint64_values_default: rosidl_runtime_rs::BoundedSequence<u64, 3>,
+    pub alignment_check: i32,
+}
+
+impl Default for BoundedPlainSequences {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::msg::rmw::BoundedPlainSequences::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for BoundedPlainSequences {
+    type RmwMsg = crate::vendor::test_msgs::msg::rmw::BoundedPlainSequences;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                bool_values: msg.bool_values,
+                byte_values: msg.byte_values,
+                char_values: msg.char_values,
+                float32_values: msg.float32_values,
+                float64_values: msg.float64_values,
+                int8_values: msg.int8_values,
+                uint8_values: msg.uint8_values,
+                int16_values: msg.int16_values,
+                uint16_values: msg.uint16_values,
+                int32_values: msg.int32_values,
+                uint32_values: msg.uint32_values,
+                int64_values: msg.int64_values,
+                uint64_values: msg.uint64_values,
+                basic_types_values: msg.basic_types_values,
+                constants_values: msg.constants_values,
+                defaults_values: msg.defaults_values,
+                bool_values_default: msg.bool_values_default,
+                byte_values_default: msg.byte_values_default,
+                char_values_default: msg.char_values_default,
+                float32_values_default: msg.float32_values_default,
+                float64_values_default: msg.float64_values_default,
+                int8_values_default: msg.int8_values_default,
+                uint8_values_default: msg.uint8_values_default,
+                int16_values_default: msg.int16_values_default,
+                uint16_values_default: msg.uint16_values_default,
+                int32_values_default: msg.int32_values_default,
+                uint32_values_default: msg.uint32_values_default,
+                int64_values_default: msg.int64_values_default,
+                uint64_values_default: msg.uint64_values_default,
+                alignment_check: msg.alignment_check,
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                bool_values: msg.bool_values.clone(),
+                byte_values: msg.byte_values.clone(),
+                char_values: msg.char_values.clone(),
+                float32_values: msg.float32_values.clone(),
+                float64_values: msg.float64_values.clone(),
+                int8_values: msg.int8_values.clone(),
+                uint8_values: msg.uint8_values.clone(),
+                int16_values: msg.int16_values.clone(),
+                uint16_values: msg.uint16_values.clone(),
+                int32_values: msg.int32_values.clone(),
+                uint32_values: msg.uint32_values.clone(),
+                int64_values: msg.int64_values.clone(),
+                uint64_values: msg.uint64_values.clone(),
+                basic_types_values: msg.basic_types_values.clone(),
+                constants_values: msg.constants_values.clone(),
+                defaults_values: msg.defaults_values.clone(),
+                bool_values_default: msg.bool_values_default.clone(),
+                byte_values_default: msg.byte_values_default.clone(),
+                char_values_default: msg.char_values_default.clone(),
+                float32_values_default: msg.float32_values_default.clone(),
+                float64_values_default: msg.float64_values_default.clone(),
+                int8_values_default: msg.int8_values_default.clone(),
+                uint8_values_default: msg.uint8_values_default.clone(),
+                int16_values_default: msg.int16_values_default.clone(),
+                uint16_values_default: msg.uint16_values_default.clone(),
+                int32_values_default: msg.int32_values_default.clone(),
+                uint32_values_default: msg.uint32_values_default.clone(),
+                int64_values_default: msg.int64_values_default.clone(),
+                uint64_values_default: msg.uint64_values_default.clone(),
+                alignment_check: msg.alignment_check,
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            bool_values: msg.bool_values,
+            byte_values: msg.byte_values,
+            char_values: msg.char_values,
+            float32_values: msg.float32_values,
+            float64_values: msg.float64_values,
+            int8_values: msg.int8_values,
+            uint8_values: msg.uint8_values,
+            int16_values: msg.int16_values,
+            uint16_values: msg.uint16_values,
+            int32_values: msg.int32_values,
+            uint32_values: msg.uint32_values,
+            int64_values: msg.int64_values,
+            uint64_values: msg.uint64_values,
+            basic_types_values: msg.basic_types_values,
+            constants_values: msg.constants_values,
+            defaults_values: msg.defaults_values,
+            bool_values_default: msg.bool_values_default,
+            byte_values_default: msg.byte_values_default,
+            char_values_default: msg.char_values_default,
+            float32_values_default: msg.float32_values_default,
+            float64_values_default: msg.float64_values_default,
+            int8_values_default: msg.int8_values_default,
+            uint8_values_default: msg.uint8_values_default,
+            int16_values_default: msg.int16_values_default,
+            uint16_values_default: msg.uint16_values_default,
+            int32_values_default: msg.int32_values_default,
+            uint32_values_default: msg.uint32_values_default,
+            int64_values_default: msg.int64_values_default,
+            uint64_values_default: msg.uint64_values_default,
+            alignment_check: msg.alignment_check,
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct BoundedSequences {
+    pub bool_values: rosidl_runtime_rs::BoundedSequence<bool, 3>,
+    pub byte_values: rosidl_runtime_rs::BoundedSequence<u8, 3>,
+    pub char_values: rosidl_runtime_rs::BoundedSequence<u8, 3>,
+    pub float32_values: rosidl_runtime_rs::BoundedSequence<f32, 3>,
+    pub float64_values: rosidl_runtime_rs::BoundedSequence<f64, 3>,
+    pub int8_values: rosidl_runtime_rs::BoundedSequence<i8, 3>,
+    pub uint8_values: rosidl_runtime_rs::BoundedSequence<u8, 3>,
+    pub int16_values: rosidl_runtime_rs::BoundedSequence<i16, 3>,
+    pub uint16_values: rosidl_runtime_rs::BoundedSequence<u16, 3>,
+    pub int32_values: rosidl_runtime_rs::BoundedSequence<i32, 3>,
+    pub uint32_values: rosidl_runtime_rs::BoundedSequence<u32, 3>,
+    pub int64_values: rosidl_runtime_rs::BoundedSequence<i64, 3>,
+    pub uint64_values: rosidl_runtime_rs::BoundedSequence<u64, 3>,
+    pub string_values: rosidl_runtime_rs::BoundedSequence<rosidl_runtime_rs::String, 3>,
+    pub basic_types_values:
+        rosidl_runtime_rs::BoundedSequence<crate::vendor::test_msgs::msg::rmw::BasicTypes, 3>,
+    pub constants_values:
+        rosidl_runtime_rs::BoundedSequence<crate::vendor::test_msgs::msg::rmw::Constants, 3>,
+    pub defaults_values:
+        rosidl_runtime_rs::BoundedSequence<crate::vendor::test_msgs::msg::rmw::Defaults, 3>,
+    pub bool_values_default: rosidl_runtime_rs::BoundedSequence<bool, 3>,
+    pub byte_values_default: rosidl_runtime_rs::BoundedSequence<u8, 3>,
+    pub char_values_default: rosidl_runtime_rs::BoundedSequence<u8, 3>,
+    pub float32_values_default: rosidl_runtime_rs::BoundedSequence<f32, 3>,
+    pub float64_values_default: rosidl_runtime_rs::BoundedSequence<f64, 3>,
+    pub int8_values_default: rosidl_runtime_rs::BoundedSequence<i8, 3>,
+    pub uint8_values_default: rosidl_runtime_rs::BoundedSequence<u8, 3>,
+    pub int16_values_default: rosidl_runtime_rs::BoundedSequence<i16, 3>,
+    pub uint16_values_default: rosidl_runtime_rs::BoundedSequence<u16, 3>,
+    pub int32_values_default: rosidl_runtime_rs::BoundedSequence<i32, 3>,
+    pub uint32_values_default: rosidl_runtime_rs::BoundedSequence<u32, 3>,
+    pub int64_values_default: rosidl_runtime_rs::BoundedSequence<i64, 3>,
+    pub uint64_values_default: rosidl_runtime_rs::BoundedSequence<u64, 3>,
+    pub string_values_default: rosidl_runtime_rs::BoundedSequence<rosidl_runtime_rs::String, 3>,
+    pub alignment_check: i32,
+}
+
+impl Default for BoundedSequences {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::msg::rmw::BoundedSequences::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for BoundedSequences {
+    type RmwMsg = crate::vendor::test_msgs::msg::rmw::BoundedSequences;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                bool_values: msg.bool_values,
+                byte_values: msg.byte_values,
+                char_values: msg.char_values,
+                float32_values: msg.float32_values,
+                float64_values: msg.float64_values,
+                int8_values: msg.int8_values,
+                uint8_values: msg.uint8_values,
+                int16_values: msg.int16_values,
+                uint16_values: msg.uint16_values,
+                int32_values: msg.int32_values,
+                uint32_values: msg.uint32_values,
+                int64_values: msg.int64_values,
+                uint64_values: msg.uint64_values,
+                string_values: msg.string_values,
+                basic_types_values: msg.basic_types_values,
+                constants_values: msg.constants_values,
+                defaults_values: msg.defaults_values,
+                bool_values_default: msg.bool_values_default,
+                byte_values_default: msg.byte_values_default,
+                char_values_default: msg.char_values_default,
+                float32_values_default: msg.float32_values_default,
+                float64_values_default: msg.float64_values_default,
+                int8_values_default: msg.int8_values_default,
+                uint8_values_default: msg.uint8_values_default,
+                int16_values_default: msg.int16_values_default,
+                uint16_values_default: msg.uint16_values_default,
+                int32_values_default: msg.int32_values_default,
+                uint32_values_default: msg.uint32_values_default,
+                int64_values_default: msg.int64_values_default,
+                uint64_values_default: msg.uint64_values_default,
+                string_values_default: msg.string_values_default,
+                alignment_check: msg.alignment_check,
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                bool_values: msg.bool_values.clone(),
+                byte_values: msg.byte_values.clone(),
+                char_values: msg.char_values.clone(),
+                float32_values: msg.float32_values.clone(),
+                float64_values: msg.float64_values.clone(),
+                int8_values: msg.int8_values.clone(),
+                uint8_values: msg.uint8_values.clone(),
+                int16_values: msg.int16_values.clone(),
+                uint16_values: msg.uint16_values.clone(),
+                int32_values: msg.int32_values.clone(),
+                uint32_values: msg.uint32_values.clone(),
+                int64_values: msg.int64_values.clone(),
+                uint64_values: msg.uint64_values.clone(),
+                string_values: msg.string_values.clone(),
+                basic_types_values: msg.basic_types_values.clone(),
+                constants_values: msg.constants_values.clone(),
+                defaults_values: msg.defaults_values.clone(),
+                bool_values_default: msg.bool_values_default.clone(),
+                byte_values_default: msg.byte_values_default.clone(),
+                char_values_default: msg.char_values_default.clone(),
+                float32_values_default: msg.float32_values_default.clone(),
+                float64_values_default: msg.float64_values_default.clone(),
+                int8_values_default: msg.int8_values_default.clone(),
+                uint8_values_default: msg.uint8_values_default.clone(),
+                int16_values_default: msg.int16_values_default.clone(),
+                uint16_values_default: msg.uint16_values_default.clone(),
+                int32_values_default: msg.int32_values_default.clone(),
+                uint32_values_default: msg.uint32_values_default.clone(),
+                int64_values_default: msg.int64_values_default.clone(),
+                uint64_values_default: msg.uint64_values_default.clone(),
+                string_values_default: msg.string_values_default.clone(),
+                alignment_check: msg.alignment_check,
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            bool_values: msg.bool_values,
+            byte_values: msg.byte_values,
+            char_values: msg.char_values,
+            float32_values: msg.float32_values,
+            float64_values: msg.float64_values,
+            int8_values: msg.int8_values,
+            uint8_values: msg.uint8_values,
+            int16_values: msg.int16_values,
+            uint16_values: msg.uint16_values,
+            int32_values: msg.int32_values,
+            uint32_values: msg.uint32_values,
+            int64_values: msg.int64_values,
+            uint64_values: msg.uint64_values,
+            string_values: msg.string_values,
+            basic_types_values: msg.basic_types_values,
+            constants_values: msg.constants_values,
+            defaults_values: msg.defaults_values,
+            bool_values_default: msg.bool_values_default,
+            byte_values_default: msg.byte_values_default,
+            char_values_default: msg.char_values_default,
+            float32_values_default: msg.float32_values_default,
+            float64_values_default: msg.float64_values_default,
+            int8_values_default: msg.int8_values_default,
+            uint8_values_default: msg.uint8_values_default,
+            int16_values_default: msg.int16_values_default,
+            uint16_values_default: msg.uint16_values_default,
+            int32_values_default: msg.int32_values_default,
+            uint32_values_default: msg.uint32_values_default,
+            int64_values_default: msg.int64_values_default,
+            uint64_values_default: msg.uint64_values_default,
+            string_values_default: msg.string_values_default,
+            alignment_check: msg.alignment_check,
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Constants {
+    pub structure_needs_at_least_one_member: u8,
+}
+
+impl Constants {
+    pub const BOOL_CONST: bool = true;
+    pub const BYTE_CONST: u8 = 50;
+    pub const CHAR_CONST: u8 = 100;
+    pub const FLOAT32_CONST: f32 = 1.125;
+    pub const FLOAT64_CONST: f64 = 1.125;
+    pub const INT8_CONST: i8 = -50;
+    pub const UINT8_CONST: u8 = 200;
+    pub const INT16_CONST: i16 = -1000;
+    pub const UINT16_CONST: u16 = 2000;
+    pub const INT32_CONST: i32 = -30000;
+    pub const UINT32_CONST: u32 = 60000;
+    pub const INT64_CONST: i64 = -40000000;
+    pub const UINT64_CONST: u64 = 50000000;
+}
+
+impl Default for Constants {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::msg::rmw::Constants::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Constants {
+    type RmwMsg = crate::vendor::test_msgs::msg::rmw::Constants;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                structure_needs_at_least_one_member: msg.structure_needs_at_least_one_member,
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                structure_needs_at_least_one_member: msg.structure_needs_at_least_one_member,
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            structure_needs_at_least_one_member: msg.structure_needs_at_least_one_member,
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Defaults {
+    pub bool_value: bool,
+    pub byte_value: u8,
+    pub char_value: u8,
+    pub float32_value: f32,
+    pub float64_value: f64,
+    pub int8_value: i8,
+    pub uint8_value: u8,
+    pub int16_value: i16,
+    pub uint16_value: u16,
+    pub int32_value: i32,
+    pub uint32_value: u32,
+    pub int64_value: i64,
+    pub uint64_value: u64,
+}
+
+impl Default for Defaults {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::msg::rmw::Defaults::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Defaults {
+    type RmwMsg = crate::vendor::test_msgs::msg::rmw::Defaults;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                bool_value: msg.bool_value,
+                byte_value: msg.byte_value,
+                char_value: msg.char_value,
+                float32_value: msg.float32_value,
+                float64_value: msg.float64_value,
+                int8_value: msg.int8_value,
+                uint8_value: msg.uint8_value,
+                int16_value: msg.int16_value,
+                uint16_value: msg.uint16_value,
+                int32_value: msg.int32_value,
+                uint32_value: msg.uint32_value,
+                int64_value: msg.int64_value,
+                uint64_value: msg.uint64_value,
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                bool_value: msg.bool_value,
+                byte_value: msg.byte_value,
+                char_value: msg.char_value,
+                float32_value: msg.float32_value,
+                float64_value: msg.float64_value,
+                int8_value: msg.int8_value,
+                uint8_value: msg.uint8_value,
+                int16_value: msg.int16_value,
+                uint16_value: msg.uint16_value,
+                int32_value: msg.int32_value,
+                uint32_value: msg.uint32_value,
+                int64_value: msg.int64_value,
+                uint64_value: msg.uint64_value,
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            bool_value: msg.bool_value,
+            byte_value: msg.byte_value,
+            char_value: msg.char_value,
+            float32_value: msg.float32_value,
+            float64_value: msg.float64_value,
+            int8_value: msg.int8_value,
+            uint8_value: msg.uint8_value,
+            int16_value: msg.int16_value,
+            uint16_value: msg.uint16_value,
+            int32_value: msg.int32_value,
+            uint32_value: msg.uint32_value,
+            int64_value: msg.int64_value,
+            uint64_value: msg.uint64_value,
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Empty {
+    pub structure_needs_at_least_one_member: u8,
+}
+
+impl Default for Empty {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::msg::rmw::Empty::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Empty {
+    type RmwMsg = crate::vendor::test_msgs::msg::rmw::Empty;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                structure_needs_at_least_one_member: msg.structure_needs_at_least_one_member,
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                structure_needs_at_least_one_member: msg.structure_needs_at_least_one_member,
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            structure_needs_at_least_one_member: msg.structure_needs_at_least_one_member,
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct MultiNested {
+    pub array_of_arrays: [crate::vendor::test_msgs::msg::Arrays; 3],
+    pub array_of_bounded_sequences: [crate::vendor::test_msgs::msg::BoundedSequences; 3],
+    pub array_of_unbounded_sequences: [crate::vendor::test_msgs::msg::UnboundedSequences; 3],
+    pub bounded_sequence_of_arrays:
+        rosidl_runtime_rs::BoundedSequence<crate::vendor::test_msgs::msg::rmw::Arrays, 3>,
+    pub bounded_sequence_of_bounded_sequences:
+        rosidl_runtime_rs::BoundedSequence<crate::vendor::test_msgs::msg::rmw::BoundedSequences, 3>,
+    pub bounded_sequence_of_unbounded_sequences: rosidl_runtime_rs::BoundedSequence<
+        crate::vendor::test_msgs::msg::rmw::UnboundedSequences,
+        3,
+    >,
+    pub unbounded_sequence_of_arrays: Vec<crate::vendor::test_msgs::msg::Arrays>,
+    pub unbounded_sequence_of_bounded_sequences:
+        Vec<crate::vendor::test_msgs::msg::BoundedSequences>,
+    pub unbounded_sequence_of_unbounded_sequences:
+        Vec<crate::vendor::test_msgs::msg::UnboundedSequences>,
+}
+
+impl Default for MultiNested {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::msg::rmw::MultiNested::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for MultiNested {
+    type RmwMsg = crate::vendor::test_msgs::msg::rmw::MultiNested;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                array_of_arrays: msg.array_of_arrays.map(|elem| {
+                    crate::vendor::test_msgs::msg::Arrays::into_rmw_message(
+                        std::borrow::Cow::Owned(elem),
+                    )
+                    .into_owned()
+                }),
+                array_of_bounded_sequences: msg.array_of_bounded_sequences.map(|elem| {
+                    crate::vendor::test_msgs::msg::BoundedSequences::into_rmw_message(
+                        std::borrow::Cow::Owned(elem),
+                    )
+                    .into_owned()
+                }),
+                array_of_unbounded_sequences: msg.array_of_unbounded_sequences.map(|elem| {
+                    crate::vendor::test_msgs::msg::UnboundedSequences::into_rmw_message(
+                        std::borrow::Cow::Owned(elem),
+                    )
+                    .into_owned()
+                }),
+                bounded_sequence_of_arrays: msg.bounded_sequence_of_arrays,
+                bounded_sequence_of_bounded_sequences: msg.bounded_sequence_of_bounded_sequences,
+                bounded_sequence_of_unbounded_sequences: msg
+                    .bounded_sequence_of_unbounded_sequences,
+                unbounded_sequence_of_arrays: msg
+                    .unbounded_sequence_of_arrays
+                    .into_iter()
+                    .map(|elem| {
+                        crate::vendor::test_msgs::msg::Arrays::into_rmw_message(
+                            std::borrow::Cow::Owned(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+                unbounded_sequence_of_bounded_sequences: msg
+                    .unbounded_sequence_of_bounded_sequences
+                    .into_iter()
+                    .map(|elem| {
+                        crate::vendor::test_msgs::msg::BoundedSequences::into_rmw_message(
+                            std::borrow::Cow::Owned(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+                unbounded_sequence_of_unbounded_sequences: msg
+                    .unbounded_sequence_of_unbounded_sequences
+                    .into_iter()
+                    .map(|elem| {
+                        crate::vendor::test_msgs::msg::UnboundedSequences::into_rmw_message(
+                            std::borrow::Cow::Owned(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                array_of_arrays: msg
+                    .array_of_arrays
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::test_msgs::msg::Arrays::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .unwrap(),
+                array_of_bounded_sequences: msg
+                    .array_of_bounded_sequences
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::test_msgs::msg::BoundedSequences::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .unwrap(),
+                array_of_unbounded_sequences: msg
+                    .array_of_unbounded_sequences
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::test_msgs::msg::UnboundedSequences::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .unwrap(),
+                bounded_sequence_of_arrays: msg.bounded_sequence_of_arrays.clone(),
+                bounded_sequence_of_bounded_sequences: msg
+                    .bounded_sequence_of_bounded_sequences
+                    .clone(),
+                bounded_sequence_of_unbounded_sequences: msg
+                    .bounded_sequence_of_unbounded_sequences
+                    .clone(),
+                unbounded_sequence_of_arrays: msg
+                    .unbounded_sequence_of_arrays
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::test_msgs::msg::Arrays::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+                unbounded_sequence_of_bounded_sequences: msg
+                    .unbounded_sequence_of_bounded_sequences
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::test_msgs::msg::BoundedSequences::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+                unbounded_sequence_of_unbounded_sequences: msg
+                    .unbounded_sequence_of_unbounded_sequences
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::test_msgs::msg::UnboundedSequences::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            array_of_arrays: msg
+                .array_of_arrays
+                .map(crate::vendor::test_msgs::msg::Arrays::from_rmw_message),
+            array_of_bounded_sequences: msg
+                .array_of_bounded_sequences
+                .map(crate::vendor::test_msgs::msg::BoundedSequences::from_rmw_message),
+            array_of_unbounded_sequences: msg
+                .array_of_unbounded_sequences
+                .map(crate::vendor::test_msgs::msg::UnboundedSequences::from_rmw_message),
+            bounded_sequence_of_arrays: msg.bounded_sequence_of_arrays,
+            bounded_sequence_of_bounded_sequences: msg.bounded_sequence_of_bounded_sequences,
+            bounded_sequence_of_unbounded_sequences: msg.bounded_sequence_of_unbounded_sequences,
+            unbounded_sequence_of_arrays: msg
+                .unbounded_sequence_of_arrays
+                .into_iter()
+                .map(crate::vendor::test_msgs::msg::Arrays::from_rmw_message)
+                .collect(),
+            unbounded_sequence_of_bounded_sequences: msg
+                .unbounded_sequence_of_bounded_sequences
+                .into_iter()
+                .map(crate::vendor::test_msgs::msg::BoundedSequences::from_rmw_message)
+                .collect(),
+            unbounded_sequence_of_unbounded_sequences: msg
+                .unbounded_sequence_of_unbounded_sequences
+                .into_iter()
+                .map(crate::vendor::test_msgs::msg::UnboundedSequences::from_rmw_message)
+                .collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Nested {
+    pub basic_types_value: crate::vendor::test_msgs::msg::BasicTypes,
+}
+
+impl Default for Nested {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::msg::rmw::Nested::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Nested {
+    type RmwMsg = crate::vendor::test_msgs::msg::rmw::Nested;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                basic_types_value: crate::vendor::test_msgs::msg::BasicTypes::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.basic_types_value),
+                )
+                .into_owned(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                basic_types_value: crate::vendor::test_msgs::msg::BasicTypes::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.basic_types_value),
+                )
+                .into_owned(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            basic_types_value: crate::vendor::test_msgs::msg::BasicTypes::from_rmw_message(
+                msg.basic_types_value,
+            ),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Strings {
+    pub string_value: std::string::String,
+    pub string_value_default1: std::string::String,
+    pub string_value_default2: std::string::String,
+    pub string_value_default3: std::string::String,
+    pub string_value_default4: std::string::String,
+    pub string_value_default5: std::string::String,
+    pub bounded_string_value: rosidl_runtime_rs::BoundedString<22>,
+    pub bounded_string_value_default1: rosidl_runtime_rs::BoundedString<22>,
+    pub bounded_string_value_default2: rosidl_runtime_rs::BoundedString<22>,
+    pub bounded_string_value_default3: rosidl_runtime_rs::BoundedString<22>,
+    pub bounded_string_value_default4: rosidl_runtime_rs::BoundedString<22>,
+    pub bounded_string_value_default5: rosidl_runtime_rs::BoundedString<22>,
+}
+
+impl Strings {
+    pub const STRING_CONST: &'static str = "Hello world!";
+}
+
+impl Default for Strings {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::msg::rmw::Strings::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Strings {
+    type RmwMsg = crate::vendor::test_msgs::msg::rmw::Strings;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                string_value: msg.string_value.as_str().into(),
+                string_value_default1: msg.string_value_default1.as_str().into(),
+                string_value_default2: msg.string_value_default2.as_str().into(),
+                string_value_default3: msg.string_value_default3.as_str().into(),
+                string_value_default4: msg.string_value_default4.as_str().into(),
+                string_value_default5: msg.string_value_default5.as_str().into(),
+                bounded_string_value: msg.bounded_string_value,
+                bounded_string_value_default1: msg.bounded_string_value_default1,
+                bounded_string_value_default2: msg.bounded_string_value_default2,
+                bounded_string_value_default3: msg.bounded_string_value_default3,
+                bounded_string_value_default4: msg.bounded_string_value_default4,
+                bounded_string_value_default5: msg.bounded_string_value_default5,
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                string_value: msg.string_value.as_str().into(),
+                string_value_default1: msg.string_value_default1.as_str().into(),
+                string_value_default2: msg.string_value_default2.as_str().into(),
+                string_value_default3: msg.string_value_default3.as_str().into(),
+                string_value_default4: msg.string_value_default4.as_str().into(),
+                string_value_default5: msg.string_value_default5.as_str().into(),
+                bounded_string_value: msg.bounded_string_value.clone(),
+                bounded_string_value_default1: msg.bounded_string_value_default1.clone(),
+                bounded_string_value_default2: msg.bounded_string_value_default2.clone(),
+                bounded_string_value_default3: msg.bounded_string_value_default3.clone(),
+                bounded_string_value_default4: msg.bounded_string_value_default4.clone(),
+                bounded_string_value_default5: msg.bounded_string_value_default5.clone(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            string_value: msg.string_value.to_string(),
+            string_value_default1: msg.string_value_default1.to_string(),
+            string_value_default2: msg.string_value_default2.to_string(),
+            string_value_default3: msg.string_value_default3.to_string(),
+            string_value_default4: msg.string_value_default4.to_string(),
+            string_value_default5: msg.string_value_default5.to_string(),
+            bounded_string_value: msg.bounded_string_value,
+            bounded_string_value_default1: msg.bounded_string_value_default1,
+            bounded_string_value_default2: msg.bounded_string_value_default2,
+            bounded_string_value_default3: msg.bounded_string_value_default3,
+            bounded_string_value_default4: msg.bounded_string_value_default4,
+            bounded_string_value_default5: msg.bounded_string_value_default5,
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct UnboundedSequences {
+    pub bool_values: Vec<bool>,
+    pub byte_values: Vec<u8>,
+    pub char_values: Vec<u8>,
+    pub float32_values: Vec<f32>,
+    pub float64_values: Vec<f64>,
+    pub int8_values: Vec<i8>,
+    pub uint8_values: Vec<u8>,
+    pub int16_values: Vec<i16>,
+    pub uint16_values: Vec<u16>,
+    pub int32_values: Vec<i32>,
+    pub uint32_values: Vec<u32>,
+    pub int64_values: Vec<i64>,
+    pub uint64_values: Vec<u64>,
+    pub string_values: Vec<std::string::String>,
+    pub basic_types_values: Vec<crate::vendor::test_msgs::msg::BasicTypes>,
+    pub constants_values: Vec<crate::vendor::test_msgs::msg::Constants>,
+    pub defaults_values: Vec<crate::vendor::test_msgs::msg::Defaults>,
+    pub bool_values_default: Vec<bool>,
+    pub byte_values_default: Vec<u8>,
+    pub char_values_default: Vec<u8>,
+    pub float32_values_default: Vec<f32>,
+    pub float64_values_default: Vec<f64>,
+    pub int8_values_default: Vec<i8>,
+    pub uint8_values_default: Vec<u8>,
+    pub int16_values_default: Vec<i16>,
+    pub uint16_values_default: Vec<u16>,
+    pub int32_values_default: Vec<i32>,
+    pub uint32_values_default: Vec<u32>,
+    pub int64_values_default: Vec<i64>,
+    pub uint64_values_default: Vec<u64>,
+    pub string_values_default: Vec<std::string::String>,
+    pub alignment_check: i32,
+}
+
+impl Default for UnboundedSequences {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::msg::rmw::UnboundedSequences::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for UnboundedSequences {
+    type RmwMsg = crate::vendor::test_msgs::msg::rmw::UnboundedSequences;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                bool_values: msg.bool_values.into(),
+                byte_values: msg.byte_values.into(),
+                char_values: msg.char_values.into(),
+                float32_values: msg.float32_values.into(),
+                float64_values: msg.float64_values.into(),
+                int8_values: msg.int8_values.into(),
+                uint8_values: msg.uint8_values.into(),
+                int16_values: msg.int16_values.into(),
+                uint16_values: msg.uint16_values.into(),
+                int32_values: msg.int32_values.into(),
+                uint32_values: msg.uint32_values.into(),
+                int64_values: msg.int64_values.into(),
+                uint64_values: msg.uint64_values.into(),
+                string_values: msg
+                    .string_values
+                    .into_iter()
+                    .map(|elem| elem.as_str().into())
+                    .collect(),
+                basic_types_values: msg
+                    .basic_types_values
+                    .into_iter()
+                    .map(|elem| {
+                        crate::vendor::test_msgs::msg::BasicTypes::into_rmw_message(
+                            std::borrow::Cow::Owned(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+                constants_values: msg
+                    .constants_values
+                    .into_iter()
+                    .map(|elem| {
+                        crate::vendor::test_msgs::msg::Constants::into_rmw_message(
+                            std::borrow::Cow::Owned(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+                defaults_values: msg
+                    .defaults_values
+                    .into_iter()
+                    .map(|elem| {
+                        crate::vendor::test_msgs::msg::Defaults::into_rmw_message(
+                            std::borrow::Cow::Owned(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+                bool_values_default: msg.bool_values_default.into(),
+                byte_values_default: msg.byte_values_default.into(),
+                char_values_default: msg.char_values_default.into(),
+                float32_values_default: msg.float32_values_default.into(),
+                float64_values_default: msg.float64_values_default.into(),
+                int8_values_default: msg.int8_values_default.into(),
+                uint8_values_default: msg.uint8_values_default.into(),
+                int16_values_default: msg.int16_values_default.into(),
+                uint16_values_default: msg.uint16_values_default.into(),
+                int32_values_default: msg.int32_values_default.into(),
+                uint32_values_default: msg.uint32_values_default.into(),
+                int64_values_default: msg.int64_values_default.into(),
+                uint64_values_default: msg.uint64_values_default.into(),
+                string_values_default: msg
+                    .string_values_default
+                    .into_iter()
+                    .map(|elem| elem.as_str().into())
+                    .collect(),
+                alignment_check: msg.alignment_check,
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                bool_values: msg.bool_values.as_slice().into(),
+                byte_values: msg.byte_values.as_slice().into(),
+                char_values: msg.char_values.as_slice().into(),
+                float32_values: msg.float32_values.as_slice().into(),
+                float64_values: msg.float64_values.as_slice().into(),
+                int8_values: msg.int8_values.as_slice().into(),
+                uint8_values: msg.uint8_values.as_slice().into(),
+                int16_values: msg.int16_values.as_slice().into(),
+                uint16_values: msg.uint16_values.as_slice().into(),
+                int32_values: msg.int32_values.as_slice().into(),
+                uint32_values: msg.uint32_values.as_slice().into(),
+                int64_values: msg.int64_values.as_slice().into(),
+                uint64_values: msg.uint64_values.as_slice().into(),
+                string_values: msg
+                    .string_values
+                    .iter()
+                    .map(|elem| elem.as_str().into())
+                    .collect(),
+                basic_types_values: msg
+                    .basic_types_values
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::test_msgs::msg::BasicTypes::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+                constants_values: msg
+                    .constants_values
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::test_msgs::msg::Constants::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+                defaults_values: msg
+                    .defaults_values
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::test_msgs::msg::Defaults::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+                bool_values_default: msg.bool_values_default.as_slice().into(),
+                byte_values_default: msg.byte_values_default.as_slice().into(),
+                char_values_default: msg.char_values_default.as_slice().into(),
+                float32_values_default: msg.float32_values_default.as_slice().into(),
+                float64_values_default: msg.float64_values_default.as_slice().into(),
+                int8_values_default: msg.int8_values_default.as_slice().into(),
+                uint8_values_default: msg.uint8_values_default.as_slice().into(),
+                int16_values_default: msg.int16_values_default.as_slice().into(),
+                uint16_values_default: msg.uint16_values_default.as_slice().into(),
+                int32_values_default: msg.int32_values_default.as_slice().into(),
+                uint32_values_default: msg.uint32_values_default.as_slice().into(),
+                int64_values_default: msg.int64_values_default.as_slice().into(),
+                uint64_values_default: msg.uint64_values_default.as_slice().into(),
+                string_values_default: msg
+                    .string_values_default
+                    .iter()
+                    .map(|elem| elem.as_str().into())
+                    .collect(),
+                alignment_check: msg.alignment_check,
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            bool_values: msg.bool_values.into_iter().collect(),
+            byte_values: msg.byte_values.into_iter().collect(),
+            char_values: msg.char_values.into_iter().collect(),
+            float32_values: msg.float32_values.into_iter().collect(),
+            float64_values: msg.float64_values.into_iter().collect(),
+            int8_values: msg.int8_values.into_iter().collect(),
+            uint8_values: msg.uint8_values.into_iter().collect(),
+            int16_values: msg.int16_values.into_iter().collect(),
+            uint16_values: msg.uint16_values.into_iter().collect(),
+            int32_values: msg.int32_values.into_iter().collect(),
+            uint32_values: msg.uint32_values.into_iter().collect(),
+            int64_values: msg.int64_values.into_iter().collect(),
+            uint64_values: msg.uint64_values.into_iter().collect(),
+            string_values: msg
+                .string_values
+                .into_iter()
+                .map(|elem| elem.to_string())
+                .collect(),
+            basic_types_values: msg
+                .basic_types_values
+                .into_iter()
+                .map(crate::vendor::test_msgs::msg::BasicTypes::from_rmw_message)
+                .collect(),
+            constants_values: msg
+                .constants_values
+                .into_iter()
+                .map(crate::vendor::test_msgs::msg::Constants::from_rmw_message)
+                .collect(),
+            defaults_values: msg
+                .defaults_values
+                .into_iter()
+                .map(crate::vendor::test_msgs::msg::Defaults::from_rmw_message)
+                .collect(),
+            bool_values_default: msg.bool_values_default.into_iter().collect(),
+            byte_values_default: msg.byte_values_default.into_iter().collect(),
+            char_values_default: msg.char_values_default.into_iter().collect(),
+            float32_values_default: msg.float32_values_default.into_iter().collect(),
+            float64_values_default: msg.float64_values_default.into_iter().collect(),
+            int8_values_default: msg.int8_values_default.into_iter().collect(),
+            uint8_values_default: msg.uint8_values_default.into_iter().collect(),
+            int16_values_default: msg.int16_values_default.into_iter().collect(),
+            uint16_values_default: msg.uint16_values_default.into_iter().collect(),
+            int32_values_default: msg.int32_values_default.into_iter().collect(),
+            uint32_values_default: msg.uint32_values_default.into_iter().collect(),
+            int64_values_default: msg.int64_values_default.into_iter().collect(),
+            uint64_values_default: msg.uint64_values_default.into_iter().collect(),
+            string_values_default: msg
+                .string_values_default
+                .into_iter()
+                .map(|elem| elem.to_string())
+                .collect(),
+            alignment_check: msg.alignment_check,
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct WStrings {
+    pub wstring_value: std::string::String,
+    pub wstring_value_default1: std::string::String,
+    pub wstring_value_default2: std::string::String,
+    pub wstring_value_default3: std::string::String,
+    pub array_of_wstrings: [std::string::String; 3],
+    pub bounded_sequence_of_wstrings:
+        rosidl_runtime_rs::BoundedSequence<rosidl_runtime_rs::WString, 3>,
+    pub unbounded_sequence_of_wstrings: Vec<std::string::String>,
+}
+
+impl Default for WStrings {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::msg::rmw::WStrings::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for WStrings {
+    type RmwMsg = crate::vendor::test_msgs::msg::rmw::WStrings;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                wstring_value: msg.wstring_value.as_str().into(),
+                wstring_value_default1: msg.wstring_value_default1.as_str().into(),
+                wstring_value_default2: msg.wstring_value_default2.as_str().into(),
+                wstring_value_default3: msg.wstring_value_default3.as_str().into(),
+                array_of_wstrings: msg.array_of_wstrings.map(|elem| elem.as_str().into()),
+                bounded_sequence_of_wstrings: msg.bounded_sequence_of_wstrings,
+                unbounded_sequence_of_wstrings: msg
+                    .unbounded_sequence_of_wstrings
+                    .into_iter()
+                    .map(|elem| elem.as_str().into())
+                    .collect(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                wstring_value: msg.wstring_value.as_str().into(),
+                wstring_value_default1: msg.wstring_value_default1.as_str().into(),
+                wstring_value_default2: msg.wstring_value_default2.as_str().into(),
+                wstring_value_default3: msg.wstring_value_default3.as_str().into(),
+                array_of_wstrings: msg
+                    .array_of_wstrings
+                    .iter()
+                    .map(|elem| elem.as_str().into())
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .unwrap(),
+                bounded_sequence_of_wstrings: msg.bounded_sequence_of_wstrings.clone(),
+                unbounded_sequence_of_wstrings: msg
+                    .unbounded_sequence_of_wstrings
+                    .iter()
+                    .map(|elem| elem.as_str().into())
+                    .collect(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            wstring_value: msg.wstring_value.to_string(),
+            wstring_value_default1: msg.wstring_value_default1.to_string(),
+            wstring_value_default2: msg.wstring_value_default2.to_string(),
+            wstring_value_default3: msg.wstring_value_default3.to_string(),
+            array_of_wstrings: msg.array_of_wstrings.map(|elem| elem.to_string()),
+            bounded_sequence_of_wstrings: msg.bounded_sequence_of_wstrings,
+            unbounded_sequence_of_wstrings: msg
+                .unbounded_sequence_of_wstrings
+                .into_iter()
+                .map(|elem| elem.to_string())
+                .collect(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Builtins {
+    pub duration_value: crate::vendor::builtin_interfaces::msg::Duration,
+    pub time_value: crate::vendor::builtin_interfaces::msg::Time,
+}
+
+impl Default for Builtins {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::msg::rmw::Builtins::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Builtins {
+    type RmwMsg = crate::vendor::test_msgs::msg::rmw::Builtins;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                duration_value: crate::vendor::builtin_interfaces::msg::Duration::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.duration_value),
+                )
+                .into_owned(),
+                time_value: crate::vendor::builtin_interfaces::msg::Time::into_rmw_message(
+                    std::borrow::Cow::Owned(msg.time_value),
+                )
+                .into_owned(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                duration_value: crate::vendor::builtin_interfaces::msg::Duration::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.duration_value),
+                )
+                .into_owned(),
+                time_value: crate::vendor::builtin_interfaces::msg::Time::into_rmw_message(
+                    std::borrow::Cow::Borrowed(&msg.time_value),
+                )
+                .into_owned(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            duration_value: crate::vendor::builtin_interfaces::msg::Duration::from_rmw_message(
+                msg.duration_value,
+            ),
+            time_value: crate::vendor::builtin_interfaces::msg::Time::from_rmw_message(
+                msg.time_value,
+            ),
+        }
+    }
+}

--- a/rclrs/src/vendor/test_msgs/srv.rs
+++ b/rclrs/src/vendor/test_msgs/srv.rs
@@ -1,0 +1,1415 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Arrays_Request {
+    pub bool_values: [bool; 3],
+    pub byte_values: [u8; 3],
+    pub char_values: [u8; 3],
+    pub float32_values: [f32; 3],
+    pub float64_values: [f64; 3],
+    pub int8_values: [i8; 3],
+    pub uint8_values: [u8; 3],
+    pub int16_values: [i16; 3],
+    pub uint16_values: [u16; 3],
+    pub int32_values: [i32; 3],
+    pub uint32_values: [u32; 3],
+    pub int64_values: [i64; 3],
+    pub uint64_values: [u64; 3],
+    pub string_values: [std::string::String; 3],
+    pub basic_types_values: [crate::vendor::test_msgs::msg::BasicTypes; 3],
+    pub constants_values: [crate::vendor::test_msgs::msg::Constants; 3],
+    pub defaults_values: [crate::vendor::test_msgs::msg::Defaults; 3],
+    pub bool_values_default: [bool; 3],
+    pub byte_values_default: [u8; 3],
+    pub char_values_default: [u8; 3],
+    pub float32_values_default: [f32; 3],
+    pub float64_values_default: [f64; 3],
+    pub int8_values_default: [i8; 3],
+    pub uint8_values_default: [u8; 3],
+    pub int16_values_default: [i16; 3],
+    pub uint16_values_default: [u16; 3],
+    pub int32_values_default: [i32; 3],
+    pub uint32_values_default: [u32; 3],
+    pub int64_values_default: [i64; 3],
+    pub uint64_values_default: [u64; 3],
+    pub string_values_default: [std::string::String; 3],
+}
+
+impl Default for Arrays_Request {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::srv::rmw::Arrays_Request::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Arrays_Request {
+    type RmwMsg = crate::vendor::test_msgs::srv::rmw::Arrays_Request;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                bool_values: msg.bool_values,
+                byte_values: msg.byte_values,
+                char_values: msg.char_values,
+                float32_values: msg.float32_values,
+                float64_values: msg.float64_values,
+                int8_values: msg.int8_values,
+                uint8_values: msg.uint8_values,
+                int16_values: msg.int16_values,
+                uint16_values: msg.uint16_values,
+                int32_values: msg.int32_values,
+                uint32_values: msg.uint32_values,
+                int64_values: msg.int64_values,
+                uint64_values: msg.uint64_values,
+                string_values: msg.string_values.map(|elem| elem.as_str().into()),
+                basic_types_values: msg.basic_types_values.map(|elem| {
+                    crate::vendor::test_msgs::msg::BasicTypes::into_rmw_message(
+                        std::borrow::Cow::Owned(elem),
+                    )
+                    .into_owned()
+                }),
+                constants_values: msg.constants_values.map(|elem| {
+                    crate::vendor::test_msgs::msg::Constants::into_rmw_message(
+                        std::borrow::Cow::Owned(elem),
+                    )
+                    .into_owned()
+                }),
+                defaults_values: msg.defaults_values.map(|elem| {
+                    crate::vendor::test_msgs::msg::Defaults::into_rmw_message(
+                        std::borrow::Cow::Owned(elem),
+                    )
+                    .into_owned()
+                }),
+                bool_values_default: msg.bool_values_default,
+                byte_values_default: msg.byte_values_default,
+                char_values_default: msg.char_values_default,
+                float32_values_default: msg.float32_values_default,
+                float64_values_default: msg.float64_values_default,
+                int8_values_default: msg.int8_values_default,
+                uint8_values_default: msg.uint8_values_default,
+                int16_values_default: msg.int16_values_default,
+                uint16_values_default: msg.uint16_values_default,
+                int32_values_default: msg.int32_values_default,
+                uint32_values_default: msg.uint32_values_default,
+                int64_values_default: msg.int64_values_default,
+                uint64_values_default: msg.uint64_values_default,
+                string_values_default: msg.string_values_default.map(|elem| elem.as_str().into()),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                bool_values: msg.bool_values,
+                byte_values: msg.byte_values,
+                char_values: msg.char_values,
+                float32_values: msg.float32_values,
+                float64_values: msg.float64_values,
+                int8_values: msg.int8_values,
+                uint8_values: msg.uint8_values,
+                int16_values: msg.int16_values,
+                uint16_values: msg.uint16_values,
+                int32_values: msg.int32_values,
+                uint32_values: msg.uint32_values,
+                int64_values: msg.int64_values,
+                uint64_values: msg.uint64_values,
+                string_values: msg
+                    .string_values
+                    .iter()
+                    .map(|elem| elem.as_str().into())
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .unwrap(),
+                basic_types_values: msg
+                    .basic_types_values
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::test_msgs::msg::BasicTypes::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .unwrap(),
+                constants_values: msg
+                    .constants_values
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::test_msgs::msg::Constants::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .unwrap(),
+                defaults_values: msg
+                    .defaults_values
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::test_msgs::msg::Defaults::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .unwrap(),
+                bool_values_default: msg.bool_values_default,
+                byte_values_default: msg.byte_values_default,
+                char_values_default: msg.char_values_default,
+                float32_values_default: msg.float32_values_default,
+                float64_values_default: msg.float64_values_default,
+                int8_values_default: msg.int8_values_default,
+                uint8_values_default: msg.uint8_values_default,
+                int16_values_default: msg.int16_values_default,
+                uint16_values_default: msg.uint16_values_default,
+                int32_values_default: msg.int32_values_default,
+                uint32_values_default: msg.uint32_values_default,
+                int64_values_default: msg.int64_values_default,
+                uint64_values_default: msg.uint64_values_default,
+                string_values_default: msg
+                    .string_values_default
+                    .iter()
+                    .map(|elem| elem.as_str().into())
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .unwrap(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            bool_values: msg.bool_values,
+            byte_values: msg.byte_values,
+            char_values: msg.char_values,
+            float32_values: msg.float32_values,
+            float64_values: msg.float64_values,
+            int8_values: msg.int8_values,
+            uint8_values: msg.uint8_values,
+            int16_values: msg.int16_values,
+            uint16_values: msg.uint16_values,
+            int32_values: msg.int32_values,
+            uint32_values: msg.uint32_values,
+            int64_values: msg.int64_values,
+            uint64_values: msg.uint64_values,
+            string_values: msg.string_values.map(|elem| elem.to_string()),
+            basic_types_values: msg
+                .basic_types_values
+                .map(crate::vendor::test_msgs::msg::BasicTypes::from_rmw_message),
+            constants_values: msg
+                .constants_values
+                .map(crate::vendor::test_msgs::msg::Constants::from_rmw_message),
+            defaults_values: msg
+                .defaults_values
+                .map(crate::vendor::test_msgs::msg::Defaults::from_rmw_message),
+            bool_values_default: msg.bool_values_default,
+            byte_values_default: msg.byte_values_default,
+            char_values_default: msg.char_values_default,
+            float32_values_default: msg.float32_values_default,
+            float64_values_default: msg.float64_values_default,
+            int8_values_default: msg.int8_values_default,
+            uint8_values_default: msg.uint8_values_default,
+            int16_values_default: msg.int16_values_default,
+            uint16_values_default: msg.uint16_values_default,
+            int32_values_default: msg.int32_values_default,
+            uint32_values_default: msg.uint32_values_default,
+            int64_values_default: msg.int64_values_default,
+            uint64_values_default: msg.uint64_values_default,
+            string_values_default: msg.string_values_default.map(|elem| elem.to_string()),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Arrays_Response {
+    pub bool_values: [bool; 3],
+    pub byte_values: [u8; 3],
+    pub char_values: [u8; 3],
+    pub float32_values: [f32; 3],
+    pub float64_values: [f64; 3],
+    pub int8_values: [i8; 3],
+    pub uint8_values: [u8; 3],
+    pub int16_values: [i16; 3],
+    pub uint16_values: [u16; 3],
+    pub int32_values: [i32; 3],
+    pub uint32_values: [u32; 3],
+    pub int64_values: [i64; 3],
+    pub uint64_values: [u64; 3],
+    pub string_values: [std::string::String; 3],
+    pub basic_types_values: [crate::vendor::test_msgs::msg::BasicTypes; 3],
+    pub constants_values: [crate::vendor::test_msgs::msg::Constants; 3],
+    pub defaults_values: [crate::vendor::test_msgs::msg::Defaults; 3],
+    pub bool_values_default: [bool; 3],
+    pub byte_values_default: [u8; 3],
+    pub char_values_default: [u8; 3],
+    pub float32_values_default: [f32; 3],
+    pub float64_values_default: [f64; 3],
+    pub int8_values_default: [i8; 3],
+    pub uint8_values_default: [u8; 3],
+    pub int16_values_default: [i16; 3],
+    pub uint16_values_default: [u16; 3],
+    pub int32_values_default: [i32; 3],
+    pub uint32_values_default: [u32; 3],
+    pub int64_values_default: [i64; 3],
+    pub uint64_values_default: [u64; 3],
+    pub string_values_default: [std::string::String; 3],
+}
+
+impl Default for Arrays_Response {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::srv::rmw::Arrays_Response::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Arrays_Response {
+    type RmwMsg = crate::vendor::test_msgs::srv::rmw::Arrays_Response;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                bool_values: msg.bool_values,
+                byte_values: msg.byte_values,
+                char_values: msg.char_values,
+                float32_values: msg.float32_values,
+                float64_values: msg.float64_values,
+                int8_values: msg.int8_values,
+                uint8_values: msg.uint8_values,
+                int16_values: msg.int16_values,
+                uint16_values: msg.uint16_values,
+                int32_values: msg.int32_values,
+                uint32_values: msg.uint32_values,
+                int64_values: msg.int64_values,
+                uint64_values: msg.uint64_values,
+                string_values: msg.string_values.map(|elem| elem.as_str().into()),
+                basic_types_values: msg.basic_types_values.map(|elem| {
+                    crate::vendor::test_msgs::msg::BasicTypes::into_rmw_message(
+                        std::borrow::Cow::Owned(elem),
+                    )
+                    .into_owned()
+                }),
+                constants_values: msg.constants_values.map(|elem| {
+                    crate::vendor::test_msgs::msg::Constants::into_rmw_message(
+                        std::borrow::Cow::Owned(elem),
+                    )
+                    .into_owned()
+                }),
+                defaults_values: msg.defaults_values.map(|elem| {
+                    crate::vendor::test_msgs::msg::Defaults::into_rmw_message(
+                        std::borrow::Cow::Owned(elem),
+                    )
+                    .into_owned()
+                }),
+                bool_values_default: msg.bool_values_default,
+                byte_values_default: msg.byte_values_default,
+                char_values_default: msg.char_values_default,
+                float32_values_default: msg.float32_values_default,
+                float64_values_default: msg.float64_values_default,
+                int8_values_default: msg.int8_values_default,
+                uint8_values_default: msg.uint8_values_default,
+                int16_values_default: msg.int16_values_default,
+                uint16_values_default: msg.uint16_values_default,
+                int32_values_default: msg.int32_values_default,
+                uint32_values_default: msg.uint32_values_default,
+                int64_values_default: msg.int64_values_default,
+                uint64_values_default: msg.uint64_values_default,
+                string_values_default: msg.string_values_default.map(|elem| elem.as_str().into()),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                bool_values: msg.bool_values,
+                byte_values: msg.byte_values,
+                char_values: msg.char_values,
+                float32_values: msg.float32_values,
+                float64_values: msg.float64_values,
+                int8_values: msg.int8_values,
+                uint8_values: msg.uint8_values,
+                int16_values: msg.int16_values,
+                uint16_values: msg.uint16_values,
+                int32_values: msg.int32_values,
+                uint32_values: msg.uint32_values,
+                int64_values: msg.int64_values,
+                uint64_values: msg.uint64_values,
+                string_values: msg
+                    .string_values
+                    .iter()
+                    .map(|elem| elem.as_str().into())
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .unwrap(),
+                basic_types_values: msg
+                    .basic_types_values
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::test_msgs::msg::BasicTypes::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .unwrap(),
+                constants_values: msg
+                    .constants_values
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::test_msgs::msg::Constants::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .unwrap(),
+                defaults_values: msg
+                    .defaults_values
+                    .iter()
+                    .map(|elem| {
+                        crate::vendor::test_msgs::msg::Defaults::into_rmw_message(
+                            std::borrow::Cow::Borrowed(elem),
+                        )
+                        .into_owned()
+                    })
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .unwrap(),
+                bool_values_default: msg.bool_values_default,
+                byte_values_default: msg.byte_values_default,
+                char_values_default: msg.char_values_default,
+                float32_values_default: msg.float32_values_default,
+                float64_values_default: msg.float64_values_default,
+                int8_values_default: msg.int8_values_default,
+                uint8_values_default: msg.uint8_values_default,
+                int16_values_default: msg.int16_values_default,
+                uint16_values_default: msg.uint16_values_default,
+                int32_values_default: msg.int32_values_default,
+                uint32_values_default: msg.uint32_values_default,
+                int64_values_default: msg.int64_values_default,
+                uint64_values_default: msg.uint64_values_default,
+                string_values_default: msg
+                    .string_values_default
+                    .iter()
+                    .map(|elem| elem.as_str().into())
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .unwrap(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            bool_values: msg.bool_values,
+            byte_values: msg.byte_values,
+            char_values: msg.char_values,
+            float32_values: msg.float32_values,
+            float64_values: msg.float64_values,
+            int8_values: msg.int8_values,
+            uint8_values: msg.uint8_values,
+            int16_values: msg.int16_values,
+            uint16_values: msg.uint16_values,
+            int32_values: msg.int32_values,
+            uint32_values: msg.uint32_values,
+            int64_values: msg.int64_values,
+            uint64_values: msg.uint64_values,
+            string_values: msg.string_values.map(|elem| elem.to_string()),
+            basic_types_values: msg
+                .basic_types_values
+                .map(crate::vendor::test_msgs::msg::BasicTypes::from_rmw_message),
+            constants_values: msg
+                .constants_values
+                .map(crate::vendor::test_msgs::msg::Constants::from_rmw_message),
+            defaults_values: msg
+                .defaults_values
+                .map(crate::vendor::test_msgs::msg::Defaults::from_rmw_message),
+            bool_values_default: msg.bool_values_default,
+            byte_values_default: msg.byte_values_default,
+            char_values_default: msg.char_values_default,
+            float32_values_default: msg.float32_values_default,
+            float64_values_default: msg.float64_values_default,
+            int8_values_default: msg.int8_values_default,
+            uint8_values_default: msg.uint8_values_default,
+            int16_values_default: msg.int16_values_default,
+            uint16_values_default: msg.uint16_values_default,
+            int32_values_default: msg.int32_values_default,
+            uint32_values_default: msg.uint32_values_default,
+            int64_values_default: msg.int64_values_default,
+            uint64_values_default: msg.uint64_values_default,
+            string_values_default: msg.string_values_default.map(|elem| elem.to_string()),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct BasicTypes_Request {
+    pub bool_value: bool,
+    pub byte_value: u8,
+    pub char_value: u8,
+    pub float32_value: f32,
+    pub float64_value: f64,
+    pub int8_value: i8,
+    pub uint8_value: u8,
+    pub int16_value: i16,
+    pub uint16_value: u16,
+    pub int32_value: i32,
+    pub uint32_value: u32,
+    pub int64_value: i64,
+    pub uint64_value: u64,
+    pub string_value: std::string::String,
+}
+
+impl Default for BasicTypes_Request {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::srv::rmw::BasicTypes_Request::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for BasicTypes_Request {
+    type RmwMsg = crate::vendor::test_msgs::srv::rmw::BasicTypes_Request;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                bool_value: msg.bool_value,
+                byte_value: msg.byte_value,
+                char_value: msg.char_value,
+                float32_value: msg.float32_value,
+                float64_value: msg.float64_value,
+                int8_value: msg.int8_value,
+                uint8_value: msg.uint8_value,
+                int16_value: msg.int16_value,
+                uint16_value: msg.uint16_value,
+                int32_value: msg.int32_value,
+                uint32_value: msg.uint32_value,
+                int64_value: msg.int64_value,
+                uint64_value: msg.uint64_value,
+                string_value: msg.string_value.as_str().into(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                bool_value: msg.bool_value,
+                byte_value: msg.byte_value,
+                char_value: msg.char_value,
+                float32_value: msg.float32_value,
+                float64_value: msg.float64_value,
+                int8_value: msg.int8_value,
+                uint8_value: msg.uint8_value,
+                int16_value: msg.int16_value,
+                uint16_value: msg.uint16_value,
+                int32_value: msg.int32_value,
+                uint32_value: msg.uint32_value,
+                int64_value: msg.int64_value,
+                uint64_value: msg.uint64_value,
+                string_value: msg.string_value.as_str().into(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            bool_value: msg.bool_value,
+            byte_value: msg.byte_value,
+            char_value: msg.char_value,
+            float32_value: msg.float32_value,
+            float64_value: msg.float64_value,
+            int8_value: msg.int8_value,
+            uint8_value: msg.uint8_value,
+            int16_value: msg.int16_value,
+            uint16_value: msg.uint16_value,
+            int32_value: msg.int32_value,
+            uint32_value: msg.uint32_value,
+            int64_value: msg.int64_value,
+            uint64_value: msg.uint64_value,
+            string_value: msg.string_value.to_string(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct BasicTypes_Response {
+    pub bool_value: bool,
+    pub byte_value: u8,
+    pub char_value: u8,
+    pub float32_value: f32,
+    pub float64_value: f64,
+    pub int8_value: i8,
+    pub uint8_value: u8,
+    pub int16_value: i16,
+    pub uint16_value: u16,
+    pub int32_value: i32,
+    pub uint32_value: u32,
+    pub int64_value: i64,
+    pub uint64_value: u64,
+    pub string_value: std::string::String,
+}
+
+impl Default for BasicTypes_Response {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::srv::rmw::BasicTypes_Response::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for BasicTypes_Response {
+    type RmwMsg = crate::vendor::test_msgs::srv::rmw::BasicTypes_Response;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                bool_value: msg.bool_value,
+                byte_value: msg.byte_value,
+                char_value: msg.char_value,
+                float32_value: msg.float32_value,
+                float64_value: msg.float64_value,
+                int8_value: msg.int8_value,
+                uint8_value: msg.uint8_value,
+                int16_value: msg.int16_value,
+                uint16_value: msg.uint16_value,
+                int32_value: msg.int32_value,
+                uint32_value: msg.uint32_value,
+                int64_value: msg.int64_value,
+                uint64_value: msg.uint64_value,
+                string_value: msg.string_value.as_str().into(),
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                bool_value: msg.bool_value,
+                byte_value: msg.byte_value,
+                char_value: msg.char_value,
+                float32_value: msg.float32_value,
+                float64_value: msg.float64_value,
+                int8_value: msg.int8_value,
+                uint8_value: msg.uint8_value,
+                int16_value: msg.int16_value,
+                uint16_value: msg.uint16_value,
+                int32_value: msg.int32_value,
+                uint32_value: msg.uint32_value,
+                int64_value: msg.int64_value,
+                uint64_value: msg.uint64_value,
+                string_value: msg.string_value.as_str().into(),
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            bool_value: msg.bool_value,
+            byte_value: msg.byte_value,
+            char_value: msg.char_value,
+            float32_value: msg.float32_value,
+            float64_value: msg.float64_value,
+            int8_value: msg.int8_value,
+            uint8_value: msg.uint8_value,
+            int16_value: msg.int16_value,
+            uint16_value: msg.uint16_value,
+            int32_value: msg.int32_value,
+            uint32_value: msg.uint32_value,
+            int64_value: msg.int64_value,
+            uint64_value: msg.uint64_value,
+            string_value: msg.string_value.to_string(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Empty_Request {
+    pub structure_needs_at_least_one_member: u8,
+}
+
+impl Default for Empty_Request {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::srv::rmw::Empty_Request::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Empty_Request {
+    type RmwMsg = crate::vendor::test_msgs::srv::rmw::Empty_Request;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                structure_needs_at_least_one_member: msg.structure_needs_at_least_one_member,
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                structure_needs_at_least_one_member: msg.structure_needs_at_least_one_member,
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            structure_needs_at_least_one_member: msg.structure_needs_at_least_one_member,
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Empty_Response {
+    pub structure_needs_at_least_one_member: u8,
+}
+
+impl Default for Empty_Response {
+    fn default() -> Self {
+        <Self as rosidl_runtime_rs::Message>::from_rmw_message(
+            crate::vendor::test_msgs::srv::rmw::Empty_Response::default(),
+        )
+    }
+}
+
+impl rosidl_runtime_rs::Message for Empty_Response {
+    type RmwMsg = crate::vendor::test_msgs::srv::rmw::Empty_Response;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        match msg_cow {
+            std::borrow::Cow::Owned(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                structure_needs_at_least_one_member: msg.structure_needs_at_least_one_member,
+            }),
+            std::borrow::Cow::Borrowed(msg) => std::borrow::Cow::Owned(Self::RmwMsg {
+                structure_needs_at_least_one_member: msg.structure_needs_at_least_one_member,
+            }),
+        }
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        Self {
+            structure_needs_at_least_one_member: msg.structure_needs_at_least_one_member,
+        }
+    }
+}
+
+#[link(name = "test_msgs__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_service_type_support_handle__test_msgs__srv__Arrays(
+    ) -> *const std::ffi::c_void;
+}
+
+// Corresponds to test_msgs__srv__Arrays
+pub struct Arrays;
+
+impl rosidl_runtime_rs::Service for Arrays {
+    type Request = crate::vendor::test_msgs::srv::Arrays_Request;
+    type Response = crate::vendor::test_msgs::srv::Arrays_Response;
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        // SAFETY: No preconditions for this function.
+        unsafe { rosidl_typesupport_c__get_service_type_support_handle__test_msgs__srv__Arrays() }
+    }
+}
+
+#[link(name = "test_msgs__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_service_type_support_handle__test_msgs__srv__BasicTypes(
+    ) -> *const std::ffi::c_void;
+}
+
+// Corresponds to test_msgs__srv__BasicTypes
+pub struct BasicTypes;
+
+impl rosidl_runtime_rs::Service for BasicTypes {
+    type Request = crate::vendor::test_msgs::srv::BasicTypes_Request;
+    type Response = crate::vendor::test_msgs::srv::BasicTypes_Response;
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        // SAFETY: No preconditions for this function.
+        unsafe {
+            rosidl_typesupport_c__get_service_type_support_handle__test_msgs__srv__BasicTypes()
+        }
+    }
+}
+
+#[link(name = "test_msgs__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_service_type_support_handle__test_msgs__srv__Empty(
+    ) -> *const std::ffi::c_void;
+}
+
+// Corresponds to test_msgs__srv__Empty
+pub struct Empty;
+
+impl rosidl_runtime_rs::Service for Empty {
+    type Request = crate::vendor::test_msgs::srv::Empty_Request;
+    type Response = crate::vendor::test_msgs::srv::Empty_Response;
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        // SAFETY: No preconditions for this function.
+        unsafe { rosidl_typesupport_c__get_service_type_support_handle__test_msgs__srv__Empty() }
+    }
+}
+
+pub mod rmw {
+
+    #[cfg(feature = "serde")]
+    use serde::{Deserialize, Serialize};
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__srv__Arrays_Request(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__srv__Arrays_Request__init(msg: *mut Arrays_Request) -> bool;
+        fn test_msgs__srv__Arrays_Request__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Arrays_Request>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__srv__Arrays_Request__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Arrays_Request>,
+        );
+        fn test_msgs__srv__Arrays_Request__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Arrays_Request>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Arrays_Request>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__srv__Arrays_Request
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Arrays_Request {
+        pub bool_values: [bool; 3],
+        pub byte_values: [u8; 3],
+        pub char_values: [u8; 3],
+        pub float32_values: [f32; 3],
+        pub float64_values: [f64; 3],
+        pub int8_values: [i8; 3],
+        pub uint8_values: [u8; 3],
+        pub int16_values: [i16; 3],
+        pub uint16_values: [u16; 3],
+        pub int32_values: [i32; 3],
+        pub uint32_values: [u32; 3],
+        pub int64_values: [i64; 3],
+        pub uint64_values: [u64; 3],
+        pub string_values: [rosidl_runtime_rs::String; 3],
+        pub basic_types_values: [crate::vendor::test_msgs::msg::rmw::BasicTypes; 3],
+        pub constants_values: [crate::vendor::test_msgs::msg::rmw::Constants; 3],
+        pub defaults_values: [crate::vendor::test_msgs::msg::rmw::Defaults; 3],
+        pub bool_values_default: [bool; 3],
+        pub byte_values_default: [u8; 3],
+        pub char_values_default: [u8; 3],
+        pub float32_values_default: [f32; 3],
+        pub float64_values_default: [f64; 3],
+        pub int8_values_default: [i8; 3],
+        pub uint8_values_default: [u8; 3],
+        pub int16_values_default: [i16; 3],
+        pub uint16_values_default: [u16; 3],
+        pub int32_values_default: [i32; 3],
+        pub uint32_values_default: [u32; 3],
+        pub int64_values_default: [i64; 3],
+        pub uint64_values_default: [u64; 3],
+        pub string_values_default: [rosidl_runtime_rs::String; 3],
+    }
+
+    impl Default for Arrays_Request {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__srv__Arrays_Request__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__srv__Arrays_Request__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Arrays_Request {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__srv__Arrays_Request__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__srv__Arrays_Request__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__srv__Arrays_Request__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Arrays_Request {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Arrays_Request
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/srv/Arrays_Request";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__srv__Arrays_Request()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__srv__Arrays_Response(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__srv__Arrays_Response__init(msg: *mut Arrays_Response) -> bool;
+        fn test_msgs__srv__Arrays_Response__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Arrays_Response>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__srv__Arrays_Response__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Arrays_Response>,
+        );
+        fn test_msgs__srv__Arrays_Response__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Arrays_Response>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Arrays_Response>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__srv__Arrays_Response
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Arrays_Response {
+        pub bool_values: [bool; 3],
+        pub byte_values: [u8; 3],
+        pub char_values: [u8; 3],
+        pub float32_values: [f32; 3],
+        pub float64_values: [f64; 3],
+        pub int8_values: [i8; 3],
+        pub uint8_values: [u8; 3],
+        pub int16_values: [i16; 3],
+        pub uint16_values: [u16; 3],
+        pub int32_values: [i32; 3],
+        pub uint32_values: [u32; 3],
+        pub int64_values: [i64; 3],
+        pub uint64_values: [u64; 3],
+        pub string_values: [rosidl_runtime_rs::String; 3],
+        pub basic_types_values: [crate::vendor::test_msgs::msg::rmw::BasicTypes; 3],
+        pub constants_values: [crate::vendor::test_msgs::msg::rmw::Constants; 3],
+        pub defaults_values: [crate::vendor::test_msgs::msg::rmw::Defaults; 3],
+        pub bool_values_default: [bool; 3],
+        pub byte_values_default: [u8; 3],
+        pub char_values_default: [u8; 3],
+        pub float32_values_default: [f32; 3],
+        pub float64_values_default: [f64; 3],
+        pub int8_values_default: [i8; 3],
+        pub uint8_values_default: [u8; 3],
+        pub int16_values_default: [i16; 3],
+        pub uint16_values_default: [u16; 3],
+        pub int32_values_default: [i32; 3],
+        pub uint32_values_default: [u32; 3],
+        pub int64_values_default: [i64; 3],
+        pub uint64_values_default: [u64; 3],
+        pub string_values_default: [rosidl_runtime_rs::String; 3],
+    }
+
+    impl Default for Arrays_Response {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__srv__Arrays_Response__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__srv__Arrays_Response__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Arrays_Response {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__srv__Arrays_Response__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__srv__Arrays_Response__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__srv__Arrays_Response__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Arrays_Response {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Arrays_Response
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/srv/Arrays_Response";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__srv__Arrays_Response()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__srv__BasicTypes_Request(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__srv__BasicTypes_Request__init(msg: *mut BasicTypes_Request) -> bool;
+        fn test_msgs__srv__BasicTypes_Request__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<BasicTypes_Request>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__srv__BasicTypes_Request__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<BasicTypes_Request>,
+        );
+        fn test_msgs__srv__BasicTypes_Request__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<BasicTypes_Request>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<BasicTypes_Request>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__srv__BasicTypes_Request
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct BasicTypes_Request {
+        pub bool_value: bool,
+        pub byte_value: u8,
+        pub char_value: u8,
+        pub float32_value: f32,
+        pub float64_value: f64,
+        pub int8_value: i8,
+        pub uint8_value: u8,
+        pub int16_value: i16,
+        pub uint16_value: u16,
+        pub int32_value: i32,
+        pub uint32_value: u32,
+        pub int64_value: i64,
+        pub uint64_value: u64,
+        pub string_value: rosidl_runtime_rs::String,
+    }
+
+    impl Default for BasicTypes_Request {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__srv__BasicTypes_Request__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__srv__BasicTypes_Request__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for BasicTypes_Request {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__srv__BasicTypes_Request__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__srv__BasicTypes_Request__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__srv__BasicTypes_Request__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for BasicTypes_Request {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for BasicTypes_Request
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/srv/BasicTypes_Request";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__srv__BasicTypes_Request()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__srv__BasicTypes_Response(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__srv__BasicTypes_Response__init(msg: *mut BasicTypes_Response) -> bool;
+        fn test_msgs__srv__BasicTypes_Response__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<BasicTypes_Response>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__srv__BasicTypes_Response__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<BasicTypes_Response>,
+        );
+        fn test_msgs__srv__BasicTypes_Response__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<BasicTypes_Response>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<BasicTypes_Response>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__srv__BasicTypes_Response
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct BasicTypes_Response {
+        pub bool_value: bool,
+        pub byte_value: u8,
+        pub char_value: u8,
+        pub float32_value: f32,
+        pub float64_value: f64,
+        pub int8_value: i8,
+        pub uint8_value: u8,
+        pub int16_value: i16,
+        pub uint16_value: u16,
+        pub int32_value: i32,
+        pub uint32_value: u32,
+        pub int64_value: i64,
+        pub uint64_value: u64,
+        pub string_value: rosidl_runtime_rs::String,
+    }
+
+    impl Default for BasicTypes_Response {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__srv__BasicTypes_Response__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__srv__BasicTypes_Response__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for BasicTypes_Response {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__srv__BasicTypes_Response__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__srv__BasicTypes_Response__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe {
+                test_msgs__srv__BasicTypes_Response__Sequence__copy(in_seq, out_seq as *mut _)
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for BasicTypes_Response {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for BasicTypes_Response
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/srv/BasicTypes_Response";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__srv__BasicTypes_Response()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__srv__Empty_Request(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__srv__Empty_Request__init(msg: *mut Empty_Request) -> bool;
+        fn test_msgs__srv__Empty_Request__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Empty_Request>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__srv__Empty_Request__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Empty_Request>,
+        );
+        fn test_msgs__srv__Empty_Request__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Empty_Request>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Empty_Request>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__srv__Empty_Request
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Empty_Request {
+        pub structure_needs_at_least_one_member: u8,
+    }
+
+    impl Default for Empty_Request {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__srv__Empty_Request__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__srv__Empty_Request__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Empty_Request {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__srv__Empty_Request__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__srv__Empty_Request__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__srv__Empty_Request__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Empty_Request {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Empty_Request
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/srv/Empty_Request";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__srv__Empty_Request(
+                )
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_message_type_support_handle__test_msgs__srv__Empty_Response(
+        ) -> *const std::ffi::c_void;
+    }
+
+    #[link(name = "test_msgs__rosidl_generator_c")]
+    extern "C" {
+        fn test_msgs__srv__Empty_Response__init(msg: *mut Empty_Response) -> bool;
+        fn test_msgs__srv__Empty_Response__Sequence__init(
+            seq: *mut rosidl_runtime_rs::Sequence<Empty_Response>,
+            size: usize,
+        ) -> bool;
+        fn test_msgs__srv__Empty_Response__Sequence__fini(
+            seq: *mut rosidl_runtime_rs::Sequence<Empty_Response>,
+        );
+        fn test_msgs__srv__Empty_Response__Sequence__copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Empty_Response>,
+            out_seq: *mut rosidl_runtime_rs::Sequence<Empty_Response>,
+        ) -> bool;
+    }
+
+    // Corresponds to test_msgs__srv__Empty_Response
+    #[repr(C)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[derive(Clone, Debug, PartialEq, PartialOrd)]
+    pub struct Empty_Response {
+        pub structure_needs_at_least_one_member: u8,
+    }
+
+    impl Default for Empty_Response {
+        fn default() -> Self {
+            unsafe {
+                let mut msg = std::mem::zeroed();
+                if !test_msgs__srv__Empty_Response__init(&mut msg as *mut _) {
+                    panic!("Call to test_msgs__srv__Empty_Response__init() failed");
+                }
+                msg
+            }
+        }
+    }
+
+    impl rosidl_runtime_rs::SequenceAlloc for Empty_Response {
+        fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__srv__Empty_Response__Sequence__init(seq as *mut _, size) }
+        }
+        fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__srv__Empty_Response__Sequence__fini(seq as *mut _) }
+        }
+        fn sequence_copy(
+            in_seq: &rosidl_runtime_rs::Sequence<Self>,
+            out_seq: &mut rosidl_runtime_rs::Sequence<Self>,
+        ) -> bool {
+            // SAFETY: This is safe since the pointer is guaranteed to be valid/initialized.
+            unsafe { test_msgs__srv__Empty_Response__Sequence__copy(in_seq, out_seq as *mut _) }
+        }
+    }
+
+    impl rosidl_runtime_rs::Message for Empty_Response {
+        type RmwMsg = Self;
+        fn into_rmw_message(
+            msg_cow: std::borrow::Cow<'_, Self>,
+        ) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            msg_cow
+        }
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg
+        }
+    }
+
+    impl rosidl_runtime_rs::RmwMessage for Empty_Response
+    where
+        Self: Sized,
+    {
+        const TYPE_NAME: &'static str = "test_msgs/srv/Empty_Response";
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_message_type_support_handle__test_msgs__srv__Empty_Response()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_service_type_support_handle__test_msgs__srv__Arrays(
+        ) -> *const std::ffi::c_void;
+    }
+
+    // Corresponds to test_msgs__srv__Arrays
+    pub struct Arrays;
+
+    impl rosidl_runtime_rs::Service for Arrays {
+        type Request = crate::vendor::test_msgs::srv::rmw::Arrays_Request;
+        type Response = crate::vendor::test_msgs::srv::rmw::Arrays_Response;
+
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_service_type_support_handle__test_msgs__srv__Arrays()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_service_type_support_handle__test_msgs__srv__BasicTypes(
+        ) -> *const std::ffi::c_void;
+    }
+
+    // Corresponds to test_msgs__srv__BasicTypes
+    pub struct BasicTypes;
+
+    impl rosidl_runtime_rs::Service for BasicTypes {
+        type Request = crate::vendor::test_msgs::srv::rmw::BasicTypes_Request;
+        type Response = crate::vendor::test_msgs::srv::rmw::BasicTypes_Response;
+
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_service_type_support_handle__test_msgs__srv__BasicTypes()
+            }
+        }
+    }
+
+    #[link(name = "test_msgs__rosidl_typesupport_c")]
+    extern "C" {
+        fn rosidl_typesupport_c__get_service_type_support_handle__test_msgs__srv__Empty(
+        ) -> *const std::ffi::c_void;
+    }
+
+    // Corresponds to test_msgs__srv__Empty
+    pub struct Empty;
+
+    impl rosidl_runtime_rs::Service for Empty {
+        type Request = crate::vendor::test_msgs::srv::rmw::Empty_Request;
+        type Response = crate::vendor::test_msgs::srv::rmw::Empty_Response;
+
+        fn get_type_support() -> *const std::ffi::c_void {
+            // SAFETY: No preconditions for this function.
+            unsafe {
+                rosidl_typesupport_c__get_service_type_support_handle__test_msgs__srv__Empty()
+            }
+        }
+    }
+} // mod rmw

--- a/rclrs/src/worker.rs
+++ b/rclrs/src/worker.rs
@@ -502,7 +502,7 @@ impl<Payload: 'static + Send + Sync> WorkScope for Worker<Payload> {
 mod tests {
     use crate::*;
     use std::time::Duration;
-    use test_msgs::{
+    use crate::vendor::test_msgs::{
         msg::Empty as EmptyMsg,
         srv::{Empty as EmptySrv, Empty_Request, Empty_Response},
     };

--- a/rclrs/src/worker.rs
+++ b/rclrs/src/worker.rs
@@ -228,6 +228,7 @@ impl<Payload: 'static + Send + Sync> WorkerState<Payload> {
     ///
     /// ```
     /// # use rclrs::*;
+    /// # use rclrs::vendor::example_interfaces;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
     /// // The worker's payload is data that we want to share with other callbacks.
@@ -320,9 +321,9 @@ impl<Payload: 'static + Send + Sync> WorkerState<Payload> {
     ///
     /// ```
     /// # use rclrs::*;
+    /// # use rclrs::vendor::example_interfaces::srv::*;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
-    /// use example_interfaces::srv::*;
     ///
     /// /// Store the operands of the service request for later reference
     /// #[derive(Default)]
@@ -500,12 +501,12 @@ impl<Payload: 'static + Send + Sync> WorkScope for Worker<Payload> {
 
 #[cfg(test)]
 mod tests {
-    use crate::*;
-    use std::time::Duration;
     use crate::vendor::test_msgs::{
         msg::Empty as EmptyMsg,
         srv::{Empty as EmptySrv, Empty_Request, Empty_Response},
     };
+    use crate::*;
+    use std::time::Duration;
 
     #[derive(Default, Clone, Copy, Debug)]
     struct TestPayload {

--- a/rclrs/src/worker.rs
+++ b/rclrs/src/worker.rs
@@ -228,7 +228,7 @@ impl<Payload: 'static + Send + Sync> WorkerState<Payload> {
     ///
     /// ```
     /// # use rclrs::*;
-    /// # use rclrs::vendor::example_interfaces;
+    /// # use crate::rclrs::vendor::example_interfaces;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
     /// // The worker's payload is data that we want to share with other callbacks.
@@ -321,7 +321,7 @@ impl<Payload: 'static + Send + Sync> WorkerState<Payload> {
     ///
     /// ```
     /// # use rclrs::*;
-    /// # use rclrs::vendor::example_interfaces::srv::*;
+    /// # use crate::rclrs::vendor::example_interfaces;
     /// # let executor = Context::default().create_basic_executor();
     /// # let node = executor.create_node("my_node").unwrap();
     ///
@@ -339,17 +339,17 @@ impl<Payload: 'static + Send + Sync> WorkerState<Payload> {
     /// // callback.
     /// let mut count = 0_usize;
     ///
-    /// let service = worker.create_service::<AddTwoInts, _>(
+    /// let service = worker.create_service::<example_interfaces::srv::AddTwoInts, _>(
     ///     "add",
-    ///     move |payload: &mut Operands, request: AddTwoInts_Request| {
+    ///     move |payload: &mut Operands, request: example_interfaces::srv::AddTwoInts_Request| {
     ///         count += 1;
-    ///         let AddTwoInts_Request { a, b } = request;
+    ///         let example_interfaces::srv::AddTwoInts_Request { a, b } = request;
     ///         let sum = a + b;
     ///         println!("#{count} | {a} + {b} = {sum}");
     ///
     ///         *payload = Operands { a, b };
     ///
-    ///         AddTwoInts_Response { sum }
+    ///         example_interfaces::srv::AddTwoInts_Response { sum }
     ///     }
     /// )?;
     /// # Ok::<(), RclrsError>(())

--- a/rclrs/vendor_interfaces.py
+++ b/rclrs/vendor_interfaces.py
@@ -16,8 +16,10 @@ import subprocess
 vendored_packages = [
   "action_msgs",
   "builtin_interfaces",
+  "example_interfaces",
   "rcl_interfaces",
   "rosgraph_msgs",
+  "test_msgs",
   "unique_identifier_msgs",
 ]
 

--- a/rclrs/vendor_interfaces.py
+++ b/rclrs/vendor_interfaces.py
@@ -63,6 +63,7 @@ def main():
 
   mod_contents = "//! Created by {}\n".format(Path(__file__).name)
   mod_contents += "#![allow(dead_code)]\n"
+  mod_contents += "#![allow(missing_docs)]\n"
   mod_contents += "\n"
   for pkg in vendored_packages:
     mod_contents += f"pub mod {pkg};\n"


### PR DESCRIPTION
This PR vendorizes the `example_interfaces` and `test_msgs` packages so that `cargo update` can work during the release-plz job (see https://github.com/ros2-rust/ros2_rust/actions/runs/16942715079/job/48016392561)