### PR TITLE
fix: let user pass compiler flag to specify the ROS distro

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+env:
+  RUSTFLAGS: --cfg ros_distro="humble"
+
 jobs:
   release-plz-release:
     name: Release-plz release

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  RUSTFLAGS: --cfg ros_distro="humble"
+  RUSTFLAGS: "--cfg ros_distro=\"humble\""
 
 jobs:
   release-plz-release:

--- a/rclrs/Cargo.toml
+++ b/rclrs/Cargo.toml
@@ -43,10 +43,9 @@ tempfile = "3.3.0"
 tokio = { version = "1", features = ["rt", "time", "macros"] }
 
 [build-dependencies]
-# Needed for FFI
-bindgen = "0.70"
 # Needed for uploading documentation to docs.rs
 cfg-if = "1.0.0"
+rustflags = "0.1"
 
 [features]
 default = []
@@ -58,3 +57,4 @@ use_ros_shim = ["rosidl_runtime_rs/use_ros_shim"]
 
 [package.metadata.docs.rs]
 features = ["use_ros_shim"]
+rustc-args = ["--cfg", "ros_distro=\"humble\""]

--- a/rclrs/build.rs
+++ b/rclrs/build.rs
@@ -1,12 +1,6 @@
-use std::{
-    env,
-    fs::read_dir,
-    path::{Path, PathBuf},
-};
-
+use std::{env, path::Path};
 const AMENT_PREFIX_PATH: &str = "AMENT_PREFIX_PATH";
 const ROS_DISTRO: &str = "ROS_DISTRO";
-const BINDGEN_WRAPPER: &str = "src/rcl_wrapper.h";
 
 fn get_env_var_or_abort(env_var: &'static str) -> String {
     if let Ok(value) = env::var(env_var) {
@@ -20,22 +14,37 @@ fn get_env_var_or_abort(env_var: &'static str) -> String {
 }
 
 fn main() {
+    println!(
+        "cargo:rustc-check-cfg=cfg(ros_distro, values(\"{}\"))",
+        vec!["humble", "jazzy", "kilted", "rolling"].join("\", \"")
+    );
     let ros_distro = if let Ok(value) = env::var(ROS_DISTRO) {
         value
     } else {
-        let error_msg =
-            "ROS_DISTRO environment variable not set - please source ROS 2 installation first.";
+        use rustflags;
         cfg_if::cfg_if! {
             if #[cfg(feature="use_ros_shim")] {
-                println!("{}", error_msg);
-                return;
+                // // Look for --cfg ros_distro=<ros_distro>
+                for flag in rustflags::from_env() {
+                    if matches!(flag, rustflags::Flag::Cfg { ref name, value : _ } if name == "ros_distro") {
+                        if let rustflags::Flag::Cfg {name:_, value: flag_value} = flag {
+                            println!("cargo:rustc-cfg=ros_distro=\"{}\"", flag_value.unwrap());
+                            return;
+                        } else {
+                            continue;
+                        }
+                    }
+                }
+                let error_msg =
+                    "When using the use_ros_shim feature, you must pass the ROS distribution you are targeting as a compiler flag with --cfg ros_distro=\"<ros_distro>\"";
+                panic!("{}", error_msg);
             } else {
+                let error_msg =
+                    "ROS_DISTRO environment variable not set - please source ROS 2 installation first.";
                 panic!("{}", error_msg);
             }
         }
     };
-
-    println!("cargo:rustc-check-cfg=cfg(ros_distro, values(\"humble\", \"jazzy\", \"rolling\"))");
     println!("cargo:rustc-cfg=ros_distro=\"{ros_distro}\"");
 
     let ament_prefix_paths = get_env_var_or_abort(AMENT_PREFIX_PATH);

--- a/rclrs/src/rcl_bindings.rs
+++ b/rclrs/src/rcl_bindings.rs
@@ -12,29 +12,40 @@
 #![allow(missing_docs)]
 
 cfg_if::cfg_if! {
-    if #[cfg(feature="use_ros_shim")] {
+    if #[cfg(ros_distro="humble")] {
         include!(
             concat!(
                 env!("CARGO_MANIFEST_DIR"),
-                "/src/rcl_bindings_generated_",
-                "rolling", // rolling will always be a valid ROS distro
-                ".rs",
-            )
-        );
-
+                "/src/rcl_bindings_generated_humble.rs",
+                )
+            );
+    } else if #[cfg(ros_distro="jazzy")] {
+        include!(
+            concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/src/rcl_bindings_generated_jazzy.rs",
+                )
+            );
+    } else if #[cfg(ros_distro="kilted")] {
+        include!(
+            concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/src/rcl_bindings_generated_kilted.rs",
+                )
+            );
+    } else if #[cfg(ros_distro="rolling")] {
+        include!(
+            concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/src/rcl_bindings_generated_rolling.rs",
+                )
+            );
     } else {
-        include!(
-            concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/src/rcl_bindings_generated_",
-                env!("ROS_DISTRO"),
-                ".rs",
-            )
-        );
-
-        pub const RMW_GID_STORAGE_SIZE: usize = rmw_gid_storage_size_constant;
+        panic!("Unsupported ROS distribution");
     }
 }
+
+pub const RMW_GID_STORAGE_SIZE: usize = rmw_gid_storage_size_constant;
 
 /// Wrapper around [`std::slice::from_raw_parts`] that accommodates the rcl
 /// convention of providing a null pointer to represent empty arrays. This


### PR DESCRIPTION
This PR lets the user set the target ROS distro via `RUSTFLAGS = --cfg ros_distro="<ros_distro>"`

This also fixes an issue in the release-plz job that prevented it from building the crate before being published to crates.io