### PR TITLE
ci: fix name of the bindgen CLI crate

### DIFF
--- a/.github/workflows/generate-bindings.yml
+++ b/.github/workflows/generate-bindings.yml
@@ -61,7 +61,7 @@ jobs:
       run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 
     - name: Install bindgen
-      run: cargo binstall -y bindgen
+      run: cargo binstall -y bindgen-cli
 
     - name: Generate bindings
       run: |


### PR DESCRIPTION
The name of the crate that ships the command line tool for invoking `bindgen` is `bindgen-cli` (see https://docs.rs/crate/bindgen-cli/latest)