### PR TITLE
Fix executor timeout

### DIFF
--- a/rclrs/src/executor.rs
+++ b/rclrs/src/executor.rs
@@ -497,12 +497,20 @@ mod tests {
     fn test_timeout() {
         let context = Context::default();
         let mut executor = context.create_basic_executor();
-        let _node = executor.create_node(&format!("test_timeout_{}", line!())).unwrap();
+        let _node = executor
+            .create_node(&format!("test_timeout_{}", line!()))
+            .unwrap();
 
         for _ in 0..10 {
             let r = executor.spin(SpinOptions::default().timeout(Duration::from_millis(1)));
             assert_eq!(r.len(), 1);
-            assert!(matches!(r[0], RclrsError::RclError { code: RclReturnCode::Timeout, .. }));
+            assert!(matches!(
+                r[0],
+                RclrsError::RclError {
+                    code: RclReturnCode::Timeout,
+                    ..
+                }
+            ));
         }
     }
 }

--- a/rclrs/src/wait_set.rs
+++ b/rclrs/src/wait_set.rs
@@ -123,8 +123,7 @@ impl WaitSet {
         //   the waitable of each primitive to one (and only one) WaitSet when
         //   the primitive gets constructed. The waitables are never allowed to
         //   move between wait sets.
-        let r = match unsafe { rcl_wait(&mut self.handle.rcl_wait_set, timeout_ns) }.ok()
-        {
+        let r = match unsafe { rcl_wait(&mut self.handle.rcl_wait_set, timeout_ns) }.ok() {
             Ok(_) => Ok(()),
             Err(error) => match error {
                 RclrsError::RclError { code, msg } => match code {


### PR DESCRIPTION
As reported by https://github.com/ros2-rust/ros2_rust/issues/518 the current main branch experiences a segfault when the user specifies a timeout.

The timeout was caused by a subtle bug where we were exiting from `WaitSet::wait` early when an error code gets returned from `rcl_wait`. The original rationale was that if an error happens then it is not valid to continue processing the wait set, and the user will not want to keep spinning it. However, that overlooked two things:
* A timeout is categorized as an error, but does not imply that there is anything wrong with the wait set
* There are important cleanup steps that we apply after `rcl_wait` which get skipped if we exit `WaitSet::wait` early

This PR tweaks the ordering so that we always do the appropriate cleanup each time `WaitSet::wait` is called, even if an error is encountered. This also adds a test which currently experiences a segmentation fault on main.