### PR TITLE
chore: Fix Generate Bindings CI

### DIFF
--- a/.github/workflows/generate-bindings.yml
+++ b/.github/workflows/generate-bindings.yml
@@ -73,7 +73,8 @@ jobs:
 
     - name: Submit PR
       run: |
-        pwd
+        cd $GITHUB_WORKSPACE
+        git config --global --add safe.directory $GITHUB_WORKSPACE
         if git diff --exit-code; then
           exit 0
         fi

--- a/.github/workflows/generate-bindings.yml
+++ b/.github/workflows/generate-bindings.yml
@@ -73,6 +73,7 @@ jobs:
 
     - name: Submit PR
       run: |
+        pwd
         if git diff --exit-code; then
           exit 0
         fi


### PR DESCRIPTION
Noticed two issues in our `Generate bindings` action.

1. We are trying to run `git diff` in `rclrs/src` (which is failing)
```
warning: Not a git repository. Use --no-index to compare two paths outside a working tree
```

2. The repo needs to be marked as a safe directory
```
fatal: detected dubious ownership in repository at '/__w/ros2_rust/ros2_rust'
```

---

Not quite sure how to test this since the generate bindings action is on a timer :thinking: 