### PR TITLE
chore: Fix an unused import warning

### DIFF
--- a/rclrs/build.rs
+++ b/rclrs/build.rs
@@ -21,9 +21,9 @@ fn main() {
     let ros_distro = if let Ok(value) = env::var(ROS_DISTRO) {
         value
     } else {
-        use rustflags;
         cfg_if::cfg_if! {
             if #[cfg(feature="use_ros_shim")] {
+                use rustflags;
                 // // Look for --cfg ros_distro=<ros_distro>
                 for flag in rustflags::from_env() {
                     if matches!(flag, rustflags::Flag::Cfg { ref name, value : _ } if name == "ros_distro") {


### PR DESCRIPTION
Put `use rustflags;` next to its usage to prevent a build warning.

```
   warning: the item `rustflags` is imported redundantly
    --> rclrs/build.rs:24:13
     |
  24 |         use rustflags;
     |             ^^^^^^^^^ the item `rustflags` is already defined here
     |
     = note: `#[warn(unused_imports)]` on by default
  
  warning: unused import: `rustflags`
    --> rclrs/build.rs:24:13
     |
  24 |         use rustflags;
     |             ^^^^^^^^^
  
  ---
  Finished <<< rclrs [9.19s]
  --- stderr: rclrs
  warning: the item `rustflags` is imported redundantly
    --> rclrs/build.rs:24:13
     |
  24 |         use rustflags;
     |             ^^^^^^^^^ the item `rustflags` is already defined here
     |
     = note: `#[warn(unused_imports)]` on by default
  
  warning: unused import: `rustflags`
    --> rclrs/build.rs:24:13
     |
  24 |         use rustflags;
     |             ^^^^^^^^^
  
  ---
  ```