### PR TITLE
Minimal changes for new Action trait

### DIFF
--- a/rclrs/src/vendor/example_interfaces/action.rs
+++ b/rclrs/src/vendor/example_interfaces/action.rs
@@ -1247,26 +1247,25 @@ extern "C" {
 pub struct Fibonacci;
 
 impl rosidl_runtime_rs::Action for Fibonacci {
+    // --- Associated types for client library users ---
     type Goal = crate::vendor::example_interfaces::action::Fibonacci_Goal;
     type Result = crate::vendor::example_interfaces::action::Fibonacci_Result;
     type Feedback = crate::vendor::example_interfaces::action::Fibonacci_Feedback;
 
+    // --- Associated types for client library implementation ---
+    type FeedbackMessage =
+        crate::vendor::example_interfaces::action::rmw::Fibonacci_FeedbackMessage;
+    type SendGoalService = crate::vendor::example_interfaces::action::rmw::Fibonacci_SendGoal;
+    type CancelGoalService = crate::vendor::action_msgs::srv::rmw::CancelGoal;
+    type GetResultService = crate::vendor::example_interfaces::action::rmw::Fibonacci_GetResult;
+
+    // --- Methods for client library implementation ---
     fn get_type_support() -> *const std::ffi::c_void {
         // SAFETY: No preconditions for this function.
         unsafe {
             rosidl_typesupport_c__get_action_type_support_handle__example_interfaces__action__Fibonacci()
         }
     }
-}
-
-impl rosidl_runtime_rs::ActionImpl for Fibonacci {
-    type GoalStatusMessage = crate::vendor::action_msgs::msg::rmw::GoalStatusArray;
-    type FeedbackMessage =
-        crate::vendor::example_interfaces::action::rmw::Fibonacci_FeedbackMessage;
-
-    type SendGoalService = crate::vendor::example_interfaces::action::rmw::Fibonacci_SendGoal;
-    type CancelGoalService = crate::vendor::action_msgs::srv::rmw::CancelGoal;
-    type GetResultService = crate::vendor::example_interfaces::action::rmw::Fibonacci_GetResult;
 
     fn create_goal_request(
         goal_id: &[u8; 16],
@@ -1278,10 +1277,13 @@ impl rosidl_runtime_rs::ActionImpl for Fibonacci {
         }
     }
 
-    fn get_goal_request_uuid(
-        request: &crate::vendor::example_interfaces::action::rmw::Fibonacci_SendGoal_Request,
-    ) -> &[u8; 16] {
-        &request.goal_id.uuid
+    fn split_goal_request(
+        request: crate::vendor::example_interfaces::action::rmw::Fibonacci_SendGoal_Request,
+    ) -> (
+        [u8; 16],
+        crate::vendor::example_interfaces::action::rmw::Fibonacci_Goal,
+    ) {
+        (request.goal_id.uuid, request.goal)
     }
 
     fn create_goal_response(
@@ -1320,16 +1322,13 @@ impl rosidl_runtime_rs::ActionImpl for Fibonacci {
         message
     }
 
-    fn get_feedback_message_uuid(
-        feedback: &crate::vendor::example_interfaces::action::rmw::Fibonacci_FeedbackMessage,
-    ) -> &[u8; 16] {
-        &feedback.goal_id.uuid
-    }
-
-    fn get_feedback_message_feedback(
-        feedback: &crate::vendor::example_interfaces::action::rmw::Fibonacci_FeedbackMessage,
-    ) -> &crate::vendor::example_interfaces::action::rmw::Fibonacci_Feedback {
-        &feedback.feedback
+    fn split_feedback_message(
+        feedback: crate::vendor::example_interfaces::action::rmw::Fibonacci_FeedbackMessage,
+    ) -> (
+        [u8; 16],
+        crate::vendor::example_interfaces::action::rmw::Fibonacci_Feedback,
+    ) {
+        (feedback.goal_id.uuid, feedback.feedback)
     }
 
     fn create_result_request(
@@ -1356,15 +1355,12 @@ impl rosidl_runtime_rs::ActionImpl for Fibonacci {
         }
     }
 
-    fn get_result_response_result(
-        response: &crate::vendor::example_interfaces::action::rmw::Fibonacci_GetResult_Response,
-    ) -> &crate::vendor::example_interfaces::action::rmw::Fibonacci_Result {
-        &response.result
-    }
-
-    fn get_result_response_status(
-        response: &crate::vendor::example_interfaces::action::rmw::Fibonacci_GetResult_Response,
-    ) -> i8 {
-        response.status
+    fn split_result_response(
+        response: crate::vendor::example_interfaces::action::rmw::Fibonacci_GetResult_Response,
+    ) -> (
+        i8,
+        crate::vendor::example_interfaces::action::rmw::Fibonacci_Result,
+    ) {
+        (response.status, response.result)
     }
 }

--- a/rclrs/src/vendor/test_msgs/action.rs
+++ b/rclrs/src/vendor/test_msgs/action.rs
@@ -2497,25 +2497,24 @@ extern "C" {
 pub struct Fibonacci;
 
 impl rosidl_runtime_rs::Action for Fibonacci {
+    // --- Associated types for client library users ---
     type Goal = crate::vendor::test_msgs::action::Fibonacci_Goal;
     type Result = crate::vendor::test_msgs::action::Fibonacci_Result;
     type Feedback = crate::vendor::test_msgs::action::Fibonacci_Feedback;
 
+    // --- Associated types for client library implementation ---
+    type FeedbackMessage = crate::vendor::test_msgs::action::rmw::Fibonacci_FeedbackMessage;
+    type SendGoalService = crate::vendor::test_msgs::action::rmw::Fibonacci_SendGoal;
+    type CancelGoalService = crate::vendor::action_msgs::srv::rmw::CancelGoal;
+    type GetResultService = crate::vendor::test_msgs::action::rmw::Fibonacci_GetResult;
+
+    // --- Methods for client library implementation ---
     fn get_type_support() -> *const std::ffi::c_void {
         // SAFETY: No preconditions for this function.
         unsafe {
             rosidl_typesupport_c__get_action_type_support_handle__test_msgs__action__Fibonacci()
         }
     }
-}
-
-impl rosidl_runtime_rs::ActionImpl for Fibonacci {
-    type GoalStatusMessage = crate::vendor::action_msgs::msg::rmw::GoalStatusArray;
-    type FeedbackMessage = crate::vendor::test_msgs::action::rmw::Fibonacci_FeedbackMessage;
-
-    type SendGoalService = crate::vendor::test_msgs::action::rmw::Fibonacci_SendGoal;
-    type CancelGoalService = crate::vendor::action_msgs::srv::rmw::CancelGoal;
-    type GetResultService = crate::vendor::test_msgs::action::rmw::Fibonacci_GetResult;
 
     fn create_goal_request(
         goal_id: &[u8; 16],
@@ -2527,10 +2526,13 @@ impl rosidl_runtime_rs::ActionImpl for Fibonacci {
         }
     }
 
-    fn get_goal_request_uuid(
-        request: &crate::vendor::test_msgs::action::rmw::Fibonacci_SendGoal_Request,
-    ) -> &[u8; 16] {
-        &request.goal_id.uuid
+    fn split_goal_request(
+        request: crate::vendor::test_msgs::action::rmw::Fibonacci_SendGoal_Request,
+    ) -> (
+        [u8; 16],
+        crate::vendor::test_msgs::action::rmw::Fibonacci_Goal,
+    ) {
+        (request.goal_id.uuid, request.goal)
     }
 
     fn create_goal_response(
@@ -2569,16 +2571,13 @@ impl rosidl_runtime_rs::ActionImpl for Fibonacci {
         message
     }
 
-    fn get_feedback_message_uuid(
-        feedback: &crate::vendor::test_msgs::action::rmw::Fibonacci_FeedbackMessage,
-    ) -> &[u8; 16] {
-        &feedback.goal_id.uuid
-    }
-
-    fn get_feedback_message_feedback(
-        feedback: &crate::vendor::test_msgs::action::rmw::Fibonacci_FeedbackMessage,
-    ) -> &crate::vendor::test_msgs::action::rmw::Fibonacci_Feedback {
-        &feedback.feedback
+    fn split_feedback_message(
+        feedback: crate::vendor::test_msgs::action::rmw::Fibonacci_FeedbackMessage,
+    ) -> (
+        [u8; 16],
+        crate::vendor::test_msgs::action::rmw::Fibonacci_Feedback,
+    ) {
+        (feedback.goal_id.uuid, feedback.feedback)
     }
 
     fn create_result_request(
@@ -2602,16 +2601,10 @@ impl rosidl_runtime_rs::ActionImpl for Fibonacci {
         crate::vendor::test_msgs::action::rmw::Fibonacci_GetResult_Response { status, result }
     }
 
-    fn get_result_response_result(
-        response: &crate::vendor::test_msgs::action::rmw::Fibonacci_GetResult_Response,
-    ) -> &crate::vendor::test_msgs::action::rmw::Fibonacci_Result {
-        &response.result
-    }
-
-    fn get_result_response_status(
-        response: &crate::vendor::test_msgs::action::rmw::Fibonacci_GetResult_Response,
-    ) -> i8 {
-        response.status
+    fn split_result_response(
+        response: crate::vendor::test_msgs::action::rmw::Fibonacci_GetResult_Response,
+    ) -> (i8, crate::vendor::test_msgs::action::rmw::Fibonacci_Result) {
+        (response.status, response.result)
     }
 }
 
@@ -2625,25 +2618,24 @@ extern "C" {
 pub struct NestedMessage;
 
 impl rosidl_runtime_rs::Action for NestedMessage {
+    // --- Associated types for client library users ---
     type Goal = crate::vendor::test_msgs::action::NestedMessage_Goal;
     type Result = crate::vendor::test_msgs::action::NestedMessage_Result;
     type Feedback = crate::vendor::test_msgs::action::NestedMessage_Feedback;
 
+    // --- Associated types for client library implementation ---
+    type FeedbackMessage = crate::vendor::test_msgs::action::rmw::NestedMessage_FeedbackMessage;
+    type SendGoalService = crate::vendor::test_msgs::action::rmw::NestedMessage_SendGoal;
+    type CancelGoalService = crate::vendor::action_msgs::srv::rmw::CancelGoal;
+    type GetResultService = crate::vendor::test_msgs::action::rmw::NestedMessage_GetResult;
+
+    // --- Methods for client library implementation ---
     fn get_type_support() -> *const std::ffi::c_void {
         // SAFETY: No preconditions for this function.
         unsafe {
             rosidl_typesupport_c__get_action_type_support_handle__test_msgs__action__NestedMessage()
         }
     }
-}
-
-impl rosidl_runtime_rs::ActionImpl for NestedMessage {
-    type GoalStatusMessage = crate::vendor::action_msgs::msg::rmw::GoalStatusArray;
-    type FeedbackMessage = crate::vendor::test_msgs::action::rmw::NestedMessage_FeedbackMessage;
-
-    type SendGoalService = crate::vendor::test_msgs::action::rmw::NestedMessage_SendGoal;
-    type CancelGoalService = crate::vendor::action_msgs::srv::rmw::CancelGoal;
-    type GetResultService = crate::vendor::test_msgs::action::rmw::NestedMessage_GetResult;
 
     fn create_goal_request(
         goal_id: &[u8; 16],
@@ -2655,10 +2647,13 @@ impl rosidl_runtime_rs::ActionImpl for NestedMessage {
         }
     }
 
-    fn get_goal_request_uuid(
-        request: &crate::vendor::test_msgs::action::rmw::NestedMessage_SendGoal_Request,
-    ) -> &[u8; 16] {
-        &request.goal_id.uuid
+    fn split_goal_request(
+        request: crate::vendor::test_msgs::action::rmw::NestedMessage_SendGoal_Request,
+    ) -> (
+        [u8; 16],
+        crate::vendor::test_msgs::action::rmw::NestedMessage_Goal,
+    ) {
+        (request.goal_id.uuid, request.goal)
     }
 
     fn create_goal_response(
@@ -2697,16 +2692,13 @@ impl rosidl_runtime_rs::ActionImpl for NestedMessage {
         message
     }
 
-    fn get_feedback_message_uuid(
-        feedback: &crate::vendor::test_msgs::action::rmw::NestedMessage_FeedbackMessage,
-    ) -> &[u8; 16] {
-        &feedback.goal_id.uuid
-    }
-
-    fn get_feedback_message_feedback(
-        feedback: &crate::vendor::test_msgs::action::rmw::NestedMessage_FeedbackMessage,
-    ) -> &crate::vendor::test_msgs::action::rmw::NestedMessage_Feedback {
-        &feedback.feedback
+    fn split_feedback_message(
+        feedback: crate::vendor::test_msgs::action::rmw::NestedMessage_FeedbackMessage,
+    ) -> (
+        [u8; 16],
+        crate::vendor::test_msgs::action::rmw::NestedMessage_Feedback,
+    ) {
+        (feedback.goal_id.uuid, feedback.feedback)
     }
 
     fn create_result_request(
@@ -2730,15 +2722,12 @@ impl rosidl_runtime_rs::ActionImpl for NestedMessage {
         crate::vendor::test_msgs::action::rmw::NestedMessage_GetResult_Response { status, result }
     }
 
-    fn get_result_response_result(
-        response: &crate::vendor::test_msgs::action::rmw::NestedMessage_GetResult_Response,
-    ) -> &crate::vendor::test_msgs::action::rmw::NestedMessage_Result {
-        &response.result
-    }
-
-    fn get_result_response_status(
-        response: &crate::vendor::test_msgs::action::rmw::NestedMessage_GetResult_Response,
-    ) -> i8 {
-        response.status
+    fn split_result_response(
+        response: crate::vendor::test_msgs::action::rmw::NestedMessage_GetResult_Response,
+    ) -> (
+        i8,
+        crate::vendor::test_msgs::action::rmw::NestedMessage_Result,
+    ) {
+        (response.status, response.result)
     }
 }


### PR DESCRIPTION
After https://github.com/ros2-rust/rosidl_runtime_rs/pull/15 was merged, the action bindings of the vendored message binding packages fell out of sync. This PR makes the minimal changes necessary to the vendored message binding packages to allow rclrs to compile.

This PR is a sibling of https://github.com/ros2-rust/rosidl_rust/pull/7. They don't technically depend on each other, but they each bring their repo up to date with the new action trait definition.