### PR TITLE
first fetch and rebase branch before PR

### DIFF
--- a/.github/workflows/generate-bindings.yml
+++ b/.github/workflows/generate-bindings.yml
@@ -99,6 +99,8 @@ jobs:
           CREATE_PR=1
           git checkout -b update-bindings-${{ matrix.ros_distribution }}
         fi
+        git fetch origin update-bindings-${{ matrix.ros_distribution }}
+        git rebase origin/update-bindings-${{ matrix.ros_distribution }}
         git add rclrs/src/rcl_bindings_generated_${{ matrix.ros_distribution }}.rs
         git commit -m "Regenerate bindings for ${{ matrix.ros_distribution }}"
         git push -u origin update-bindings-${{ matrix.ros_distribution }}


### PR DESCRIPTION
The CI for creating bindings fails because of this:

```
Fetching origin
error: Your local changes to the following files would be overwritten by checkout:
	rclrs/src/rcl_bindings_generated_rolling.rs
Please commit your changes or stash them before you switch branches.
Aborting
Switched to a new branch 'update-bindings-rolling'
[update-bindings-rolling c039255] Regenerate bindings for rolling
 1 file changed, 1 insertion(+), 1 deletion(-)
To https://github.com/ros2-rust/ros2_rust
 ! [rejected]        update-bindings-rolling -> update-bindings-rolling (non-fast-forward)
error: failed to push some refs to 'https://github.com/ros2-rust/ros2_rust'
hint: Updates were rejected because the tip of your current branch is behind
hint: its remote counterpart. If you want to integrate the remote changes,
hint: use 'git pull' before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
```

I've added a fetch and rebase to the yml. But I might add some more improvements as well so I'll keep it in draft 