### PR TITLE
Fix rebase order in generate-bindings workflow

### DIFF
--- a/.github/workflows/generate-bindings.yml
+++ b/.github/workflows/generate-bindings.yml
@@ -99,10 +99,10 @@ jobs:
           CREATE_PR=1
           git checkout -b update-bindings-${{ matrix.ros_distribution }}
         fi
-        git fetch origin update-bindings-${{ matrix.ros_distribution }}
-        git rebase origin/update-bindings-${{ matrix.ros_distribution }}
         git add rclrs/src/rcl_bindings_generated_${{ matrix.ros_distribution }}.rs
         git commit -m "Regenerate bindings for ${{ matrix.ros_distribution }}"
+        git fetch origin update-bindings-${{ matrix.ros_distribution }}
+        git rebase origin/update-bindings-${{ matrix.ros_distribution }}
         git push -u origin update-bindings-${{ matrix.ros_distribution }}
         if [ $CREATE_PR -eq 1 ]; then
           gh pr create --base main --head update-bindings-${{ matrix.ros_distribution }} --title "Regenerate bindings for ${{ matrix.ros_distribution }}" --body "This PR regenerates the bindings for ${{ matrix.ros_distribution }}."


### PR DESCRIPTION
In PR #540 I've placed these lines in the wrong order. Ofcourse it needs to be done after the commit (thanks @esteve). The dangers of doing blind PRs testing the action itself :)

Let's try again!