### PR TITLE
ci: only run scheduled python bindings generation on main repo

### DIFF
--- a/.github/workflows/generate-bindings.yml
+++ b/.github/workflows/generate-bindings.yml
@@ -38,6 +38,10 @@ jobs:
             ros_distribution: rolling
             ros_version: 2
     runs-on: ubuntu-latest
+    if: |
+        github.event_name == 'workflow_dispatch' || (
+          github.event_name == 'schedule' && github.repository == 'ros2-rust/ros2_rust'
+        )
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
To prevent the generate python bindings to also run on our forks. It is quite invasive of creating pull requests on all of our forked repos as well.

If this works nicely, let's also add this to all the other CI as well.

But the manual triggering of actions should still work though 

