### PR TITLE
Add service introspection

### DIFF
--- a/rclrs/src/client.rs
+++ b/rclrs/src/client.rs
@@ -10,9 +10,12 @@ use rosidl_runtime_rs::Message;
 use crate::{
     error::ToResult, log_fatal, rcl_bindings::*, IntoPrimitiveOptions, MessageCow, Node, Promise,
     QoSProfile, RclPrimitive, RclPrimitiveHandle, RclPrimitiveKind, RclReturnCode, RclrsError,
-    ReadyKind, ServiceInfo, ServiceIntrospectionState, Waitable, WaitableLifecycle,
-    ENTITY_LIFECYCLE_MUTEX,
+    ReadyKind, ServiceInfo, Waitable, WaitableLifecycle, ENTITY_LIFECYCLE_MUTEX,
 };
+
+// The API for service introspection was added in Jazzy.
+#[cfg(not(ros_distro = "humble"))]
+use crate::ServiceIntrospectionState;
 
 mod client_async_callback;
 pub use client_async_callback::*;
@@ -377,6 +380,8 @@ where
     ///     - Off: Disabled
     ///     - Metadata: Only metadata without any user data contents
     ///     - Contents: User data contents with metadata
+    // The API for service introspection was added in Jazzy.
+    #[cfg(not(ros_distro = "humble"))]
     pub fn configure_introspection(
         &self,
         introspection_state: ServiceIntrospectionState,

--- a/rclrs/src/client.rs
+++ b/rclrs/src/client.rs
@@ -10,7 +10,8 @@ use rosidl_runtime_rs::Message;
 use crate::{
     error::ToResult, log_fatal, rcl_bindings::*, IntoPrimitiveOptions, MessageCow, Node, Promise,
     QoSProfile, RclPrimitive, RclPrimitiveHandle, RclPrimitiveKind, RclReturnCode, RclrsError,
-    ReadyKind, ServiceInfo, Waitable, WaitableLifecycle, ENTITY_LIFECYCLE_MUTEX,
+    ReadyKind, ServiceInfo, ServiceIntrospectionState, Waitable, WaitableLifecycle,
+    ENTITY_LIFECYCLE_MUTEX,
 };
 
 mod client_async_callback;
@@ -368,6 +369,41 @@ where
             board,
             lifecycle,
         }))
+    }
+
+    /// Configure service introspection for this client.
+    /// Service introspection allows tools to monitor service requests and responses.
+    /// Service introspection can be set to either
+    ///     - Off: Disabled
+    ///     - Metadata: Only metadata without any user data contents
+    ///     - Contents: User data contents with metadata
+    pub fn configure_introspection(
+        &self,
+        introspection_state: ServiceIntrospectionState,
+    ) -> Result<(), RclrsError> {
+        let client = &mut *self.handle.rcl_client.lock().unwrap();
+        let node = &mut *self.handle.node.handle().rcl_node.lock().unwrap();
+        let clock = self.handle.node.get_clock();
+        let rcl_clock = &mut *clock.get_rcl_clock().lock().unwrap();
+        let type_support = <T as rosidl_runtime_rs::Service>::get_type_support()
+            as *const rosidl_service_type_support_t;
+
+        // SAFETY: No preconditions for this function.
+        let publisher_options = unsafe { rcl_publisher_get_default_options() };
+
+        unsafe {
+            rcl_client_configure_service_introspection(
+                client,
+                node,
+                rcl_clock,
+                type_support,
+                publisher_options,
+                introspection_state.into(),
+            )
+            .ok()?;
+        }
+
+        Ok(())
     }
 }
 

--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -632,7 +632,7 @@ impl NodeState {
     /// The advantage of creating a service directly from the [`NodeState`] is you
     /// can create async services using [`NodeState::create_async_service`].
     pub fn create_service<'a, T, Args>(
-        &self,
+        self: &Arc<Self>,
         options: impl Into<ServiceOptions<'a>>,
         callback: impl IntoNodeServiceCallback<T, Args>,
     ) -> Result<Service<T>, RclrsError>
@@ -642,7 +642,7 @@ impl NodeState {
         ServiceState::<T, Node>::create(
             options,
             callback.into_node_service_callback(),
-            &self.handle,
+            self,
             self.commands.async_worker_commands(),
         )
     }
@@ -723,7 +723,7 @@ impl NodeState {
     /// # Ok::<(), RclrsError>(())
     /// ```
     pub fn create_async_service<'a, T, Args>(
-        &self,
+        self: &Arc<Self>,
         options: impl Into<ServiceOptions<'a>>,
         callback: impl IntoAsyncServiceCallback<T, Args>,
     ) -> Result<Service<T>, RclrsError>
@@ -733,7 +733,7 @@ impl NodeState {
         ServiceState::<T, Node>::create(
             options,
             callback.into_async_service_callback(),
-            &self.handle,
+            self,
             self.commands.async_worker_commands(),
         )
     }

--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -632,7 +632,7 @@ impl NodeState {
     /// The advantage of creating a service directly from the [`NodeState`] is you
     /// can create async services using [`NodeState::create_async_service`].
     pub fn create_service<'a, T, Args>(
-        self: &Arc<Self>,
+        &self,
         options: impl Into<ServiceOptions<'a>>,
         callback: impl IntoNodeServiceCallback<T, Args>,
     ) -> Result<Service<T>, RclrsError>

--- a/rclrs/src/service.rs
+++ b/rclrs/src/service.rs
@@ -172,6 +172,8 @@ where
     ///     - Off: Disabled
     ///     - Metadata: Only metadata without any user data contents
     ///     - Contents: User data contents with metadata
+    // The API for service introspection was added in Jazzy.
+    #[cfg(not(ros_distro = "humble"))]
     pub fn configure_introspection(
         &self,
         introspection_state: ServiceIntrospectionState,
@@ -428,6 +430,8 @@ impl Drop for ServiceHandle {
     }
 }
 
+// The API for service introspection was added in Jazzy.
+#[cfg(not(ros_distro = "humble"))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ServiceIntrospectionState {
     Off,
@@ -435,6 +439,8 @@ pub enum ServiceIntrospectionState {
     Contents,
 }
 
+// The API for service introspection was added in Jazzy.
+#[cfg(not(ros_distro = "humble"))]
 impl From<rcl_service_introspection_state_e> for ServiceIntrospectionState {
     fn from(value: rcl_service_introspection_state_e) -> Self {
         match value {
@@ -451,6 +457,8 @@ impl From<rcl_service_introspection_state_e> for ServiceIntrospectionState {
     }
 }
 
+// The API for service introspection was added in Jazzy.
+#[cfg(not(ros_distro = "humble"))]
 impl From<ServiceIntrospectionState> for rcl_service_introspection_state_e {
     fn from(value: ServiceIntrospectionState) -> Self {
         match value {

--- a/rclrs/src/service.rs
+++ b/rclrs/src/service.rs
@@ -430,12 +430,16 @@ impl Drop for ServiceHandle {
     }
 }
 
+/// The possible service introspection configurations
 // The API for service introspection was added in Jazzy.
 #[cfg(not(ros_distro = "humble"))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ServiceIntrospectionState {
+    /// Disable service introspection
     Off,
+    /// Enable service introspection with metadata only
     Metadata,
+    /// Enable service introspection with metadata and contents
     Contents,
 }
 

--- a/rclrs/src/service.rs
+++ b/rclrs/src/service.rs
@@ -391,6 +391,45 @@ impl Drop for ServiceHandle {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServiceIntrospectionState {
+    Off,
+    Metadata,
+    Contents,
+}
+
+impl From<rcl_service_introspection_state_e> for ServiceIntrospectionState {
+    fn from(value: rcl_service_introspection_state_e) -> Self {
+        match value {
+            rcl_service_introspection_state_e::RCL_SERVICE_INTROSPECTION_OFF => {
+                ServiceIntrospectionState::Off
+            }
+            rcl_service_introspection_state_e::RCL_SERVICE_INTROSPECTION_METADATA => {
+                ServiceIntrospectionState::Metadata
+            }
+            rcl_service_introspection_state_e::RCL_SERVICE_INTROSPECTION_CONTENTS => {
+                ServiceIntrospectionState::Contents
+            }
+        }
+    }
+}
+
+impl From<ServiceIntrospectionState> for rcl_service_introspection_state_e {
+    fn from(value: ServiceIntrospectionState) -> Self {
+        match value {
+            ServiceIntrospectionState::Off => {
+                rcl_service_introspection_state_e::RCL_SERVICE_INTROSPECTION_OFF
+            }
+            ServiceIntrospectionState::Metadata => {
+                rcl_service_introspection_state_e::RCL_SERVICE_INTROSPECTION_METADATA
+            }
+            ServiceIntrospectionState::Contents => {
+                rcl_service_introspection_state_e::RCL_SERVICE_INTROSPECTION_CONTENTS
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rclrs/src/service.rs
+++ b/rclrs/src/service.rs
@@ -143,7 +143,7 @@ where
 
         let handle = Arc::new(ServiceHandle {
             rcl_service: Mutex::new(rcl_service),
-            node: Arc::clone(node),
+            node: Arc::clone(&node),
         });
 
         let (waitable, lifecycle) = Waitable::new(

--- a/rclrs/src/service.rs
+++ b/rclrs/src/service.rs
@@ -9,8 +9,9 @@ use rosidl_runtime_rs::{Message, Service as ServiceIDL};
 
 use crate::{
     error::ToResult, rcl_bindings::*, Clock, IntoPrimitiveOptions, MessageCow, Node, NodeHandle,
-    QoSProfile, RclPrimitive, RclPrimitiveHandle, RclPrimitiveKind, RclrsError, ReadyKind,
-    Waitable, WaitableLifecycle, WorkScope, Worker, WorkerCommands, ENTITY_LIFECYCLE_MUTEX,
+    NodeState, QoSProfile, RclPrimitive, RclPrimitiveHandle, RclPrimitiveKind, RclrsError,
+    ReadyKind, Waitable, WaitableLifecycle, WorkScope, Worker, WorkerCommands,
+    ENTITY_LIFECYCLE_MUTEX,
 };
 
 mod any_service_callback;
@@ -101,7 +102,7 @@ where
     pub(crate) fn create<'a>(
         options: impl Into<ServiceOptions<'a>>,
         callback: AnyServiceCallback<T, Scope::Payload>,
-        node: &Node,
+        node: &NodeState,
         commands: &Arc<WorkerCommands>,
     ) -> Result<Arc<Self>, RclrsError> {
         let ServiceOptions { name, qos } = options.into();

--- a/rclrs/src/worker.rs
+++ b/rclrs/src/worker.rs
@@ -428,7 +428,7 @@ impl<Payload: 'static + Send + Sync> WorkerState<Payload> {
         ServiceState::<T, Worker<Payload>>::create(
             options,
             callback.into_worker_service_callback(),
-            self.node.handle(),
+            &self.node,
             &self.commands,
         )
     }


### PR DESCRIPTION
This PR is a work in progress to add service introspection support to rclrs.

- [x] Configure service introspection for `ClientState`
- [x] Configure service introspection for `ServiceState`

I'm not all that familiar with the RCL interface and how to get and pass around the proper pointers. If anyone more familiar could double check the calls to RCL that would be appreciated.

I'm currently looking to add similar support for `ServiceState` but I can't implement it in the same way because it only stores a `NodeHandle` instead of the full `Node` and I'm not sure how to get the clock from it. I've asked on the Matrix chat what the reason was behind the asymmetry. I'm not sure if there is a way to work around this or if we need to make a breaking change and unify the APIs?

----

### Edit
I've made the API changes in a second commit and implemented the introspection for `ServiceState` as well. If that is not the desired way forward it is easy to drop that commit.