### PR TITLE
fix: add explicit lifetimes to fix mismatched_lifetime_syntaxes warnings

### DIFF
--- a/rclrs/src/action/action_client.rs
+++ b/rclrs/src/action/action_client.rs
@@ -847,7 +847,7 @@ impl<A: Action> RclPrimitive for ActionClientExecutable<A> {
         RclPrimitiveKind::ActionClient
     }
 
-    fn handle(&self) -> crate::RclPrimitiveHandle {
+    fn handle(&self) -> crate::RclPrimitiveHandle<'_> {
         RclPrimitiveHandle::ActionClient(self.board.handle.lock())
     }
 }
@@ -863,7 +863,7 @@ pub struct ActionClientHandle {
 }
 
 impl ActionClientHandle {
-    fn lock(&self) -> MutexGuard<rcl_action_client_t> {
+    fn lock(&self) -> MutexGuard<'_, rcl_action_client_t> {
         self.rcl_action_client.lock().unwrap()
     }
 

--- a/rclrs/src/action/action_server.rs
+++ b/rclrs/src/action/action_server.rs
@@ -662,7 +662,7 @@ impl<A: Action> RclPrimitive for ActionServerExecutable<A> {
         RclPrimitiveKind::ActionServer
     }
 
-    fn handle(&self) -> RclPrimitiveHandle {
+    fn handle(&self) -> RclPrimitiveHandle<'_> {
         RclPrimitiveHandle::ActionServer(self.board.handle.lock())
     }
 }
@@ -687,7 +687,7 @@ pub(crate) struct ActionServerHandle<A: Action> {
 unsafe impl Send for rcl_action_server_t {}
 
 impl<A: Action> ActionServerHandle<A> {
-    pub(super) fn lock(&self) -> MutexGuard<rcl_action_server_t> {
+    pub(super) fn lock(&self) -> MutexGuard<'_, rcl_action_server_t> {
         self.rcl_action_server.lock().unwrap()
     }
 

--- a/rclrs/src/action/action_server/action_server_goal_handle.rs
+++ b/rclrs/src/action/action_server/action_server_goal_handle.rs
@@ -31,7 +31,7 @@ impl<A: Action> ActionServerGoalHandle<A> {
         }
     }
 
-    pub(super) fn lock(&self) -> MutexGuard<rcl_action_goal_handle_t> {
+    pub(super) fn lock(&self) -> MutexGuard<'_, rcl_action_goal_handle_t> {
         self.rcl_handle.lock().unwrap()
     }
 

--- a/rclrs/src/client.rs
+++ b/rclrs/src/client.rs
@@ -420,7 +420,7 @@ where
         self.board.lock().unwrap().execute(&self.handle)
     }
 
-    fn handle(&self) -> RclPrimitiveHandle {
+    fn handle(&self) -> RclPrimitiveHandle<'_> {
         RclPrimitiveHandle::Client(self.handle.lock())
     }
 
@@ -543,7 +543,7 @@ struct ClientHandle {
 }
 
 impl ClientHandle {
-    fn lock(&self) -> MutexGuard<rcl_client_t> {
+    fn lock(&self) -> MutexGuard<'_, rcl_client_t> {
         self.rcl_client.lock().unwrap()
     }
 }

--- a/rclrs/src/logging/log_params.rs
+++ b/rclrs/src/logging/log_params.rs
@@ -36,7 +36,7 @@ impl<'a> LogParams<'a> {
     }
 
     /// Get the logger name
-    pub fn get_logger_name(&self) -> &LoggerName {
+    pub fn get_logger_name(&self) -> &LoggerName<'_> {
         &self.logger_name
     }
 

--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -1405,7 +1405,7 @@ impl NodeState {
     /// Enables usage of undeclared parameters for this node.
     ///
     /// Returns a [`Parameters`] struct that can be used to get and set all parameters.
-    pub fn use_undeclared_parameters(&self) -> Parameters {
+    pub fn use_undeclared_parameters(&self) -> Parameters<'_> {
         self.parameter.allow_undeclared();
         Parameters {
             interface: &self.parameter,

--- a/rclrs/src/service.rs
+++ b/rclrs/src/service.rs
@@ -265,7 +265,7 @@ where
         RclPrimitiveKind::Service
     }
 
-    fn handle(&self) -> RclPrimitiveHandle {
+    fn handle(&self) -> RclPrimitiveHandle<'_> {
         RclPrimitiveHandle::Service(self.handle.lock())
     }
 }
@@ -285,7 +285,7 @@ pub struct ServiceHandle {
 }
 
 impl ServiceHandle {
-    fn lock(&self) -> MutexGuard<rcl_service_t> {
+    fn lock(&self) -> MutexGuard<'_, rcl_service_t> {
         self.rcl_service.lock().unwrap()
     }
 

--- a/rclrs/src/subscription.rs
+++ b/rclrs/src/subscription.rs
@@ -291,7 +291,7 @@ where
         RclPrimitiveKind::Subscription
     }
 
-    fn handle(&self) -> RclPrimitiveHandle {
+    fn handle(&self) -> RclPrimitiveHandle<'_> {
         RclPrimitiveHandle::Subscription(self.handle.lock())
     }
 }
@@ -311,7 +311,7 @@ pub(crate) struct SubscriptionHandle {
 }
 
 impl SubscriptionHandle {
-    pub(crate) fn lock(&self) -> MutexGuard<rcl_subscription_t> {
+    pub(crate) fn lock(&self) -> MutexGuard<'_, rcl_subscription_t> {
         self.rcl_subscription.lock().unwrap()
     }
 

--- a/rclrs/src/timer.rs
+++ b/rclrs/src/timer.rs
@@ -506,7 +506,7 @@ impl<Scope: WorkScope> RclPrimitive for TimerExecutable<Scope> {
         RclPrimitiveKind::Timer
     }
 
-    fn handle(&self) -> RclPrimitiveHandle {
+    fn handle(&self) -> RclPrimitiveHandle<'_> {
         RclPrimitiveHandle::Timer(self.handle.rcl_timer.lock().unwrap())
     }
 }

--- a/rclrs/src/wait_set/guard_condition.rs
+++ b/rclrs/src/wait_set/guard_condition.rs
@@ -218,7 +218,7 @@ impl RclPrimitive for GuardConditionExecutable {
         RclPrimitiveKind::GuardCondition
     }
 
-    fn handle(&self) -> RclPrimitiveHandle {
+    fn handle(&self) -> RclPrimitiveHandle<'_> {
         RclPrimitiveHandle::GuardCondition(self.handle.rcl_guard_condition.lock().unwrap())
     }
 }

--- a/rclrs/src/wait_set/rcl_primitive.rs
+++ b/rclrs/src/wait_set/rcl_primitive.rs
@@ -27,7 +27,7 @@ pub trait RclPrimitive: Send + Sync {
     fn kind(&self) -> RclPrimitiveKind;
 
     /// Provide the handle for this primitive
-    fn handle(&self) -> RclPrimitiveHandle;
+    fn handle(&self) -> RclPrimitiveHandle<'_>;
 }
 
 /// Enum to describe the kind of an executable.


### PR DESCRIPTION
Add explicit '_ lifetime annotations to return types where &self implies a lifetime but the return type uses elision to hide it. This addresses the mismatched_lifetime_syntaxes lint enabled by default in recent Rust versions.

Fixes 16 warnings across 11 files:
- RclPrimitive::handle() trait and all implementations
- Various lock() methods returning MutexGuard
- NodeState::use_undeclared_parameters() returning Parameters
- LogParams::get_logger_name() returning &LoggerName

Closes #558