### PR TITLE
ci: update Debian packages before running the bindings generation script

### DIFF
--- a/.github/workflows/generate-bindings.yml
+++ b/.github/workflows/generate-bindings.yml
@@ -58,6 +58,9 @@ jobs:
         required-ros-distributions: ${{ matrix.ros_distribution }}
         use-ros2-testing: ${{ matrix.ros_distribution == 'rolling' }}
 
+    - name: Update environment
+      run: apt-get update && apt-get upgrade -y
+
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@1.85
       with:


### PR DESCRIPTION
This PR ensures that the latest released version of all the packages are installed.

Fixes #581 