### PR TITLE
ci(generate-bindings): use conventional commit format for messages and PR titles

### DIFF
--- a/.github/workflows/generate-bindings.yml
+++ b/.github/workflows/generate-bindings.yml
@@ -116,7 +116,7 @@ jobs:
         fi
         
         git add rclrs/src/rcl_bindings_generated_${{ matrix.ros_distribution }}.rs
-        git commit -m "Regenerate bindings for ${{ matrix.ros_distribution }}"
+        git commit -m "build(bindings): regenerate bindings for ${{ matrix.ros_distribution }}"
         
         git push -f origin HEAD:refs/heads/$BRANCH_NAME
         
@@ -124,7 +124,7 @@ jobs:
           gh pr create \
             --base main \
             --head "$BRANCH_NAME" \
-            --title "Regenerate bindings for ${{ matrix.ros_distribution }}" \
+            --title "build(bindings): regenerate bindings for ${{ matrix.ros_distribution }}" \
             --body "This PR regenerates the bindings for ${{ matrix.ros_distribution }}."
             echo "Created new PR!"
         else


### PR DESCRIPTION
This PR updates the `generate-bindings` CI workflow to use the Conventional Commits format (https://www.conventionalcommits.org/en/v1.0.0/)