### PR TITLE
fix: initialize rosout publisher on distros newer than Humble

### DIFF
--- a/rclrs/src/node/graph.rs
+++ b/rclrs/src/node/graph.rs
@@ -493,21 +493,12 @@ mod tests {
         let node = executor.create_node(node_name).unwrap();
 
         let check_rosout = |topics: HashMap<String, Vec<String>>| {
-            // rosout shows up in humble and iron, even if the graph is empty
-            #[cfg(any(ros_distro = "humble"))]
-            {
-                assert_eq!(topics.len(), 1);
-                assert_eq!(
-                    topics.get("/rosout").unwrap().first().unwrap(),
-                    "rcl_interfaces/msg/Log"
-                );
-            }
-
-            // rosout does not automatically show up in jazzy when the graph is empty
-            #[cfg(any(ros_distro = "jazzy", ros_distro = "rolling"))]
-            {
-                assert_eq!(topics.len(), 0);
-            }
+            // rosout shows up when a node is created (on all distros after enabling rosout)
+            assert_eq!(topics.len(), 1);
+            assert_eq!(
+                topics.get("/rosout").unwrap().first().unwrap(),
+                "rcl_interfaces/msg/Log"
+            );
         };
 
         let names_and_topics = node

--- a/rclrs/src/test_helpers/mod.rs
+++ b/rclrs/src/test_helpers/mod.rs
@@ -5,3 +5,26 @@ pub(crate) use self::graph_helpers::*;
 
 pub(crate) fn assert_send<T: Send>() {}
 pub(crate) fn assert_sync<T: Sync>() {}
+
+use crate::{Executor, SpinOptions};
+use std::time::{Duration, Instant};
+
+/// Spins the executor until a condition returns true or timeout is reached.
+/// Returns true if condition was met, false if timed out.
+pub(crate) fn spin_until_condition<F>(
+    executor: &mut Executor,
+    mut condition: F,
+    timeout: Duration,
+) -> bool
+where
+    F: FnMut() -> bool,
+{
+    let start = Instant::now();
+    while !condition() {
+        if start.elapsed() >= timeout {
+            return false;
+        }
+        executor.spin(SpinOptions::spin_once().timeout(Duration::from_millis(10)));
+    }
+    true
+}


### PR DESCRIPTION
This PR initializes the `rosout` publisher for distros after Humble.

Fixes https://github.com/ros2-rust/ros2_rust/issues/590