### PR TITLE
ci(windows): update win ROS 2 rolling package download link in workflow

### DIFF
--- a/.github/workflows/rust-win.yml
+++ b/.github/workflows/rust-win.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Get prebuilt ROS files and unzip
         run: |
-          irm https://github.com/knmcguire/ros2/releases/download/temp_win_v.0.0.1/ros2-package-windows-AMD64.zip -Outfile ros2-package-windows-AMD64.zip
+          irm https://github.com/ros2/ros2/releases/download/release-rolling-nightlies/ros2-rolling-nightly-windows-amd64.zip -Outfile ros2-package-windows-AMD64.zip
           Expand-Archive -Path ros2-package-windows-AMD64.zip -DestinationPath C:/pixi_ws/
 
       - name: Build the rust package


### PR DESCRIPTION
There is now a nightly release available for rolling that is updated every night here: https://github.com/ros2/ros2/releases/tag/release-rolling-nightlies

This fixes our issue of the ci.ros2.org being behind an authentication wall!

Fixes #562