### PR TITLE
ci: force update packages to deal with GH action caching

### DIFF
--- a/.github/workflows/generate-bindings.yml
+++ b/.github/workflows/generate-bindings.yml
@@ -58,8 +58,13 @@ jobs:
         required-ros-distributions: ${{ matrix.ros_distribution }}
         use-ros2-testing: ${{ matrix.ros_distribution == 'rolling' }}
 
-    - name: Update environment
-      run: apt-get update && apt-get upgrade -y
+    - name: Update environment and force upgrade new packages
+      run: |
+        apt-get update
+        apt-get dist-upgrade -y
+        sync
+        ldconfig
+        sleep 1
 
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@1.85

--- a/.github/workflows/generate-bindings.yml
+++ b/.github/workflows/generate-bindings.yml
@@ -62,9 +62,6 @@ jobs:
       run: |
         apt-get update
         apt-get dist-upgrade -y
-        sync
-        ldconfig
-        sleep 1
 
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@1.85


### PR DESCRIPTION
Hopefully fixes #605 

The problem is that it kept using old headers that were still in the caches of the github actions docker. This will hopefully force all the packages to be updated. 