### PR TITLE
docs: add missing cargo-ament-build to installation prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ sudo apt install -y git libclang-dev python3-pip python3-vcstool
 
 # Install colcon plugins for Rust
 pip install --break-system-packages colcon-cargo colcon-ros-cargo
+
+# Install cargo plugin for ament
+cargo install cargo-ament-build
 ```
 
 Because of an issue in `rclrs` (https://github.com/ros2-rust/ros2_rust/issues/557), as a workaround, the following two packages need to be installed:

--- a/docs/building.md
+++ b/docs/building.md
@@ -45,6 +45,7 @@ sudo apt install -y git libclang-dev python3-pip python3-vcstool # libclang-dev 
 # Install these plugins for cargo and colcon:
 pip install git+https://github.com/colcon/colcon-cargo.git
 pip install git+https://github.com/colcon/colcon-ros-cargo.git
+cargo install cargo-ament-build
 ```
 
 ### Option 2: Using the Docker image


### PR DESCRIPTION
Description:
The current installation instructions missed the cargo-ament-build dependency. Without installing it globally via cargo install cargo-ament-build, running colcon build will fail with a fatal error stating "cargo ament-build was not detected".

Changes:
Added cargo install cargo-ament-build to the prerequisites block in README.md.
Added the same command to the "Option 1: Installing the dependencies" section in docs/building.md.

This will help new users successfully build the workspace without encountering the missing cargo plugin error.