### PR TITLE
fix: add align(8) to rcl_context_s and rmw_context_s for ARM32

### DIFF
--- a/rclrs/src/rcl_bindings_generated_humble.rs
+++ b/rclrs/src/rcl_bindings_generated_humble.rs
@@ -817,7 +817,7 @@ pub struct rmw_context_impl_s {
     _unused: [u8; 0],
 }
 pub type rmw_context_impl_t = rmw_context_impl_s;
-#[repr(C)]
+#[repr(C, align(8))]
 #[derive(Debug)]
 pub struct rmw_context_s {
     pub instance_id: u64,
@@ -1538,7 +1538,7 @@ pub struct rcl_context_impl_s {
     _unused: [u8; 0],
 }
 pub type rcl_context_impl_t = rcl_context_impl_s;
-#[repr(C)]
+#[repr(C, align(8))]
 #[derive(Debug)]
 pub struct rcl_context_s {
     pub global_arguments: rcl_arguments_t,


### PR DESCRIPTION
## Summary

- Add `#[repr(C, align(8))]` to `rcl_context_s` and `rmw_context_s` in the Humble bindings to fix `SIGBUS (BUS_ADRALN)` on ARM32 Linux.

## Problem

On ARM32 Linux (kernel 4.19), `rcl_context_s.instance_id_storage` is declared as `[u8; 8]` (alignment = 1), which gives the struct an alignment of 4 (from pointer fields). In C, this field is `atomic_uint_least64_t` (alignment = 8), so the C struct naturally gets 8-byte alignment.

When `librcl.so` accesses the `instance_id_storage` field using a Thumb-2 `LDRD` instruction from a 4-byte-aligned (but not 8-byte-aligned) address, the kernel's alignment fixup handler cannot handle Thumb-2 LDRD, resulting in `SIGBUS`.

## Fix

Add explicit `align(8)` to match the C struct's alignment. This is a no-op on 64-bit platforms (pointer alignment is already 8), and only affects 32-bit platforms where it corrects the struct alignment from 4 to 8.

## Test plan

- [x] Verified on ARM32 device (ARMv7, Linux 4.19.87-rt35) — `SIGBUS` resolved
- [x] Verified 64-bit builds unaffected (no layout change)
- [x] Docker e2e tests pass (x86_64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)