### PR TITLE
chore: add nix flake development shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,153 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nix-ros-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1774001258,
+        "narHash": "sha256-DoT1Dyg/8O1P980AqP5KbzVQu5iC5BarvgrUspS17VM=",
+        "owner": "lopsided98",
+        "repo": "nix-ros-overlay",
+        "rev": "9816ceba7fc2e340308768fdecfd7c07e8a70730",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lopsided98",
+        "ref": "master",
+        "repo": "nix-ros-overlay",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1759381078,
+        "narHash": "sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7df7ff7d8e00218376575f0acdcc5d66741351ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lopsided98",
+        "ref": "nix-ros",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nix-ros-overlay": "nix-ros-overlay",
+        "nixpkgs": [
+          "nix-ros-overlay",
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1774494762,
+        "narHash": "sha256-lt22GCJZ6qBQLgNZZl3S/RUjTLXTlEy0Fn0sqMttLxQ=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "ce3b3a61ebf28670dfc8b97eb35ed9e24474a2cf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -42,11 +42,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1774047596,
-        "narHash": "sha256-UNT8fGmAm2ZlaktMmiVYPeHgok2IJoCfLg698rO3Kq8=",
+        "lastModified": 1775764892,
+        "narHash": "sha256-l1UbHppd5KaU4K/TQPIXf9wnVifH4Tgrx5z2GFoq/bw=",
         "owner": "lopsided98",
         "repo": "nix-ros-overlay",
-        "rev": "c0659dc45d4c1736d71d5578b17f12e3b1afe190",
+        "rev": "0a4e8cf51001d2d1c613f95dadd3853da42c0164",
         "type": "github"
       },
       "original": {
@@ -57,16 +57,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1759381078,
-        "narHash": "sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs=",
+        "lastModified": 1771369470,
+        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7df7ff7d8e00218376575f0acdcc5d66741351ee",
+        "rev": "0182a361324364ae3f436a63005877674cf45efb",
         "type": "github"
       },
       "original": {
-        "owner": "lopsided98",
-        "ref": "nix-ros",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -103,11 +103,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1774494762,
-        "narHash": "sha256-lt22GCJZ6qBQLgNZZl3S/RUjTLXTlEy0Fn0sqMttLxQ=",
+        "lastModified": 1775877051,
+        "narHash": "sha256-wpSQm2PD/w4uRo2wb8utk0b5hOBkkg/CZ1xICY+qB7M=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "ce3b3a61ebf28670dfc8b97eb35ed9e24474a2cf",
+        "rev": "08b4f3633471874c8894632ade1b78d75dbda002",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -42,16 +42,15 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1774001258,
-        "narHash": "sha256-DoT1Dyg/8O1P980AqP5KbzVQu5iC5BarvgrUspS17VM=",
+        "lastModified": 1774047596,
+        "narHash": "sha256-UNT8fGmAm2ZlaktMmiVYPeHgok2IJoCfLg698rO3Kq8=",
         "owner": "lopsided98",
         "repo": "nix-ros-overlay",
-        "rev": "9816ceba7fc2e340308768fdecfd7c07e8a70730",
+        "rev": "c0659dc45d4c1736d71d5578b17f12e3b1afe190",
         "type": "github"
       },
       "original": {
         "owner": "lopsided98",
-        "ref": "master",
         "repo": "nix-ros-overlay",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -19,203 +19,219 @@
           inherit system overlays;
         };
 
-        rosDistro = pkgs.rosPackages.jazzy;
+        supportedDistros = builtins.filter
+          (name:
+            let value = pkgs.rosPackages.${name};
+            in builtins.isAttrs value && builtins.hasAttr "ros-core" value
+          )
+          (builtins.attrNames pkgs.rosPackages);
+        defaultDistro = "jazzy";
+
         rustToolchain = pkgs.rust-bin.stable.latest.default.override {
           extensions = [ "rust-src" ];
         };
 
-        rosPrefixes = "${rosDistro.ament-cmake}:${rosDistro.ament-cmake-core}:${rosDistro.python-cmake-module}:${rosDistro.rmw}:${rosDistro.rosidl-default-generators}:${rosDistro.rosidl-runtime-c}:${rosDistro.rosidl-typesupport-c}:${rosDistro.rosidl-typesupport-interface}:${rosDistro.std-msgs}:${rosDistro.test-msgs}";
+        mkRosDevShell = distroName:
+          let
+            rosDistro = pkgs.rosPackages.${distroName};
+            rosPrefixes = "${rosDistro.ament-cmake}:${rosDistro.ament-cmake-core}:${rosDistro.python-cmake-module}:${rosDistro.rmw}:${rosDistro.rosidl-default-generators}:${rosDistro.rosidl-runtime-c}:${rosDistro.rosidl-typesupport-c}:${rosDistro.rosidl-typesupport-interface}:${rosDistro.std-msgs}:${rosDistro.test-msgs}";
+          in
+          pkgs.mkShell {
+            packages =
+              [
+                rustToolchain
+                pkgs.gcc
+                pkgs.clang
+                pkgs.cmake
+                pkgs.mold
+                pkgs.pkg-config
+                pkgs.colcon
+                (with rosDistro; buildEnv {
+                  paths = [
+                    ros-core
+                    ros-base
+                    cyclonedds
+                    rmw-cyclonedds-cpp
+                    test-msgs
+                  ];
+                })
+              ];
+
+            RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
+
+            shellHook = ''
+              export LIBCLANG_PATH="${pkgs.llvmPackages.libclang.lib}/lib"
+              export LD_LIBRARY_PATH="${pkgs.stdenv.cc.cc.lib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+              export CC=clang
+              export CXX=clang++
+
+              dedup_flags() {
+                  local var_name="$1"
+                  local current_value
+                  current_value="$(printenv "$var_name" 2>/dev/null || true)"
+
+                  if [ -z "$current_value" ]; then
+                      return
+                  fi
+
+                  export "$var_name=$(
+                      printf '%s' "$current_value" \
+                          | tr ' ' '\n' \
+                          | awk '
+                              function flush_entry(entry_key, entry_value) {
+                                  if (!(entry_key in seen)) {
+                                      seen[entry_key] = 1
+                                      print entry_value
+                                  }
+                              }
+
+                              BEGIN {
+                                  expects_value["-I"] = 1
+                                  expects_value["-L"] = 1
+                                  expects_value["-B"] = 1
+                                  expects_value["-include"] = 1
+                                  expects_value["-iquote"] = 1
+                                  expects_value["-idirafter"] = 1
+                                  expects_value["-isystem"] = 1
+                                  expects_value["-isysroot"] = 1
+                                  expects_value["-iframework"] = 1
+                              }
+
+                              NF == 0 {
+                                  next
+                              }
+
+                              pending_option != "" {
+                                  flush_entry(pending_option SUBSEP $0, pending_option " " $0)
+                                  pending_option = ""
+                                  next
+                              }
+
+                              {
+                                  if ($0 in expects_value) {
+                                      pending_option = $0
+                                      next
+                                  }
+
+                                  flush_entry($0, $0)
+                              }
+
+                              END {
+                                  if (pending_option != "") {
+                                      flush_entry(pending_option, pending_option)
+                                  }
+                              }
+                          ' \
+                          | paste -sd ' ' -
+                  )"
+              }
+
+              dedup_flags NIX_CFLAGS_COMPILE
+              dedup_flags NIX_CXXFLAGS_COMPILE
+              dedup_flags NIX_LDFLAGS
+
+              prepend_prefixes() {
+                  local var_name="$1"
+                  local existing_value
+
+                  existing_value="$(printenv "$var_name" 2>/dev/null || true)"
+                  if [ -n "$existing_value" ]; then
+                      export "$var_name=${rosPrefixes}:$existing_value"
+                  else
+                      export "$var_name=${rosPrefixes}"
+                  fi
+              }
+
+              prepend_prefixes CMAKE_PREFIX_PATH
+
+              setup_synthetic_ament_prefix() {
+                  local base_dir
+                  local synthetic_prefix
+                  local source_prefixes
+                  local old_ifs="$IFS"
+                  local prefix
+                  local category_dir
+                  local resource
+                  local existing_value
+                  local filtered=""
+
+                  if [ -n "''${XDG_CACHE_HOME:-}" ]; then
+                      base_dir="$XDG_CACHE_HOME"
+                  elif [ -n "''${TMPDIR:-}" ]; then
+                      base_dir="$TMPDIR"
+                  else
+                      base_dir="/tmp"
+                  fi
+
+                  synthetic_prefix="$base_dir/ros2-rust-nix-ament-prefix-${system}"
+                  mkdir -p "$synthetic_prefix/share/ament_index/resource_index/packages"
+
+                  printf '%s\n' '#!/usr/bin/env sh' > "$synthetic_prefix/local_setup.sh"
+                  printf '%s\n' '#!/usr/bin/env bash' > "$synthetic_prefix/local_setup.bash"
+                  printf '%s\n' '#!/usr/bin/env zsh' > "$synthetic_prefix/local_setup.zsh"
+                  chmod +x \
+                      "$synthetic_prefix/local_setup.sh" \
+                      "$synthetic_prefix/local_setup.bash" \
+                      "$synthetic_prefix/local_setup.zsh"
+
+                  find "$synthetic_prefix/share/ament_index/resource_index" -mindepth 1 -delete
+
+                  source_prefixes="$(printenv CMAKE_PREFIX_PATH 2>/dev/null || true)"
+                  IFS=:
+                  for prefix in $source_prefixes; do
+                      if [ ! -d "$prefix/share/ament_index/resource_index" ]; then
+                          continue
+                      fi
+
+                      for category_dir in "$prefix"/share/ament_index/resource_index/*; do
+                          if [ ! -d "$category_dir" ]; then
+                              continue
+                          fi
+
+                          mkdir -p "$synthetic_prefix/share/ament_index/resource_index/$(basename "$category_dir")"
+                          for resource in "$category_dir"/*; do
+                              if [ ! -f "$resource" ]; then
+                                  continue
+                              fi
+                              ln -sf "$resource" \
+                                  "$synthetic_prefix/share/ament_index/resource_index/$(basename "$category_dir")/$(basename "$resource")"
+                          done
+                      done
+                  done
+                  IFS="$old_ifs"
+
+                  existing_value="$(printenv AMENT_PREFIX_PATH 2>/dev/null || true)"
+                  if [ -n "$existing_value" ]; then
+                      IFS=:
+                      for prefix in $existing_value; do
+                          if [ -f "$prefix/local_setup.sh" ] || [ -f "$prefix/local_setup.bash" ] || [ -f "$prefix/local_setup.zsh" ]; then
+                              if [ -n "$filtered" ]; then
+                                  filtered="$filtered:$prefix"
+                              else
+                                  filtered="$prefix"
+                              fi
+                          fi
+                      done
+                      IFS="$old_ifs"
+                  fi
+
+                  if [ -n "$filtered" ]; then
+                      export AMENT_PREFIX_PATH="$synthetic_prefix:$filtered"
+                  else
+                      export AMENT_PREFIX_PATH="$synthetic_prefix"
+                  fi
+              }
+
+              setup_synthetic_ament_prefix
+            '';
+          };
+
+        distroShells = builtins.listToAttrs (
+          map (name: { inherit name; value = mkRosDevShell name; }) supportedDistros
+        );
       in
       {
-        devShells.default = pkgs.mkShell {
-          packages =
-            [
-              rustToolchain
-              pkgs.gcc
-              pkgs.clang
-              pkgs.cmake
-              pkgs.mold
-              pkgs.pkg-config
-              pkgs.colcon
-              (with rosDistro; buildEnv {
-                paths = [
-                  ros-core
-                  ros-base
-                  cyclonedds
-                  rmw-cyclonedds-cpp
-                  test-msgs
-                ];
-              })
-            ];
-
-          RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
-
-          shellHook = ''
-            export LIBCLANG_PATH="${pkgs.llvmPackages.libclang.lib}/lib"
-            export LD_LIBRARY_PATH="${pkgs.stdenv.cc.cc.lib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-            export CC=clang
-            export CXX=clang++
-
-            dedup_flags() {
-                local var_name="$1"
-                local current_value
-                current_value="$(printenv "$var_name" 2>/dev/null || true)"
-
-                if [ -z "$current_value" ]; then
-                    return
-                fi
-
-                export "$var_name=$(
-                    printf '%s' "$current_value" \
-                        | tr ' ' '\n' \
-                        | awk '
-                            function flush_entry(entry_key, entry_value) {
-                                if (!(entry_key in seen)) {
-                                    seen[entry_key] = 1
-                                    print entry_value
-                                }
-                            }
-
-                            BEGIN {
-                                expects_value["-I"] = 1
-                                expects_value["-L"] = 1
-                                expects_value["-B"] = 1
-                                expects_value["-include"] = 1
-                                expects_value["-iquote"] = 1
-                                expects_value["-idirafter"] = 1
-                                expects_value["-isystem"] = 1
-                                expects_value["-isysroot"] = 1
-                                expects_value["-iframework"] = 1
-                            }
-
-                            NF == 0 {
-                                next
-                            }
-
-                            pending_option != "" {
-                                flush_entry(pending_option SUBSEP $0, pending_option " " $0)
-                                pending_option = ""
-                                next
-                            }
-
-                            {
-                                if ($0 in expects_value) {
-                                    pending_option = $0
-                                    next
-                                }
-
-                                flush_entry($0, $0)
-                            }
-
-                            END {
-                                if (pending_option != "") {
-                                    flush_entry(pending_option, pending_option)
-                                }
-                            }
-                        ' \
-                        | paste -sd ' ' -
-                )"
-            }
-
-            dedup_flags NIX_CFLAGS_COMPILE
-            dedup_flags NIX_CXXFLAGS_COMPILE
-            dedup_flags NIX_LDFLAGS
-
-            prepend_prefixes() {
-                local var_name="$1"
-                local existing_value
-
-                existing_value="$(printenv "$var_name" 2>/dev/null || true)"
-                if [ -n "$existing_value" ]; then
-                    export "$var_name=${rosPrefixes}:$existing_value"
-                else
-                    export "$var_name=${rosPrefixes}"
-                fi
-            }
-
-            prepend_prefixes CMAKE_PREFIX_PATH
-
-            setup_synthetic_ament_prefix() {
-                local base_dir
-                local synthetic_prefix
-                local source_prefixes
-                local old_ifs="$IFS"
-                local prefix
-                local category_dir
-                local resource
-                local existing_value
-                local filtered=""
-
-                if [ -n "''${XDG_CACHE_HOME:-}" ]; then
-                    base_dir="$XDG_CACHE_HOME"
-                elif [ -n "''${TMPDIR:-}" ]; then
-                    base_dir="$TMPDIR"
-                else
-                    base_dir="/tmp"
-                fi
-
-                synthetic_prefix="$base_dir/ros2-rust-nix-ament-prefix-${system}"
-                mkdir -p "$synthetic_prefix/share/ament_index/resource_index/packages"
-
-                printf '%s\n' '#!/usr/bin/env sh' > "$synthetic_prefix/local_setup.sh"
-                printf '%s\n' '#!/usr/bin/env bash' > "$synthetic_prefix/local_setup.bash"
-                printf '%s\n' '#!/usr/bin/env zsh' > "$synthetic_prefix/local_setup.zsh"
-                chmod +x \
-                    "$synthetic_prefix/local_setup.sh" \
-                    "$synthetic_prefix/local_setup.bash" \
-                    "$synthetic_prefix/local_setup.zsh"
-
-                find "$synthetic_prefix/share/ament_index/resource_index" -mindepth 1 -delete
-
-                source_prefixes="$(printenv CMAKE_PREFIX_PATH 2>/dev/null || true)"
-                IFS=:
-                for prefix in $source_prefixes; do
-                    if [ ! -d "$prefix/share/ament_index/resource_index" ]; then
-                        continue
-                    fi
-
-                    for category_dir in "$prefix"/share/ament_index/resource_index/*; do
-                        if [ ! -d "$category_dir" ]; then
-                            continue
-                        fi
-
-                        mkdir -p "$synthetic_prefix/share/ament_index/resource_index/$(basename "$category_dir")"
-                        for resource in "$category_dir"/*; do
-                            if [ ! -f "$resource" ]; then
-                                continue
-                            fi
-                            ln -sf "$resource" \
-                                "$synthetic_prefix/share/ament_index/resource_index/$(basename "$category_dir")/$(basename "$resource")"
-                        done
-                    done
-                done
-                IFS="$old_ifs"
-
-                existing_value="$(printenv AMENT_PREFIX_PATH 2>/dev/null || true)"
-                if [ -n "$existing_value" ]; then
-                    IFS=:
-                    for prefix in $existing_value; do
-                        if [ -f "$prefix/local_setup.sh" ] || [ -f "$prefix/local_setup.bash" ] || [ -f "$prefix/local_setup.zsh" ]; then
-                            if [ -n "$filtered" ]; then
-                                filtered="$filtered:$prefix"
-                            else
-                                filtered="$prefix"
-                            fi
-                        fi
-                    done
-                    IFS="$old_ifs"
-                fi
-
-                if [ -n "$filtered" ]; then
-                    export AMENT_PREFIX_PATH="$synthetic_prefix:$filtered"
-                else
-                    export AMENT_PREFIX_PATH="$synthetic_prefix"
-                fi
-            }
-
-            setup_synthetic_ament_prefix
-          '';
-        };
+        devShells = distroShells // { default = distroShells.${defaultDistro}; };
       }
     );
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,226 @@
+{
+  description = "ros flake";
+
+  inputs = {
+    nix-ros-overlay.url = "github:lopsided98/nix-ros-overlay/master";
+    nixpkgs.follows = "nix-ros-overlay/nixpkgs";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    { self, nixpkgs, rust-overlay, flake-utils, nix-ros-overlay, ... }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        overlays = [ (import rust-overlay) nix-ros-overlay.overlays.default ];
+
+        pkgs = import nixpkgs {
+          inherit system overlays;
+          config.allowUnfree = true;
+        };
+
+        rosDistro = pkgs.rosPackages.jazzy;
+
+        rosPrefixes = "${rosDistro.ament-cmake}:${rosDistro.ament-cmake-core}:${rosDistro.python-cmake-module}:${rosDistro.rmw}:${rosDistro.rosidl-default-generators}:${rosDistro.rosidl-runtime-c}:${rosDistro.rosidl-typesupport-c}:${rosDistro.rosidl-typesupport-interface}:${rosDistro.std-msgs}:${rosDistro.test-msgs}";
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages =
+            [
+              (pkgs.rust-bin.stable.latest.default.override {
+                extensions = [ "rust-src" ];
+              })
+              pkgs.gcc
+              pkgs.clang
+              pkgs.cmake
+              pkgs.mold
+              pkgs.pkg-config
+              pkgs.colcon
+              (with rosDistro; buildEnv {
+                paths = [
+                  ros-core
+                  desktop-full
+                  cyclonedds
+                  rmw-cyclonedds-cpp
+                  ackermann-msgs
+                  test-msgs
+                  moveit
+                ];
+              })
+            ];
+
+          RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
+
+          shellHook = ''
+            export LIBCLANG_PATH="${pkgs.llvmPackages.libclang.lib}/lib"
+            export LD_LIBRARY_PATH="${pkgs.stdenv.cc.cc.lib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+            export CC=clang
+            export CXX=clang++
+            export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=clang
+
+            dedup_flags() {
+                local var_name="$1"
+                local current_value
+                current_value="$(printenv "$var_name" 2>/dev/null || true)"
+
+                if [ -z "$current_value" ]; then
+                    return
+                fi
+
+                export "$var_name=$(
+                    printf '%s' "$current_value" \
+                        | tr ' ' '\n' \
+                        | awk '
+                            function flush_entry(entry_key, entry_value) {
+                                if (!(entry_key in seen)) {
+                                    seen[entry_key] = 1
+                                    print entry_value
+                                }
+                            }
+
+                            BEGIN {
+                                expects_value["-I"] = 1
+                                expects_value["-L"] = 1
+                                expects_value["-B"] = 1
+                                expects_value["-include"] = 1
+                                expects_value["-iquote"] = 1
+                                expects_value["-idirafter"] = 1
+                                expects_value["-isystem"] = 1
+                                expects_value["-isysroot"] = 1
+                                expects_value["-iframework"] = 1
+                            }
+
+                            NF == 0 {
+                                next
+                            }
+
+                            pending_option != "" {
+                                flush_entry(pending_option SUBSEP $0, pending_option " " $0)
+                                pending_option = ""
+                                next
+                            }
+
+                            {
+                                if ($0 in expects_value) {
+                                    pending_option = $0
+                                    next
+                                }
+
+                                flush_entry($0, $0)
+                            }
+
+                            END {
+                                if (pending_option != "") {
+                                    flush_entry(pending_option, pending_option)
+                                }
+                            }
+                        ' \
+                        | paste -sd ' ' -
+                )"
+            }
+
+            dedup_flags NIX_CFLAGS_COMPILE
+            dedup_flags NIX_CXXFLAGS_COMPILE
+            dedup_flags NIX_LDFLAGS
+
+            prepend_prefixes() {
+                local var_name="$1"
+                local existing_value
+
+                existing_value="$(printenv "$var_name" 2>/dev/null || true)"
+                if [ -n "$existing_value" ]; then
+                    export "$var_name=${rosPrefixes}:$existing_value"
+                else
+                    export "$var_name=${rosPrefixes}"
+                fi
+            }
+
+            prepend_prefixes CMAKE_PREFIX_PATH
+
+            setup_synthetic_ament_prefix() {
+                local synthetic_prefix
+                local source_prefixes
+                local old_ifs="$IFS"
+                local prefix
+                local category_dir
+                local resource
+                local existing_value
+                local filtered=""
+
+                synthetic_prefix="$PWD/.nix-ament-prefix"
+                mkdir -p "$synthetic_prefix/share/ament_index/resource_index/packages"
+
+                cat > "$synthetic_prefix/local_setup.sh" <<'SETUPEOF'
+            #!/usr/bin/env sh
+            SETUPEOF
+                cat > "$synthetic_prefix/local_setup.bash" <<'SETUPEOF'
+            #!/usr/bin/env bash
+            SETUPEOF
+                cat > "$synthetic_prefix/local_setup.zsh" <<'SETUPEOF'
+            #!/usr/bin/env zsh
+            SETUPEOF
+                chmod +x \
+                    "$synthetic_prefix/local_setup.sh" \
+                    "$synthetic_prefix/local_setup.bash" \
+                    "$synthetic_prefix/local_setup.zsh"
+
+                find "$synthetic_prefix/share/ament_index/resource_index" -mindepth 1 -delete
+
+                source_prefixes="$(printenv CMAKE_PREFIX_PATH 2>/dev/null || true)"
+                IFS=:
+                for prefix in $source_prefixes; do
+                    if [ ! -d "$prefix/share/ament_index/resource_index" ]; then
+                        continue
+                    fi
+
+                    for category_dir in "$prefix"/share/ament_index/resource_index/*; do
+                        if [ ! -d "$category_dir" ]; then
+                            continue
+                        fi
+
+                        mkdir -p "$synthetic_prefix/share/ament_index/resource_index/$(basename "$category_dir")"
+                        for resource in "$category_dir"/*; do
+                            if [ ! -f "$resource" ]; then
+                                continue
+                            fi
+                            ln -sf "$resource" \
+                                "$synthetic_prefix/share/ament_index/resource_index/$(basename "$category_dir")/$(basename "$resource")"
+                        done
+                    done
+                done
+                IFS="$old_ifs"
+
+                existing_value="$(printenv AMENT_PREFIX_PATH 2>/dev/null || true)"
+                if [ -n "$existing_value" ]; then
+                    IFS=:
+                    for prefix in $existing_value; do
+                        if [ -f "$prefix/local_setup.sh" ] || [ -f "$prefix/local_setup.bash" ] || [ -f "$prefix/local_setup.zsh" ]; then
+                            if [ -n "$filtered" ]; then
+                                filtered="$filtered:$prefix"
+                            else
+                                filtered="$prefix"
+                            fi
+                        fi
+                    done
+                    IFS="$old_ifs"
+                fi
+
+                if [ -n "$filtered" ]; then
+                    export AMENT_PREFIX_PATH="$synthetic_prefix:$filtered"
+                else
+                    export AMENT_PREFIX_PATH="$synthetic_prefix"
+                fi
+            }
+
+            setup_synthetic_ament_prefix
+          '';
+        };
+      }
+    );
+
+  nixConfig = {
+    extra-substituters = [ "https://ros.cachix.org" ];
+    extra-trusted-public-keys = [ "ros.cachix.org-1:dSyZxI8geDCJrwgvCOHDoAfOm5sV1wCPjBkKL+38Rvo=" ];
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "ros flake";
 
   inputs = {
-    nix-ros-overlay.url = "github:lopsided98/nix-ros-overlay/master";
+    nix-ros-overlay.url = "github:lopsided98/nix-ros-overlay";
     nixpkgs.follows = "nix-ros-overlay/nixpkgs";
     rust-overlay.url = "github:oxalica/rust-overlay";
     flake-utils.url = "github:numtide/flake-utils";
@@ -10,17 +10,19 @@
 
   outputs =
     { self, nixpkgs, rust-overlay, flake-utils, nix-ros-overlay, ... }:
-    flake-utils.lib.eachDefaultSystem (
+    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (
       system:
       let
         overlays = [ (import rust-overlay) nix-ros-overlay.overlays.default ];
 
         pkgs = import nixpkgs {
           inherit system overlays;
-          config.allowUnfree = true;
         };
 
         rosDistro = pkgs.rosPackages.jazzy;
+        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+          extensions = [ "rust-src" ];
+        };
 
         rosPrefixes = "${rosDistro.ament-cmake}:${rosDistro.ament-cmake-core}:${rosDistro.python-cmake-module}:${rosDistro.rmw}:${rosDistro.rosidl-default-generators}:${rosDistro.rosidl-runtime-c}:${rosDistro.rosidl-typesupport-c}:${rosDistro.rosidl-typesupport-interface}:${rosDistro.std-msgs}:${rosDistro.test-msgs}";
       in
@@ -28,9 +30,7 @@
         devShells.default = pkgs.mkShell {
           packages =
             [
-              (pkgs.rust-bin.stable.latest.default.override {
-                extensions = [ "rust-src" ];
-              })
+              rustToolchain
               pkgs.gcc
               pkgs.clang
               pkgs.cmake
@@ -40,24 +40,21 @@
               (with rosDistro; buildEnv {
                 paths = [
                   ros-core
-                  desktop-full
+                  ros-base
                   cyclonedds
                   rmw-cyclonedds-cpp
-                  ackermann-msgs
                   test-msgs
-                  moveit
                 ];
               })
             ];
 
-          RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
+          RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
 
           shellHook = ''
             export LIBCLANG_PATH="${pkgs.llvmPackages.libclang.lib}/lib"
             export LD_LIBRARY_PATH="${pkgs.stdenv.cc.cc.lib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
             export CC=clang
             export CXX=clang++
-            export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=clang
 
             dedup_flags() {
                 local var_name="$1"
@@ -139,6 +136,7 @@
             prepend_prefixes CMAKE_PREFIX_PATH
 
             setup_synthetic_ament_prefix() {
+                local base_dir
                 local synthetic_prefix
                 local source_prefixes
                 local old_ifs="$IFS"
@@ -148,18 +146,20 @@
                 local existing_value
                 local filtered=""
 
-                synthetic_prefix="$PWD/.nix-ament-prefix"
+                if [ -n "''${XDG_CACHE_HOME:-}" ]; then
+                    base_dir="$XDG_CACHE_HOME"
+                elif [ -n "''${TMPDIR:-}" ]; then
+                    base_dir="$TMPDIR"
+                else
+                    base_dir="/tmp"
+                fi
+
+                synthetic_prefix="$base_dir/ros2-rust-nix-ament-prefix-${system}"
                 mkdir -p "$synthetic_prefix/share/ament_index/resource_index/packages"
 
-                cat > "$synthetic_prefix/local_setup.sh" <<'SETUPEOF'
-            #!/usr/bin/env sh
-            SETUPEOF
-                cat > "$synthetic_prefix/local_setup.bash" <<'SETUPEOF'
-            #!/usr/bin/env bash
-            SETUPEOF
-                cat > "$synthetic_prefix/local_setup.zsh" <<'SETUPEOF'
-            #!/usr/bin/env zsh
-            SETUPEOF
+                printf '%s\n' '#!/usr/bin/env sh' > "$synthetic_prefix/local_setup.sh"
+                printf '%s\n' '#!/usr/bin/env bash' > "$synthetic_prefix/local_setup.bash"
+                printf '%s\n' '#!/usr/bin/env zsh' > "$synthetic_prefix/local_setup.zsh"
                 chmod +x \
                     "$synthetic_prefix/local_setup.sh" \
                     "$synthetic_prefix/local_setup.bash" \


### PR DESCRIPTION
## Summary
- add a Nix flake that provides a reproducible Rust + ROS 2 development shell for this workspace
- include the generated flake.lock so the flake inputs are pinned and repeatable
- configure the shell around ROS 2 Jazzy packages plus the Rust toolchain needed to build rclrs

## Notes
- the flake is currently set up for ROS 2 Jazzy
- adapting it to another ROS distro should mostly be a small change in the distro selection, for example swapping jazzy to humble and updating the corresponding package set as needed

## Verification
- nix develop --impure -c cargo build
