### PR TITLE
feat: add server_is_available to ActionClientState

### DIFF
--- a/rclrs/src/action.rs
+++ b/rclrs/src/action.rs
@@ -266,6 +266,50 @@ mod tests {
     use tokio::sync::mpsc::unbounded_channel;
 
     #[test]
+    fn test_action_server_availability() {
+        let mut executor = Context::default().create_basic_executor();
+
+        let node = executor
+            .create_node(&format!("test_action_discovery_{}", line!()))
+            .unwrap();
+        let action_name = format!("test_action_discovery_{}_action", line!());
+
+        let client = node
+            .create_action_client::<Fibonacci>(&action_name)
+            .unwrap();
+
+        assert!(!client.server_is_available().unwrap());
+
+        let _action_server = node
+            .create_action_server(&action_name, |handle| {
+                fibonacci_action(handle, TestActionSettings::default())
+            })
+            .unwrap();
+
+        let promise = executor.commands().run(async move {
+            let timeout = Duration::from_secs(1);
+            let start = std::time::Instant::now();
+            let mut is_available = false;
+
+            while start.elapsed() < timeout {
+                if client.server_is_available().unwrap() {
+                    is_available = true;
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+
+            assert!(
+                is_available,
+                "Server is not available after {} seconds",
+                timeout.as_secs()
+            );
+        });
+
+        executor.spin(SpinOptions::default().until_promise_resolved(promise));
+    }
+
+    #[test]
     fn test_action_success_streaming() {
         let mut executor = Context::default().create_basic_executor();
 

--- a/rclrs/src/action/action_client.rs
+++ b/rclrs/src/action/action_client.rs
@@ -169,6 +169,34 @@ pub struct ActionClientState<A: Action> {
 }
 
 impl<A: Action> ActionClientState<A> {
+    /// Checks if the action server is available and ready to receive requests.
+    ///
+    /// This method polls the underlying DDS network to determine if the action
+    /// server associated with this client is currently active. This is particularly
+    /// useful for implementing a `wait_for_server` timeout loop before dispatching goals.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`RclrsError`] if there is an issue communicating with the
+    /// underlying `rcl` C layer.
+    pub fn server_is_available(&self) -> Result<bool, RclrsError> {
+        let mut is_available = false;
+        
+        unsafe {
+            let handle = self.board.handle.lock();
+            let node_handle = self.board.handle.node_handle.rcl_node.lock().unwrap();
+            
+            rcl_action_server_is_available(
+                &*node_handle,
+                &*handle,
+                &mut is_available
+            )
+        }
+        .ok()?;
+
+        Ok(is_available)
+    }
+
     /// Request the action server to execute a goal. You will receive a
     /// [`RequestedGoalClient`] which you can use to wait for the reply from the
     /// action server that indicates whether the goal was accepted.

--- a/rclrs/src/action/action_client.rs
+++ b/rclrs/src/action/action_client.rs
@@ -181,16 +181,12 @@ impl<A: Action> ActionClientState<A> {
     /// underlying `rcl` C layer.
     pub fn server_is_available(&self) -> Result<bool, RclrsError> {
         let mut is_available = false;
-        
+
         unsafe {
             let handle = self.board.handle.lock();
             let node_handle = self.board.handle.node_handle.rcl_node.lock().unwrap();
-            
-            rcl_action_server_is_available(
-                &*node_handle,
-                &*handle,
-                &mut is_available
-            )
+
+            rcl_action_server_is_available(&*node_handle, &*handle, &mut is_available)
         }
         .ok()?;
 

--- a/ros2_rust_humble.repos
+++ b/ros2_rust_humble.repos
@@ -23,10 +23,6 @@ repositories:
     type: git
     url: https://github.com/ros2/unique_identifier_msgs.git
     version: humble
-  ros2/geometry2:
-    type: git
-    url: https://github.com/ros2/geometry2.git
-    version: humble
   ros2-rust/examples:
     type: git
     url: https://github.com/ros2-rust/examples.git

--- a/ros2_rust_humble.repos
+++ b/ros2_rust_humble.repos
@@ -23,6 +23,10 @@ repositories:
     type: git
     url: https://github.com/ros2/unique_identifier_msgs.git
     version: humble
+  ros2/geometry2:
+    type: git
+    url: https://github.com/ros2/geometry2.git
+    version: humble
   ros2-rust/examples:
     type: git
     url: https://github.com/ros2-rust/examples.git


### PR DESCRIPTION
## Description
This PR adds the `server_is_available` method to `ActionClientState`. 

Currently, `rclrs` action clients does not have a built-in mechanism to verify the availability of an action server on the network. This makes it difficult to safely send goals upon initialization without risking dropped requests.

By exposing the `rcl_action_server_is_available` binding, this PR enables developers to easily build reliable waiting logic. 

## Example Use Case
This enables the implementation of async timeout loops in user code, such as:

```rust
async fn wait_for_server(&self, timeout: std::time::Duration) -> Result<(), rclrs::RclrsError> {
    tokio::time::timeout(timeout, async {
        loop {
            if self.client.server_is_available()? {
                return Ok(());
            }
            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
        }
    }).await.unwrap_or(Err(rclrs::RclrsError::Custom("Timeout".into())))
}