### PR TITLE
fix: gate deprecated liveliness variant by distro (https://github.com/ros2/rmw/pull/414)

### DIFF
--- a/rclrs/src/qos.rs
+++ b/rclrs/src/qos.rs
@@ -511,6 +511,7 @@ impl From<&rmw_qos_liveliness_policy_t> for QoSLivelinessPolicy {
             rmw_qos_liveliness_policy_e::RMW_QOS_POLICY_LIVELINESS_BEST_AVAILABLE => {
                 QoSLivelinessPolicy::BestAvailable
             }
+            #[cfg(any(ros_distro = "humble", ros_distro = "jazzy", ros_distro = "kilted",))]
             rmw_qos_liveliness_policy_e::RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE => {
                 log_error!(
                     "QoSLivelinessPolicy.conversion",


### PR DESCRIPTION
This PR removes `RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE` from the list of available QoS options for any distro that's not Humble, Jazzy or Kilted (i.e. Lyrical, Rolling and newer).

See https://github.com/ros2/rmw/pull/414