### PR TITLE
fix: avoid panic when a parameter override is an empty YAML array

### DIFF
--- a/rclrs/src/parameter/override_map.rs
+++ b/rclrs/src/parameter/override_map.rs
@@ -125,8 +125,13 @@ pub(crate) unsafe fn resolve_parameter_overrides(
                 for (node_name, node_params) in RclParamsIter::new(rcl_params) {
                     if node_name == name_to_match {
                         for (param_name, variant) in RclNodeParamsIter::new(node_params) {
-                            let value = ParameterValue::from_rcl_variant(variant);
-                            map.insert(param_name, value);
+                            // Skip ambiguous variants (e.g. empty arrays whose element type the
+                            // rcl YAML parser could not infer). The user will get a clearer
+                            // error later if they actually require this parameter via
+                            // `declare_parameter`.
+                            if let Some(value) = ParameterValue::from_rcl_variant(variant) {
+                                map.insert(param_name, value);
+                            }
                         }
                     }
                 }
@@ -255,6 +260,52 @@ mod tests {
                 ("n", ParameterValue::Integer(3)),
                 ("o", ParameterValue::Integer(4)),
             ]
+        );
+        Ok(())
+    }
+
+    // Regression test for https://github.com/ros2-rust/ros2_rust/issues/636:
+    // a parameter declared as an empty YAML array (e.g. `my_param: []`) made the
+    // rcl YAML parser emit an `rcl_variant_t` with no type-specific pointer set,
+    // which used to trigger `assert_eq!(num_active, 1)` inside
+    // `ParameterValue::from_rcl_variant` and panic during `executor.create_node`.
+    // The expected behavior is now: the ambiguous override is silently dropped
+    // (so the node can still start) while well-formed overrides in the same file
+    // are loaded normally.
+    const EMPTY_ARRAY_PARAMS_FILE: &str = r#"
+/my_ns/my_node:
+    ros__parameters:
+        good_int: 7
+        empty_array: []
+"#;
+
+    // A minimal but well-formed YAML used wherever this test only cares about node-scoped
+    // overrides and just needs a valid `rcl_arguments_t` for the unused global slot.
+    const NOOP_GLOBAL_PARAMS_FILE: &str = r#"
+/**:
+    ros__parameters:
+        unused: 0
+"#;
+
+    #[test]
+    fn test_resolve_parameter_overrides_skips_empty_array() -> Result<(), Box<dyn Error>> {
+        let node_fqn = "/my_ns/my_node";
+        let mut rcl_node_arguments = convert_to_rcl_arguments(EMPTY_ARRAY_PARAMS_FILE)?;
+        let mut rcl_global_arguments = convert_to_rcl_arguments(NOOP_GLOBAL_PARAMS_FILE)?;
+        let overrides_map = unsafe {
+            resolve_parameter_overrides(node_fqn, &rcl_node_arguments, &rcl_global_arguments)?
+        };
+        unsafe {
+            rcl_arguments_fini(&mut rcl_node_arguments);
+            rcl_arguments_fini(&mut rcl_global_arguments);
+        }
+        assert_eq!(
+            overrides_map.get("good_int"),
+            Some(&ParameterValue::Integer(7))
+        );
+        assert!(
+            overrides_map.get("empty_array").is_none(),
+            "empty-array override should have been dropped instead of being kept or panicking"
         );
         Ok(())
     }

--- a/rclrs/src/parameter/value.rs
+++ b/rclrs/src/parameter/value.rs
@@ -436,11 +436,18 @@ impl TryFrom<RmwParameterValue> for ParameterValue {
 }
 
 impl ParameterValue {
-    // Panics if the rcl_variant_t does not have exactly one field set.
+    // Returns `None` if the `rcl_variant_t` does not have exactly one field set.
+    //
+    // This typically happens when the rcl YAML parser cannot infer the element type
+    // of an empty array parameter (e.g. `my_param: []`), in which case all 9 of the
+    // type-specific pointers in the variant are null. Returning `None` here lets the
+    // caller drop the ambiguous parameter override instead of panicking, allowing the
+    // node to continue startup and surface a more meaningful error (such as
+    // `DeclarationError::NoValueAvailable`) at the point of `declare_parameter`.
     //
     // This function is unsafe because it is possible to pass in an rcl_variant_t
     // containing dangling pointers, or incorrect array sizes.
-    pub(crate) unsafe fn from_rcl_variant(var: &rcl_variant_t) -> Self {
+    pub(crate) unsafe fn from_rcl_variant(var: &rcl_variant_t) -> Option<Self> {
         let num_active: u8 = [
             !var.bool_value.is_null(),
             !var.integer_value.is_null(),
@@ -455,7 +462,9 @@ impl ParameterValue {
         .into_iter()
         .map(u8::from)
         .sum();
-        assert_eq!(num_active, 1);
+        if num_active != 1 {
+            return None;
+        }
         // Note: Unsafe blocks below are necessary to dereference raw pointers
         // and call unsafe functions like CStr::from_ptr.
         // In general, the following operations are as safe as they can be, because
@@ -465,7 +474,7 @@ impl ParameterValue {
         // Of course, a pointer being not null is not a guarantee that it points to a valid value.
         // However, it cannot be checked that it points to a valid value. Similarly for array sizes.
         // This is why this function must be unsafe itself.
-        if !var.bool_value.is_null() {
+        Some(if !var.bool_value.is_null() {
             unsafe { ParameterValue::Bool(*var.bool_value) }
         } else if !var.integer_value.is_null() {
             unsafe { ParameterValue::Integer(*var.integer_value) }
@@ -518,7 +527,7 @@ impl ParameterValue {
             }
         } else {
             unreachable!()
-        }
+        })
     }
 
     pub(crate) fn rcl_parameter_type(&self) -> u8 {
@@ -603,7 +612,8 @@ mod tests {
             let rcl_node_params = unsafe { &(*(*rcl_params).params) };
             assert_eq!(rcl_node_params.num_params, 1);
             let rcl_variant = unsafe { &(*rcl_node_params.parameter_values) };
-            let param_value = unsafe { ParameterValue::from_rcl_variant(rcl_variant) };
+            let param_value = unsafe { ParameterValue::from_rcl_variant(rcl_variant) }
+                .expect("valid YAML parameter variant should be convertible to a ParameterValue");
             assert_eq!(param_value, pair.1);
             unsafe { rcl_yaml_node_struct_fini(rcl_params) };
         }


### PR DESCRIPTION
Fixes #636.

## Problem

A parameter override declared as an empty YAML array crashes the node at `executor.create_node` instead of returning a recoverable error.

`params.yaml`:

```yaml
minimal_publisher:
  ros__parameters:
    my_param: []
```

```
$ ros2 run examples_rclrs_minimal_pub_sub minimal_publisher \
    --ros-args --params-file params.yaml

thread 'main' panicked at rclrs/src/parameter/value.rs:458:9:
assertion `left == right` failed
  left: 0
 right: 1
stack backtrace:
   0: __rustc::rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::panicking::assert_failed_inner
   3: core::panicking::assert_failed
   4: rclrs::parameter::value::ParameterValue::from_rcl_variant
   5: rclrs::parameter::override_map::resolve_parameter_overrides
   6: rclrs::parameter::ParameterInterface::new
   7: rclrs::node::node_options::NodeOptions::build
   8: rclrs::executor::Executor::create_node
   9: minimal_publisher::main
```

## Root cause

`ParameterValue::from_rcl_variant` expects exactly one of the nine type-specific pointers on `rcl_variant_t` to be non-null. For an empty YAML array the rcl YAML parser cannot infer the element type, so it emits a variant with all nine of those pointers null. The function then hits `assert_eq!(num_active, 1)` and panics.

The same `from_rcl_variant` is reached for every parameter override that the node sees, so any node that is started with a parameters file containing a single `[]` entry will fail to start at all — including nodes that do not even declare that parameter.

## Fix

Change `from_rcl_variant` to return `Option<Self>` and return `None` when the variant has zero (or, hypothetically, more than one) active fields. The single in-tree caller — `resolve_parameter_overrides` in `override_map.rs` — now skips overrides whose type could not be determined:

```rust
if let Some(value) = ParameterValue::from_rcl_variant(variant) {
    map.insert(param_name, value);
}
```

Rationale for silently dropping rather than surfacing a brand new error variant:

- The node still starts, which matches the behavior users expect when most of their parameters file is well-formed.
- If a node actually requires the ambiguous parameter, the existing `DeclarationError::NoValueAvailable` will fire at `declare_parameter` time and point at the specific parameter, which is more actionable than a panic during construction.
- The change keeps `from_rcl_variant` `pub(crate)` and does not add a new variant to `RclrsError`, so the public API surface is unchanged.

The existing in-module test for `from_rcl_variant` is adjusted to `.expect(...)` since the variants it constructs are always well-formed.

## Verification

### Unit tests

Added a regression test `test_resolve_parameter_overrides_skips_empty_array` that loads:

```yaml
/my_ns/my_node:
    ros__parameters:
        good_int: 7
        empty_array: []
```

and asserts:

- `good_int` is present with value `Integer(7)`,
- `empty_array` is **not** in the override map,
- no panic occurs.

Full `rclrs` test suite locally:

```
test result: ok. 119 passed; 0 failed; 0 ignored; 0 measured
```

### End-to-end

With the same `params.yaml` from the bug report, after the fix:

```
$ ros2 run examples_rclrs_minimal_pub_sub minimal_publisher \
    --ros-args --params-file params.yaml
Publishing: [Hello, world! 1]
Publishing: [Hello, world! 2]
Publishing: [Hello, world! 3]
...
```

Tested on:

- Ubuntu 24.04 (Noble), ROS 2 Jazzy
- rustc 1.86 stable, `cargo-ament-build` 0.1
