### PR TITLE
add lyrical to CI jobs and rcl_bindings.rs

### DIFF
--- a/.github/workflows/generate-bindings.yml
+++ b/.github/workflows/generate-bindings.yml
@@ -19,6 +19,7 @@ jobs:
           - humble
           - jazzy
           - kilted
+          - lyrical
           - rolling
         include:
           # Humble Hawksbill (May 2022 - May 2027)
@@ -32,6 +33,10 @@ jobs:
           # Kilted Kaiju (May 2025 - Dec 2026)
           - docker_image: rostooling/setup-ros-docker:ubuntu-noble-ros-kilted-ros-base-latest
             ros_distribution: kilted
+            ros_version: 2
+          # Lyrical Luth (May 2026 - May 2031)
+          - docker_image: rostooling/setup-ros-docker:ubuntu-resolute-ros-lyrical-ros-base-latest
+            ros_distribution: lyrical
             ros_version: 2
           # Rolling Ridley  (June 2020 - Present)
           - docker_image: rostooling/setup-ros-docker:ubuntu-noble-ros-rolling-ros-base-latest

--- a/.github/workflows/rust-minimal.yml
+++ b/.github/workflows/rust-minimal.yml
@@ -36,6 +36,10 @@ jobs:
           - docker_image: rostooling/setup-ros-docker:ubuntu-noble-ros-kilted-ros-base-latest
             ros_distribution: kilted
             ros_version: 2
+          # Lyrical Luth (May 2026 - May 2031)
+          - docker_image: rostooling/setup-ros-docker:ubuntu-resolute-ros-lyrical-ros-base-latest
+            ros_distribution: lyrical
+            ros_version: 2
           # Rolling Ridley  (June 2020 - Present)
           - docker_image: rostooling/setup-ros-docker:ubuntu-noble-ros-rolling-ros-base-latest
             ros_distribution: rolling

--- a/.github/workflows/rust-minimal.yml
+++ b/.github/workflows/rust-minimal.yml
@@ -76,6 +76,7 @@ jobs:
     - name: Install colcon-cargo and colcon-ros-cargo
       run: |
         sudo rm -f /usr/lib/python3.12/EXTERNALLY-MANAGED
+        sudo rm -f /usr/lib/python3.14/EXTERNALLY-MANAGED
         sudo pip3 install git+https://github.com/colcon/colcon-cargo.git
         sudo pip3 install git+https://github.com/colcon/colcon-ros-cargo.git
 

--- a/.github/workflows/rust-stable.yml
+++ b/.github/workflows/rust-stable.yml
@@ -36,6 +36,10 @@ jobs:
           - docker_image: rostooling/setup-ros-docker:ubuntu-noble-ros-kilted-ros-base-latest
             ros_distribution: kilted
             ros_version: 2
+          # Lyrical Luth (May 2026 - May 2031)
+          - docker_image: rostooling/setup-ros-docker:ubuntu-resolute-ros-lyrical-ros-base-latest
+            ros_distribution: lyrical
+            ros_version: 2
           # Rolling Ridley  (June 2020 - Present)
           - docker_image: rostooling/setup-ros-docker:ubuntu-noble-ros-rolling-ros-base-latest
             ros_distribution: rolling

--- a/.github/workflows/rust-stable.yml
+++ b/.github/workflows/rust-stable.yml
@@ -76,6 +76,7 @@ jobs:
     - name: Install colcon-cargo and colcon-ros-cargo
       run: |
         sudo rm -f /usr/lib/python3.12/EXTERNALLY-MANAGED
+        sudo rm -f /usr/lib/python3.14/EXTERNALLY-MANAGED
         sudo pip3 install git+https://github.com/colcon/colcon-cargo.git
         sudo pip3 install git+https://github.com/colcon/colcon-ros-cargo.git
 

--- a/rclrs/build.rs
+++ b/rclrs/build.rs
@@ -2,7 +2,7 @@ use ament_rs::search_paths::get_search_paths;
 use std::{env, path::PathBuf};
 
 const ROS_DISTRO: &str = "ROS_DISTRO";
-const KNOWN_DISTROS: &[&str] = &["humble", "jazzy", "kilted", "rolling"];
+const KNOWN_DISTROS: &[&str] = &["humble", "jazzy", "kilted", "lyrical", "rolling"];
 
 fn get_ros_distro() -> String {
     env::var(ROS_DISTRO)

--- a/rclrs/src/rcl_bindings.rs
+++ b/rclrs/src/rcl_bindings.rs
@@ -33,6 +33,13 @@ cfg_if::cfg_if! {
                 "/src/rcl_bindings_generated_kilted.rs",
                 )
             );
+    } else if #[cfg(ros_distro="lyrical")] {
+        include!(
+            concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/src/rcl_bindings_generated_lyrical.rs",
+                )
+            );
     } else if #[cfg(ros_distro="rolling")] {
         include!(
             concat!(

--- a/ros2_rust_lyrical.repos
+++ b/ros2_rust_lyrical.repos
@@ -1,0 +1,37 @@
+repositories:
+  ros2/common_interfaces:
+    type: git
+    url: https://github.com/ros2/common_interfaces.git
+    version: lyrical
+  ros2/example_interfaces:
+    type: git
+    url: https://github.com/ros2/example_interfaces.git
+    version: lyrical
+  ros2/rcl_interfaces:
+    type: git
+    url: https://github.com/ros2/rcl_interfaces.git
+    version: lyrical
+  ros2/test_interface_files:
+    type: git
+    url: https://github.com/ros2/test_interface_files.git
+    version: lyrical
+  ros2/rosidl_core:
+    type: git
+    url: https://github.com/ros2/rosidl_core.git
+    version: lyrical
+  ros2/rosidl_defaults:
+    type: git
+    url: https://github.com/ros2/rosidl_defaults.git
+    version: lyrical
+  ros2/unique_identifier_msgs:
+    type: git
+    url: https://github.com/ros2/unique_identifier_msgs.git
+    version: lyrical
+  ros2-rust/rosidl_rust:
+    type: git
+    url: https://github.com/ros2-rust/rosidl_rust.git
+    version: main
+  ros2-rust/rosidl_runtime_rs:
+    type: git
+    url: https://github.com/ros2-rust/rosidl_runtime_rs.git
+    version: main


### PR DESCRIPTION
Lyrical is about to be released, the `rostooling/setup-ros-docker:ubuntu-resolute-ros-lyrical-ros-base-latest` docker image already exists. I successfully ran the `../generate_bindings.py rcl_wrapper.h lyrical .` command and ran the subscriber example on lyrical.