### PR TITLE
docs: add missing test_interface_files to manual README setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ mkdir -p workspace/src && cd workspace
 git clone -b kilted https://github.com/ros2/common_interfaces.git src/common_interfaces
 git clone -b kilted https://github.com/ros2/example_interfaces.git src/example_interfaces
 git clone -b kilted https://github.com/ros2/rcl_interfaces.git src/rcl_interfaces
+git clone -b kilted https://github.com/ros2/test_interface_files.git src/test_interface_files
 git clone -b kilted https://github.com/ros2/rosidl_core.git src/rosidl_core
 git clone -b kilted https://github.com/ros2/rosidl_defaults.git src/rosidl_defaults
 git clone -b kilted https://github.com/ros2/unique_identifier_msgs.git src/unique_identifier_msgs
@@ -135,6 +136,7 @@ mkdir -p workspace/src && cd workspace
 git clone -b jazzy https://github.com/ros2/common_interfaces.git src/common_interfaces
 git clone -b jazzy https://github.com/ros2/example_interfaces.git src/example_interfaces
 git clone -b jazzy https://github.com/ros2/rcl_interfaces.git src/rcl_interfaces
+git clone -b jazzy https://github.com/ros2/test_interface_files.git src/test_interface_files
 git clone -b jazzy https://github.com/ros2/rosidl_core.git src/rosidl_core
 git clone -b jazzy https://github.com/ros2/rosidl_defaults.git src/rosidl_defaults
 git clone -b jazzy https://github.com/ros2/unique_identifier_msgs.git src/unique_identifier_msgs
@@ -159,6 +161,7 @@ mkdir -p workspace/src && cd workspace
 git clone -b humble https://github.com/ros2/common_interfaces.git src/common_interfaces
 git clone -b humble https://github.com/ros2/example_interfaces.git src/example_interfaces
 git clone -b humble https://github.com/ros2/rcl_interfaces.git src/rcl_interfaces
+git clone -b humble https://github.com/ros2/test_interface_files.git src/test_interface_files
 git clone -b humble https://github.com/ros2/rosidl_core.git src/rosidl_core
 git clone -b humble https://github.com/ros2/rosidl_defaults.git src/rosidl_defaults
 git clone -b humble https://github.com/ros2/unique_identifier_msgs.git src/unique_identifier_msgs


### PR DESCRIPTION
## Summary

- Adds the missing `test_interface_files` clone step to the manual workspace setup instructions for Humble, Jazzy, and Kilted
- Fixes the test_interface_files build failure reported in #616. Does not address other known gaps in the manual README setup (e.g. invalid rosidl_core branch on Humble, missing rosidl_runtime_rs).
- Aligns the README manual clone workflow with what `ros2_rust_*.repos` already imports via `vcs`
- Fixes #616

## Problem

Following the per-distro manual `git clone` blocks in the README causes `colcon build` to fail when building `test_msgs` from `common_interfaces`:
