### PR TITLE
ci: pin Windows runner to VS 2022

### DIFF
--- a/.github/workflows/rust-win.yml
+++ b/.github/workflows/rust-win.yml
@@ -16,7 +16,8 @@ env:
 
 jobs:
   build:
-    runs-on: windows-latest
+    # NOTE(esteve): Pin to the VS 2022 image until the Windows ROS build tooling supports VS 18.
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
See https://github.com/colcon/colcon-cmake/pull/161 and https://github.blog/changelog/2026-02-05-github-actions-early-february-2026-updates/#windows-server-2025-with-visual-studio-2026-image-now-available-for-github-hosted-runners
