### PR TITLE
perf: add synchronous callback path for Node-scoped subscriptions

### DIFF
--- a/rclrs/src/subscription/into_async_subscription_callback.rs
+++ b/rclrs/src/subscription/into_async_subscription_callback.rs
@@ -31,7 +31,7 @@ where
     Out: Future<Output = ()> + Send + 'static,
 {
     fn into_async_subscription_callback(mut self) -> AnySubscriptionCallback<T, ()> {
-        NodeSubscriptionCallback::Regular(Box::new(move |message| Box::pin(self(message)))).into()
+        NodeSubscriptionCallback::AsyncRegular(Box::new(move |message| Box::pin(self(message)))).into()
     }
 }
 
@@ -42,7 +42,7 @@ where
     Out: Future<Output = ()> + Send + 'static,
 {
     fn into_async_subscription_callback(mut self) -> AnySubscriptionCallback<T, ()> {
-        NodeSubscriptionCallback::RegularWithMessageInfo(Box::new(move |message, info| {
+        NodeSubscriptionCallback::AsyncRegularWithMessageInfo(Box::new(move |message, info| {
             Box::pin(self(message, info))
         }))
         .into()
@@ -56,7 +56,7 @@ where
     Out: Future<Output = ()> + Send + 'static,
 {
     fn into_async_subscription_callback(mut self) -> AnySubscriptionCallback<T, ()> {
-        NodeSubscriptionCallback::Boxed(Box::new(move |message| Box::pin(self(message)))).into()
+        NodeSubscriptionCallback::AsyncBoxed(Box::new(move |message| Box::pin(self(message)))).into()
     }
 }
 
@@ -67,7 +67,7 @@ where
     F: Future<Output = ()> + Send + 'static,
 {
     fn into_async_subscription_callback(mut self) -> AnySubscriptionCallback<T, ()> {
-        NodeSubscriptionCallback::BoxedWithMessageInfo(Box::new(move |message, info| {
+        NodeSubscriptionCallback::AsyncBoxedWithMessageInfo(Box::new(move |message, info| {
             Box::pin(self(message, info))
         }))
         .into()
@@ -81,7 +81,7 @@ where
     F: Future<Output = ()> + Send + 'static,
 {
     fn into_async_subscription_callback(mut self) -> AnySubscriptionCallback<T, ()> {
-        NodeSubscriptionCallback::Loaned(Box::new(move |message| Box::pin(self(message)))).into()
+        NodeSubscriptionCallback::AsyncLoaned(Box::new(move |message| Box::pin(self(message)))).into()
     }
 }
 
@@ -92,7 +92,7 @@ where
     F: Future<Output = ()> + Send + 'static,
 {
     fn into_async_subscription_callback(mut self) -> AnySubscriptionCallback<T, ()> {
-        NodeSubscriptionCallback::LoanedWithMessageInfo(Box::new(move |message, info| {
+        NodeSubscriptionCallback::AsyncLoanedWithMessageInfo(Box::new(move |message, info| {
             Box::pin(self(message, info))
         }))
         .into()
@@ -110,68 +110,68 @@ mod tests {
         let cb = |_msg: TestMessage| async {};
         assert!(matches!(
             cb.into_async_subscription_callback(),
-            AnySubscriptionCallback::Node(NodeSubscriptionCallback::<TestMessage>::Regular(_)),
+            AnySubscriptionCallback::Node(NodeSubscriptionCallback::<TestMessage>::AsyncRegular(_)),
         ));
         let cb = |_msg: TestMessage, _info: MessageInfo| async {};
         assert!(matches!(
             cb.into_async_subscription_callback(),
             AnySubscriptionCallback::Node(
-                NodeSubscriptionCallback::<TestMessage>::RegularWithMessageInfo(_)
+                NodeSubscriptionCallback::<TestMessage>::AsyncRegularWithMessageInfo(_)
             ),
         ));
         let cb = |_msg: Box<TestMessage>| async {};
         assert!(matches!(
             cb.into_async_subscription_callback(),
-            AnySubscriptionCallback::Node(NodeSubscriptionCallback::<TestMessage>::Boxed(_)),
+            AnySubscriptionCallback::Node(NodeSubscriptionCallback::<TestMessage>::AsyncBoxed(_)),
         ));
         let cb = |_msg: Box<TestMessage>, _info: MessageInfo| async {};
         assert!(matches!(
             cb.into_async_subscription_callback(),
             AnySubscriptionCallback::Node(
-                NodeSubscriptionCallback::<TestMessage>::BoxedWithMessageInfo(_)
+                NodeSubscriptionCallback::<TestMessage>::AsyncBoxedWithMessageInfo(_)
             ),
         ));
         let cb = |_msg: ReadOnlyLoanedMessage<TestMessage>| async {};
         assert!(matches!(
             cb.into_async_subscription_callback(),
-            AnySubscriptionCallback::Node(NodeSubscriptionCallback::<TestMessage>::Loaned(_)),
+            AnySubscriptionCallback::Node(NodeSubscriptionCallback::<TestMessage>::AsyncLoaned(_)),
         ));
         let cb = |_msg: ReadOnlyLoanedMessage<TestMessage>, _info: MessageInfo| async {};
         assert!(matches!(
             cb.into_async_subscription_callback(),
             AnySubscriptionCallback::Node(
-                NodeSubscriptionCallback::<TestMessage>::LoanedWithMessageInfo(_)
+                NodeSubscriptionCallback::<TestMessage>::AsyncLoanedWithMessageInfo(_)
             ),
         ));
 
         assert!(matches!(
             test_regular.into_async_subscription_callback(),
-            AnySubscriptionCallback::Node(NodeSubscriptionCallback::<TestMessage>::Regular(_)),
+            AnySubscriptionCallback::Node(NodeSubscriptionCallback::<TestMessage>::AsyncRegular(_)),
         ));
         assert!(matches!(
             test_regular_with_info.into_async_subscription_callback(),
             AnySubscriptionCallback::Node(
-                NodeSubscriptionCallback::<TestMessage>::RegularWithMessageInfo(_)
+                NodeSubscriptionCallback::<TestMessage>::AsyncRegularWithMessageInfo(_)
             ),
         ));
         assert!(matches!(
             test_boxed.into_async_subscription_callback(),
-            AnySubscriptionCallback::Node(NodeSubscriptionCallback::<TestMessage>::Boxed(_)),
+            AnySubscriptionCallback::Node(NodeSubscriptionCallback::<TestMessage>::AsyncBoxed(_)),
         ));
         assert!(matches!(
             test_boxed_with_info.into_async_subscription_callback(),
             AnySubscriptionCallback::Node(
-                NodeSubscriptionCallback::<TestMessage>::BoxedWithMessageInfo(_)
+                NodeSubscriptionCallback::<TestMessage>::AsyncBoxedWithMessageInfo(_)
             ),
         ));
         assert!(matches!(
             test_loaned.into_async_subscription_callback(),
-            AnySubscriptionCallback::Node(NodeSubscriptionCallback::<TestMessage>::Loaned(_)),
+            AnySubscriptionCallback::Node(NodeSubscriptionCallback::<TestMessage>::AsyncLoaned(_)),
         ));
         assert!(matches!(
             test_loaned_with_info.into_async_subscription_callback(),
             AnySubscriptionCallback::Node(
-                NodeSubscriptionCallback::<TestMessage>::LoanedWithMessageInfo(_)
+                NodeSubscriptionCallback::<TestMessage>::AsyncLoanedWithMessageInfo(_)
             ),
         ));
     }

--- a/rclrs/src/subscription/into_async_subscription_callback.rs
+++ b/rclrs/src/subscription/into_async_subscription_callback.rs
@@ -31,7 +31,8 @@ where
     Out: Future<Output = ()> + Send + 'static,
 {
     fn into_async_subscription_callback(mut self) -> AnySubscriptionCallback<T, ()> {
-        NodeSubscriptionCallback::AsyncRegular(Box::new(move |message| Box::pin(self(message)))).into()
+        NodeSubscriptionCallback::AsyncRegular(Box::new(move |message| Box::pin(self(message))))
+            .into()
     }
 }
 
@@ -56,7 +57,8 @@ where
     Out: Future<Output = ()> + Send + 'static,
 {
     fn into_async_subscription_callback(mut self) -> AnySubscriptionCallback<T, ()> {
-        NodeSubscriptionCallback::AsyncBoxed(Box::new(move |message| Box::pin(self(message)))).into()
+        NodeSubscriptionCallback::AsyncBoxed(Box::new(move |message| Box::pin(self(message))))
+            .into()
     }
 }
 
@@ -81,7 +83,8 @@ where
     F: Future<Output = ()> + Send + 'static,
 {
     fn into_async_subscription_callback(mut self) -> AnySubscriptionCallback<T, ()> {
-        NodeSubscriptionCallback::AsyncLoaned(Box::new(move |message| Box::pin(self(message)))).into()
+        NodeSubscriptionCallback::AsyncLoaned(Box::new(move |message| Box::pin(self(message))))
+            .into()
     }
 }
 

--- a/rclrs/src/subscription/into_node_subscription_callback.rs
+++ b/rclrs/src/subscription/into_node_subscription_callback.rs
@@ -4,17 +4,15 @@ use crate::{
     AnySubscriptionCallback, MessageInfo, NodeSubscriptionCallback, ReadOnlyLoanedMessage,
 };
 
-use std::sync::Arc;
-
 /// A trait for regular callbacks of subscriptions.
 ///
 /// Subscription callbacks support six signatures:
-/// - [`Fn`] ( `Message` )
-/// - [`Fn`] ( `Message`, [`MessageInfo`] )
-/// - [`Fn`] ( [`Box`]<`Message`> )
-/// - [`Fn`] ( [`Box`]<`Message`>, [`MessageInfo`] )
-/// - [`Fn`] ( [`ReadOnlyLoanedMessage`]<`Message`> )
-/// - [`Fn`] ( [`ReadOnlyLoanedMessage`]<`Message`>, [`MessageInfo`] )
+/// - [`FnMut`] ( `Message` )
+/// - [`FnMut`] ( `Message`, [`MessageInfo`] )
+/// - [`FnMut`] ( [`Box`]<`Message`> )
+/// - [`FnMut`] ( [`Box`]<`Message`>, [`MessageInfo`] )
+/// - [`FnMut`] ( [`ReadOnlyLoanedMessage`]<`Message`> )
+/// - [`FnMut`] ( [`ReadOnlyLoanedMessage`]<`Message`>, [`MessageInfo`] )
 pub trait IntoNodeSubscriptionCallback<T, Args>: Send + 'static
 where
     T: Message,
@@ -28,102 +26,60 @@ where
 impl<T, Func> IntoNodeSubscriptionCallback<T, (T,)> for Func
 where
     T: Message,
-    Func: Fn(T) + Send + Sync + 'static,
+    Func: FnMut(T) + Send + 'static,
 {
     fn into_node_subscription_callback(self) -> AnySubscriptionCallback<T, ()> {
-        let func = Arc::new(self);
-        NodeSubscriptionCallback::Regular(Box::new(move |message| {
-            let f = Arc::clone(&func);
-            Box::pin(async move {
-                f(message);
-            })
-        }))
-        .into()
+        NodeSubscriptionCallback::SyncRegular(Box::new(self)).into()
     }
 }
 
 impl<T, Func> IntoNodeSubscriptionCallback<T, (T, MessageInfo)> for Func
 where
     T: Message,
-    Func: Fn(T, MessageInfo) + Send + Sync + 'static,
+    Func: FnMut(T, MessageInfo) + Send + 'static,
 {
     fn into_node_subscription_callback(self) -> AnySubscriptionCallback<T, ()> {
-        let func = Arc::new(self);
-        NodeSubscriptionCallback::RegularWithMessageInfo(Box::new(move |message, info| {
-            let f = Arc::clone(&func);
-            Box::pin(async move {
-                f(message, info);
-            })
-        }))
-        .into()
+        NodeSubscriptionCallback::SyncRegularWithMessageInfo(Box::new(self)).into()
     }
 }
 
 impl<T, Func> IntoNodeSubscriptionCallback<T, (Box<T>,)> for Func
 where
     T: Message,
-    Func: Fn(Box<T>) + Send + Sync + 'static,
+    Func: FnMut(Box<T>) + Send + 'static,
 {
     fn into_node_subscription_callback(self) -> AnySubscriptionCallback<T, ()> {
-        let func = Arc::new(self);
-        NodeSubscriptionCallback::Boxed(Box::new(move |message| {
-            let f = Arc::clone(&func);
-            Box::pin(async move {
-                f(message);
-            })
-        }))
-        .into()
+        NodeSubscriptionCallback::SyncBoxed(Box::new(self)).into()
     }
 }
 
 impl<T, Func> IntoNodeSubscriptionCallback<T, (Box<T>, MessageInfo)> for Func
 where
     T: Message,
-    Func: Fn(Box<T>, MessageInfo) + Send + Sync + 'static,
+    Func: FnMut(Box<T>, MessageInfo) + Send + 'static,
 {
     fn into_node_subscription_callback(self) -> AnySubscriptionCallback<T, ()> {
-        let func = Arc::new(self);
-        NodeSubscriptionCallback::BoxedWithMessageInfo(Box::new(move |message, info| {
-            let f = Arc::clone(&func);
-            Box::pin(async move {
-                f(message, info);
-            })
-        }))
-        .into()
+        NodeSubscriptionCallback::SyncBoxedWithMessageInfo(Box::new(self)).into()
     }
 }
 
 impl<T, Func> IntoNodeSubscriptionCallback<T, (ReadOnlyLoanedMessage<T>,)> for Func
 where
     T: Message,
-    Func: Fn(ReadOnlyLoanedMessage<T>) + Send + Sync + 'static,
+    Func: FnMut(ReadOnlyLoanedMessage<T>) + Send + 'static,
 {
     fn into_node_subscription_callback(self) -> AnySubscriptionCallback<T, ()> {
-        let func = Arc::new(self);
-        NodeSubscriptionCallback::Loaned(Box::new(move |message| {
-            let f = Arc::clone(&func);
-            Box::pin(async move {
-                f(message);
-            })
-        }))
-        .into()
+        NodeSubscriptionCallback::SyncLoaned(Box::new(self)).into()
     }
 }
 
 impl<T, Func> IntoNodeSubscriptionCallback<T, (ReadOnlyLoanedMessage<T>, MessageInfo)> for Func
 where
     T: Message,
-    Func: Fn(ReadOnlyLoanedMessage<T>, MessageInfo) + Send + Sync + 'static,
+    Func: FnMut(ReadOnlyLoanedMessage<T>, MessageInfo) + Send + 'static,
 {
     fn into_node_subscription_callback(self) -> AnySubscriptionCallback<T, ()> {
-        let func = Arc::new(self);
-        NodeSubscriptionCallback::LoanedWithMessageInfo(Box::new(move |message, info| {
-            let f = Arc::clone(&func);
-            Box::pin(async move {
-                f(message, info);
-            })
-        }))
-        .into()
+        NodeSubscriptionCallback::SyncLoanedWithMessageInfo(Box::new(self)).into()
     }
 }
 
@@ -138,68 +94,68 @@ mod tests {
         let cb = |_msg: TestMessage| {};
         assert!(matches!(
             cb.into_node_subscription_callback(),
-            AnySubscriptionCallback::Node(NodeSubscriptionCallback::<TestMessage>::Regular(_)),
+            AnySubscriptionCallback::Node(NodeSubscriptionCallback::<TestMessage>::SyncRegular(_)),
         ));
         let cb = |_msg: TestMessage, _info: MessageInfo| {};
         assert!(matches!(
             cb.into_node_subscription_callback(),
             AnySubscriptionCallback::Node(
-                NodeSubscriptionCallback::<TestMessage>::RegularWithMessageInfo(_)
+                NodeSubscriptionCallback::<TestMessage>::SyncRegularWithMessageInfo(_)
             )
         ));
         let cb = |_msg: Box<TestMessage>| {};
         assert!(matches!(
             cb.into_node_subscription_callback(),
-            AnySubscriptionCallback::Node(NodeSubscriptionCallback::<TestMessage>::Boxed(_)),
+            AnySubscriptionCallback::Node(NodeSubscriptionCallback::<TestMessage>::SyncBoxed(_)),
         ));
         let cb = |_msg: Box<TestMessage>, _info: MessageInfo| {};
         assert!(matches!(
             cb.into_node_subscription_callback(),
             AnySubscriptionCallback::Node(
-                NodeSubscriptionCallback::<TestMessage>::BoxedWithMessageInfo(_)
+                NodeSubscriptionCallback::<TestMessage>::SyncBoxedWithMessageInfo(_)
             ),
         ));
         let cb = |_msg: ReadOnlyLoanedMessage<TestMessage>| {};
         assert!(matches!(
             cb.into_node_subscription_callback(),
-            AnySubscriptionCallback::Node(NodeSubscriptionCallback::<TestMessage>::Loaned(_)),
+            AnySubscriptionCallback::Node(NodeSubscriptionCallback::<TestMessage>::SyncLoaned(_)),
         ));
         let cb = |_msg: ReadOnlyLoanedMessage<TestMessage>, _info: MessageInfo| {};
         assert!(matches!(
             cb.into_node_subscription_callback(),
             AnySubscriptionCallback::Node(
-                NodeSubscriptionCallback::<TestMessage>::LoanedWithMessageInfo(_)
+                NodeSubscriptionCallback::<TestMessage>::SyncLoanedWithMessageInfo(_)
             ),
         ));
 
         assert!(matches!(
             test_regular.into_node_subscription_callback(),
-            AnySubscriptionCallback::Node(NodeSubscriptionCallback::<TestMessage>::Regular(_)),
+            AnySubscriptionCallback::Node(NodeSubscriptionCallback::<TestMessage>::SyncRegular(_)),
         ));
         assert!(matches!(
             test_regular_with_info.into_node_subscription_callback(),
             AnySubscriptionCallback::Node(
-                NodeSubscriptionCallback::<TestMessage>::RegularWithMessageInfo(_)
+                NodeSubscriptionCallback::<TestMessage>::SyncRegularWithMessageInfo(_)
             ),
         ));
         assert!(matches!(
             test_boxed.into_node_subscription_callback(),
-            AnySubscriptionCallback::Node(NodeSubscriptionCallback::<TestMessage>::Boxed(_)),
+            AnySubscriptionCallback::Node(NodeSubscriptionCallback::<TestMessage>::SyncBoxed(_)),
         ));
         assert!(matches!(
             test_boxed_with_info.into_node_subscription_callback(),
             AnySubscriptionCallback::Node(
-                NodeSubscriptionCallback::<TestMessage>::BoxedWithMessageInfo(_)
+                NodeSubscriptionCallback::<TestMessage>::SyncBoxedWithMessageInfo(_)
             ),
         ));
         assert!(matches!(
             test_loaned.into_node_subscription_callback(),
-            AnySubscriptionCallback::Node(NodeSubscriptionCallback::<TestMessage>::Loaned(_)),
+            AnySubscriptionCallback::Node(NodeSubscriptionCallback::<TestMessage>::SyncLoaned(_)),
         ));
         assert!(matches!(
             test_loaned_with_info.into_node_subscription_callback(),
             AnySubscriptionCallback::Node(
-                NodeSubscriptionCallback::<TestMessage>::LoanedWithMessageInfo(_)
+                NodeSubscriptionCallback::<TestMessage>::SyncLoanedWithMessageInfo(_)
             ),
         ));
     }

--- a/rclrs/src/subscription/node_subscription_callback.rs
+++ b/rclrs/src/subscription/node_subscription_callback.rs
@@ -16,20 +16,36 @@ use std::sync::Arc;
 /// [1]: crate::IntoNodeSubscriptionCallback
 /// [2]: crate::IntoAsyncSubscriptionCallback
 pub enum NodeSubscriptionCallback<T: Message> {
-    /// A callback with only the message as an argument.
-    Regular(Box<dyn FnMut(T) -> BoxFuture<'static, ()> + Send>),
-    /// A callback with the message and the message info as arguments.
-    RegularWithMessageInfo(Box<dyn FnMut(T, MessageInfo) -> BoxFuture<'static, ()> + Send>),
-    /// A callback with only the boxed message as an argument.
-    Boxed(Box<dyn FnMut(Box<T>) -> BoxFuture<'static, ()> + Send>),
-    /// A callback with the boxed message and the message info as arguments.
-    BoxedWithMessageInfo(Box<dyn FnMut(Box<T>, MessageInfo) -> BoxFuture<'static, ()> + Send>),
-    /// A callback with only the loaned message as an argument.
+    // Sync variants — callback is called directly, no async wrapping.
+    /// A synchronous callback with only the message as an argument.
+    SyncRegular(Box<dyn FnMut(T) + Send>),
+    /// A synchronous callback with the message and the message info as arguments.
+    SyncRegularWithMessageInfo(Box<dyn FnMut(T, MessageInfo) + Send>),
+    /// A synchronous callback with only the boxed message as an argument.
+    SyncBoxed(Box<dyn FnMut(Box<T>) + Send>),
+    /// A synchronous callback with the boxed message and the message info as arguments.
+    SyncBoxedWithMessageInfo(Box<dyn FnMut(Box<T>, MessageInfo) + Send>),
+    /// A synchronous callback with only the loaned message as an argument.
+    SyncLoaned(Box<dyn FnMut(ReadOnlyLoanedMessage<T>) + Send>),
+    /// A synchronous callback with the loaned message and the message info as arguments.
+    SyncLoanedWithMessageInfo(Box<dyn FnMut(ReadOnlyLoanedMessage<T>, MessageInfo) + Send>),
+    // Async variants — callback returns a future, dispatched via the executor task queue.
+    /// An async callback with only the message as an argument.
+    AsyncRegular(Box<dyn FnMut(T) -> BoxFuture<'static, ()> + Send>),
+    /// An async callback with the message and the message info as arguments.
+    AsyncRegularWithMessageInfo(Box<dyn FnMut(T, MessageInfo) -> BoxFuture<'static, ()> + Send>),
+    /// An async callback with only the boxed message as an argument.
+    AsyncBoxed(Box<dyn FnMut(Box<T>) -> BoxFuture<'static, ()> + Send>),
+    /// An async callback with the boxed message and the message info as arguments.
+    AsyncBoxedWithMessageInfo(
+        Box<dyn FnMut(Box<T>, MessageInfo) -> BoxFuture<'static, ()> + Send>,
+    ),
+    /// An async callback with only the loaned message as an argument.
     #[allow(clippy::type_complexity)]
-    Loaned(Box<dyn FnMut(ReadOnlyLoanedMessage<T>) -> BoxFuture<'static, ()> + Send>),
-    /// A callback with the loaned message and the message info as arguments.
+    AsyncLoaned(Box<dyn FnMut(ReadOnlyLoanedMessage<T>) -> BoxFuture<'static, ()> + Send>),
+    /// An async callback with the loaned message and the message info as arguments.
     #[allow(clippy::type_complexity)]
-    LoanedWithMessageInfo(
+    AsyncLoanedWithMessageInfo(
         Box<dyn FnMut(ReadOnlyLoanedMessage<T>, MessageInfo) -> BoxFuture<'static, ()> + Send>,
     ),
 }
@@ -42,27 +58,53 @@ impl<T: Message> NodeSubscriptionCallback<T> {
     ) -> Result<(), RclrsError> {
         let mut evaluate = || {
             match self {
-                NodeSubscriptionCallback::Regular(cb) => {
+                // Sync variants — call directly, no async overhead
+                NodeSubscriptionCallback::SyncRegular(cb) => {
+                    let (msg, _) = handle.take::<T>()?;
+                    cb(msg);
+                }
+                NodeSubscriptionCallback::SyncRegularWithMessageInfo(cb) => {
+                    let (msg, msg_info) = handle.take::<T>()?;
+                    cb(msg, msg_info);
+                }
+                NodeSubscriptionCallback::SyncBoxed(cb) => {
+                    let (msg, _) = handle.take_boxed::<T>()?;
+                    cb(msg);
+                }
+                NodeSubscriptionCallback::SyncBoxedWithMessageInfo(cb) => {
+                    let (msg, msg_info) = handle.take_boxed::<T>()?;
+                    cb(msg, msg_info);
+                }
+                NodeSubscriptionCallback::SyncLoaned(cb) => {
+                    let (msg, _) = handle.take_loaned::<T>()?;
+                    cb(msg);
+                }
+                NodeSubscriptionCallback::SyncLoanedWithMessageInfo(cb) => {
+                    let (msg, msg_info) = handle.take_loaned::<T>()?;
+                    cb(msg, msg_info);
+                }
+                // Async variants — dispatch through executor task queue
+                NodeSubscriptionCallback::AsyncRegular(cb) => {
                     let (msg, _) = handle.take::<T>()?;
                     commands.run_async(cb(msg));
                 }
-                NodeSubscriptionCallback::RegularWithMessageInfo(cb) => {
+                NodeSubscriptionCallback::AsyncRegularWithMessageInfo(cb) => {
                     let (msg, msg_info) = handle.take::<T>()?;
                     commands.run_async(cb(msg, msg_info));
                 }
-                NodeSubscriptionCallback::Boxed(cb) => {
+                NodeSubscriptionCallback::AsyncBoxed(cb) => {
                     let (msg, _) = handle.take_boxed::<T>()?;
                     commands.run_async(cb(msg));
                 }
-                NodeSubscriptionCallback::BoxedWithMessageInfo(cb) => {
+                NodeSubscriptionCallback::AsyncBoxedWithMessageInfo(cb) => {
                     let (msg, msg_info) = handle.take_boxed::<T>()?;
                     commands.run_async(cb(msg, msg_info));
                 }
-                NodeSubscriptionCallback::Loaned(cb) => {
+                NodeSubscriptionCallback::AsyncLoaned(cb) => {
                     let (msg, _) = handle.take_loaned::<T>()?;
                     commands.run_async(cb(msg));
                 }
-                NodeSubscriptionCallback::LoanedWithMessageInfo(cb) => {
+                NodeSubscriptionCallback::AsyncLoanedWithMessageInfo(cb) => {
                     let (msg, msg_info) = handle.take_loaned::<T>()?;
                     commands.run_async(cb(msg, msg_info));
                 }

--- a/rclrs/src/subscription/node_subscription_callback.rs
+++ b/rclrs/src/subscription/node_subscription_callback.rs
@@ -37,9 +37,7 @@ pub enum NodeSubscriptionCallback<T: Message> {
     /// An async callback with only the boxed message as an argument.
     AsyncBoxed(Box<dyn FnMut(Box<T>) -> BoxFuture<'static, ()> + Send>),
     /// An async callback with the boxed message and the message info as arguments.
-    AsyncBoxedWithMessageInfo(
-        Box<dyn FnMut(Box<T>, MessageInfo) -> BoxFuture<'static, ()> + Send>,
-    ),
+    AsyncBoxedWithMessageInfo(Box<dyn FnMut(Box<T>, MessageInfo) -> BoxFuture<'static, ()> + Send>),
     /// An async callback with only the loaned message as an argument.
     #[allow(clippy::type_complexity)]
     AsyncLoaned(Box<dyn FnMut(ReadOnlyLoanedMessage<T>) -> BoxFuture<'static, ()> + Send>),


### PR DESCRIPTION
## perf: add a synchronous callback path for node-scoped subscriptions

This is a fix for part of the performance issue reported in #627.

### Subscriptions were paying an async tax they never used

Receiving a message with a plain synchronous callback is the single most common thing you do in ROS 2:

```rust
node.create_subscription::<StringMsg, _>("topic", |msg| {
    println!("{}", msg.data);
})?;
```

Yet under the hood, **every** node-scoped subscription callback was wrapped as if it were `async`, even a one-line synchronous closure. For each message received, that meant:

- `Box::pin(async { … })` to turn the callback into a future,
- `Arc::new(Task { … })` to enqueue it, and
- an `Arc::clone` for the dispatch

Three heap allocations per message, plus a hop through the executor's task queue so the callback runs on a later turn instead of inline. That's pure overhead on the hottest path in the system, paid by the ~95% of subscriptions whose callbacks are perfectly synchronous and have no reason to touch a future at all.

### The fix: call synchronous callbacks synchronously

This splits `NodeSubscriptionCallback` into **`Sync*` and `Async*` variants**:

- **Sync callbacks** (`FnMut(T) + Send`) are now invoked **directly** in the wait-set processing, no `Future`, no `Arc`, no task-queue dispatch. The message is taken and the callback runs inline, immediately and in order.
- **Async callbacks** keep the existing behavior (return a future, dispatched through the executor task queue) and are opted into explicitly via `create_async_subscription` / `IntoAsyncSubscriptionCallback`.

`IntoNodeSubscriptionCallback` now produces the `Sync` variants, so the default `create_subscription` path gets the fast path automatically, no API change at the call site.

### A nice side effect: friendlier bounds

The synchronous path only needs **`FnMut + Send`** instead of the old `Fn + Send + Sync`. In practice that means your subscription closure can now capture and mutate state directly and doesn't have to be `Sync`.

### Behavioral note

Synchronous callbacks now run inline during spin, in receipt order, rather than being deferred onto the task queue. This matches the intuition (and rclcpp's default) that a sync subscription callback runs while you're spinning. Genuinely asynchronous work should use `create_async_subscription`, which is unchanged.

### Breaking change

The public `NodeSubscriptionCallback` enum variants are renamed (`Regular` → `AsyncRegular`, `Boxed` → `AsyncBoxed`, `Loaned` → `AsyncLoaned`, and the `…WithMessageInfo` counterparts), with the new `Sync*` variants added alongside. Code that matches on these variants directly needs updating; code that creates subscriptions through the normal closure API does not.