### PR TITLE
Fix WaitSetRunner cleanup before propagating callback panics

### DIFF
--- a/rclrs/src/action/action_goal_receiver.rs
+++ b/rclrs/src/action/action_goal_receiver.rs
@@ -6,6 +6,7 @@ use rosidl_runtime_rs::Action;
 use std::{
     future::Future,
     ops::{Deref, DerefMut},
+    panic::UnwindSafe,
     sync::Arc,
 };
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
@@ -47,7 +48,7 @@ impl<A: Action> ActionGoalReceiver<A> {
     #[must_use]
     pub fn into_action_server<Task>(
         self,
-        callback: impl FnMut(RequestedGoal<A>) -> Task + Send + Sync + 'static,
+        callback: impl FnMut(RequestedGoal<A>) -> Task + Send + Sync + UnwindSafe + 'static,
     ) -> ActionServer<A>
     where
         Task: Future<Output = TerminatedGoal> + Send + Sync + 'static,

--- a/rclrs/src/action/action_server.rs
+++ b/rclrs/src/action/action_server.rs
@@ -14,6 +14,7 @@ use std::{
     collections::HashMap,
     ffi::CString,
     future::Future,
+    panic::UnwindSafe,
     sync::{Arc, Mutex, MutexGuard, Weak},
     time::Duration,
 };
@@ -204,7 +205,7 @@ impl<A: Action> ActionServerState<A> {
     /// Change the callback for this action server.
     pub fn set_callback<Task>(
         &self,
-        mut callback: impl FnMut(RequestedGoal<A>) -> Task + Send + Sync + 'static,
+        mut callback: impl FnMut(RequestedGoal<A>) -> Task + Send + Sync + UnwindSafe + 'static,
     ) where
         Task: Future<Output = TerminatedGoal> + Send + Sync + 'static,
     {
@@ -242,7 +243,7 @@ impl<A: Action> ActionServerState<A> {
     pub(crate) fn create<'a, Task>(
         node: &Node,
         options: impl IntoActionServerOptions<'a>,
-        mut callback: impl FnMut(RequestedGoal<A>) -> Task + Send + Sync + 'static,
+        mut callback: impl FnMut(RequestedGoal<A>) -> Task + Send + Sync + UnwindSafe + 'static,
     ) -> Result<ActionServer<A>, RclrsError>
     where
         Task: Future<Output = TerminatedGoal> + Send + Sync + 'static,
@@ -348,7 +349,7 @@ impl<A: Action> ActionServerState<A> {
     pub(super) fn drain_receiver_into_callback<Task>(
         &self,
         mut receiver: UnboundedReceiver<RequestedGoal<A>>,
-        mut callback: impl FnMut(RequestedGoal<A>) -> Task + Send + Sync + 'static,
+        mut callback: impl FnMut(RequestedGoal<A>) -> Task + Send + Sync + UnwindSafe + 'static,
     ) where
         Task: Future<Output = TerminatedGoal> + Send + Sync + 'static,
     {
@@ -784,7 +785,14 @@ impl<A: Action> ActionServerHandle<A> {
 }
 
 enum GoalDispatch<A: Action> {
-    Callback(Box<dyn FnMut(RequestedGoal<A>) -> BoxFuture<'static, TerminatedGoal> + Send + Sync>),
+    Callback(
+        Box<
+            dyn FnMut(RequestedGoal<A>) -> BoxFuture<'static, TerminatedGoal>
+                + Send
+                + Sync
+                + UnwindSafe,
+        >,
+    ),
     Sender(UnboundedSender<RequestedGoal<A>>),
 }
 

--- a/rclrs/src/dynamic_message/dynamic_subscription.rs
+++ b/rclrs/src/dynamic_message/dynamic_subscription.rs
@@ -3,6 +3,7 @@ use std::{
     boxed::Box,
     ffi::CString,
     ops::{Deref, DerefMut},
+    panic::{RefUnwindSafe, UnwindSafe},
     sync::{Arc, Mutex},
 };
 
@@ -53,49 +54,60 @@ struct DynamicSubscriptionExecutable<Payload> {
 }
 
 pub(crate) struct NodeDynamicSubscriptionCallback(
-    Box<dyn Fn(DynamicMessage, MessageInfo) + Send + Sync>,
+    Box<dyn Fn(DynamicMessage, MessageInfo) + Send + Sync + UnwindSafe + RefUnwindSafe>,
 );
 
 impl NodeDynamicSubscriptionCallback {
-    pub(crate) fn new(f: impl Fn(DynamicMessage, MessageInfo) + Send + Sync + 'static) -> Self {
+    pub(crate) fn new(
+        f: impl Fn(DynamicMessage, MessageInfo) + Send + Sync + UnwindSafe + RefUnwindSafe + 'static,
+    ) -> Self {
         NodeDynamicSubscriptionCallback(Box::new(f))
     }
 }
 
 pub(crate) struct NodeAsyncDynamicSubscriptionCallback(
-    Box<dyn FnMut(DynamicMessage, MessageInfo) -> BoxFuture<'static, ()> + Send + Sync>,
+    Box<
+        dyn FnMut(DynamicMessage, MessageInfo) -> BoxFuture<'static, ()> + Send + Sync + UnwindSafe,
+    >,
 );
 
 impl NodeAsyncDynamicSubscriptionCallback {
     pub(crate) fn new(
-        f: impl FnMut(DynamicMessage, MessageInfo) -> BoxFuture<'static, ()> + Send + Sync + 'static,
+        f: impl FnMut(DynamicMessage, MessageInfo) -> BoxFuture<'static, ()>
+            + Send
+            + Sync
+            + UnwindSafe
+            + 'static,
     ) -> Self {
         NodeAsyncDynamicSubscriptionCallback(Box::new(f))
     }
 }
 
 pub(crate) struct WorkerDynamicSubscriptionCallback<Payload>(
-    Box<dyn FnMut(&mut Payload, DynamicMessage, MessageInfo) + Send + Sync>,
+    Box<dyn FnMut(&mut Payload, DynamicMessage, MessageInfo) + Send + Sync + UnwindSafe>,
 );
 
 impl<Payload> WorkerDynamicSubscriptionCallback<Payload> {
     pub(crate) fn new(
-        f: impl FnMut(&mut Payload, DynamicMessage, MessageInfo) + Send + Sync + 'static,
+        f: impl FnMut(&mut Payload, DynamicMessage, MessageInfo) + Send + Sync + UnwindSafe + 'static,
     ) -> Self {
         WorkerDynamicSubscriptionCallback(Box::new(f))
     }
 }
 
 impl Deref for NodeDynamicSubscriptionCallback {
-    type Target = Box<dyn Fn(DynamicMessage, MessageInfo) + 'static + Send + Sync>;
+    type Target = Box<
+        dyn Fn(DynamicMessage, MessageInfo) + 'static + Send + Sync + UnwindSafe + RefUnwindSafe,
+    >;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
 impl Deref for NodeAsyncDynamicSubscriptionCallback {
-    type Target =
-        Box<dyn FnMut(DynamicMessage, MessageInfo) -> BoxFuture<'static, ()> + Send + Sync>;
+    type Target = Box<
+        dyn FnMut(DynamicMessage, MessageInfo) -> BoxFuture<'static, ()> + Send + Sync + UnwindSafe,
+    >;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
@@ -114,7 +126,8 @@ impl DerefMut for NodeAsyncDynamicSubscriptionCallback {
 }
 
 impl<Payload> Deref for WorkerDynamicSubscriptionCallback<Payload> {
-    type Target = Box<dyn FnMut(&mut Payload, DynamicMessage, MessageInfo) + Send + Sync>;
+    type Target =
+        Box<dyn FnMut(&mut Payload, DynamicMessage, MessageInfo) + Send + Sync + UnwindSafe>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }

--- a/rclrs/src/executor.rs
+++ b/rclrs/src/executor.rs
@@ -13,6 +13,7 @@ use futures::{
 use std::{
     any::Any,
     future::Future,
+    panic::UnwindSafe,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -338,7 +339,7 @@ pub trait WorkerChannel: Send + Sync {
 }
 
 /// Encapsulates a task that can operate on the payload of a worker
-pub type PayloadTask = Box<dyn FnOnce(&mut dyn Any) + Send>;
+pub type PayloadTask = Box<dyn FnOnce(&mut dyn Any) + Send + UnwindSafe>;
 
 /// This is constructed by [`ExecutorCommands`] and passed to the [`ExecutorRuntime`]
 /// to create a new worker. Downstream users of rclrs should not be using this class

--- a/rclrs/src/executor/basic_executor.rs
+++ b/rclrs/src/executor/basic_executor.rs
@@ -24,6 +24,8 @@ use crate::{
     WaitSetRunnerOutcome, Waitable, WeakActivityListener, WorkerChannel,
 };
 
+use std::any::Any;
+
 static FAILED_TO_SEND_WORKER: &'static str =
     "Failed to send the new runner. This should never happen. \
     Please report this to the rclrs maintainers with a minimal reproducible example.";
@@ -152,7 +154,7 @@ impl ExecutorRuntime for BasicExecutorRuntime {
             }
         }
 
-        let (runners, new_worker_receiver, errors) = worker_result_receiver.recv().expect(
+        let (runners, new_worker_receiver, errors, pending_panic) = worker_result_receiver.recv().expect(
             "Basic executor failed to receive the WaitSetRunner at the end of its spinning. \
             This is a critical bug in rclrs. \
             Please report this bug to the maintainers of rclrs by providing a minimum reproduction of the problem."
@@ -160,6 +162,10 @@ impl ExecutorRuntime for BasicExecutorRuntime {
 
         self.wait_set_runners = runners;
         self.new_worker_receiver = Some(new_worker_receiver);
+
+        if let Some(panic_payload) = pending_panic {
+            std::panic::resume_unwind(panic_payload);
+        }
 
         errors
     }
@@ -391,11 +397,13 @@ async fn manage_workers(
     Vec<WaitSetRunner>,
     StreamFuture<UnboundedReceiver<WaitSetRunner>>,
     Vec<RclrsError>,
+    Option<Box<dyn Any + Send + 'static>>,
 ) {
     let mut active_runners: Vec<oneshot::Receiver<(WaitSetRunner, WaitSetRunnerOutcome)>> =
         Vec::new();
     let mut finished_runners: Vec<WaitSetRunner> = Vec::new();
     let mut errors: Vec<RclrsError> = Vec::new();
+    let mut pending_panic: Option<Box<dyn Any + Send + 'static>> = None;
 
     let add_runner = |new_runner: Option<WaitSetRunner>,
                       active_runners: &mut Vec<_>,
@@ -429,7 +437,12 @@ async fn manage_workers(
                             }
                         }
                         WaitSetRunnerOutcome::Panicked(panic_payload) => {
-                            std::panic::resume_unwind(panic_payload);
+                            finished_runners.push(runner);
+                            if pending_panic.is_none() {
+                                pending_panic = Some(panic_payload);
+                                conditions.halt_spinning.store(true, Ordering::Release);
+                                all_guard_conditions.trigger();
+                            }
                         }
                     },
                     Err(_) => {
@@ -453,5 +466,5 @@ async fn manage_workers(
         }
     }
 
-    (finished_runners, new_workers, errors)
+    (finished_runners, new_workers, errors, pending_panic)
 }

--- a/rclrs/src/executor/basic_executor.rs
+++ b/rclrs/src/executor/basic_executor.rs
@@ -21,7 +21,7 @@ use std::{
 use crate::{
     log_debug, log_fatal, log_warn, ExecutorChannel, ExecutorRuntime, ExecutorWorkerOptions,
     GuardCondition, PayloadTask, RclrsError, SpinConditions, WaitSetRunConditions, WaitSetRunner,
-    Waitable, WeakActivityListener, WorkerChannel,
+    WaitSetRunnerOutcome, Waitable, WeakActivityListener, WorkerChannel,
 };
 
 static FAILED_TO_SEND_WORKER: &'static str =
@@ -392,7 +392,7 @@ async fn manage_workers(
     StreamFuture<UnboundedReceiver<WaitSetRunner>>,
     Vec<RclrsError>,
 ) {
-    let mut active_runners: Vec<oneshot::Receiver<(WaitSetRunner, Result<(), RclrsError>)>> =
+    let mut active_runners: Vec<oneshot::Receiver<(WaitSetRunner, WaitSetRunnerOutcome)>> =
         Vec::new();
     let mut finished_runners: Vec<WaitSetRunner> = Vec::new();
     let mut errors: Vec<RclrsError> = Vec::new();
@@ -421,12 +421,17 @@ async fn manage_workers(
         match next_event.await {
             Either::Left(((finished_worker, _, remaining_workers), new_worker_stream)) => {
                 match finished_worker {
-                    Ok((runner, result)) => {
-                        finished_runners.push(runner);
-                        if let Err(err) = result {
-                            errors.push(err);
+                    Ok((runner, outcome)) => match outcome {
+                        WaitSetRunnerOutcome::Completed(result) => {
+                            finished_runners.push(runner);
+                            if let Err(err) = result {
+                                errors.push(err);
+                            }
                         }
-                    }
+                        WaitSetRunnerOutcome::Panicked(panic_payload) => {
+                            std::panic::resume_unwind(panic_payload);
+                        }
+                    },
                     Err(_) => {
                         log_fatal!(
                             "rclrs.basic_executor",

--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -16,6 +16,7 @@ use std::{
     fmt,
     future::Future,
     os::raw::c_char,
+    panic::{RefUnwindSafe, UnwindSafe},
     sync::{atomic::AtomicBool, Arc, Mutex},
     time::Duration,
 };
@@ -401,7 +402,7 @@ impl NodeState {
     pub fn create_action_server<'a, A: Action, Task>(
         self: &Arc<Self>,
         options: impl IntoActionServerOptions<'a>,
-        callback: impl FnMut(RequestedGoal<A>) -> Task + Send + Sync + 'static,
+        callback: impl FnMut(RequestedGoal<A>) -> Task + Send + Sync + UnwindSafe + 'static,
     ) -> Result<ActionServer<A>, RclrsError>
     where
         Task: Future<Output = TerminatedGoal> + Send + Sync + 'static,
@@ -933,7 +934,7 @@ impl NodeState {
         callback: F,
     ) -> Result<DynamicSubscription, RclrsError>
     where
-        F: Fn(DynamicMessage, MessageInfo) + Send + Sync + 'static,
+        F: Fn(DynamicMessage, MessageInfo) + Send + Sync + UnwindSafe + RefUnwindSafe + 'static,
     {
         DynamicSubscriptionState::<Node>::create(
             topic_type,
@@ -1007,7 +1008,11 @@ impl NodeState {
         callback: F,
     ) -> Result<DynamicSubscription, RclrsError>
     where
-        F: FnMut(DynamicMessage, MessageInfo) -> BoxFuture<'static, ()> + Send + Sync + 'static,
+        F: FnMut(DynamicMessage, MessageInfo) -> BoxFuture<'static, ()>
+            + Send
+            + Sync
+            + UnwindSafe
+            + 'static,
     {
         DynamicSubscriptionState::<Node>::create(
             topic_type,

--- a/rclrs/src/node/node_options.rs
+++ b/rclrs/src/node/node_options.rs
@@ -1,6 +1,7 @@
 use std::{
     borrow::Borrow,
     ffi::{CStr, CString},
+    panic::AssertUnwindSafe,
     sync::{atomic::AtomicBool, Arc, Mutex},
 };
 
@@ -385,7 +386,7 @@ impl<'a> NodeOptions<'a> {
 
         // --- Set up guard condition for graph change events ---
         let (graph_change_action, graph_change_receiver) = unbounded();
-        let graph_change_execute_sender = graph_change_action.clone();
+        let graph_change_execute_sender = AssertUnwindSafe(graph_change_action.clone());
 
         let rcl_graph_change_guard_condition = unsafe {
             // SAFETY: The node is valid because we just instantiated it.

--- a/rclrs/src/service/into_async_service_callback.rs
+++ b/rclrs/src/service/into_async_service_callback.rs
@@ -2,7 +2,7 @@ use rosidl_runtime_rs::Service;
 
 use super::{AnyServiceCallback, NodeServiceCallback, RequestId, ServiceInfo};
 
-use std::future::Future;
+use std::{future::Future, panic::UnwindSafe};
 
 /// A trait for async callbacks of services.
 ///
@@ -10,7 +10,7 @@ use std::future::Future;
 /// - [`FnMut`] ( `Request` ) -> impl [`Future`]<Output=`Response`>
 /// - [`FnMut`] ( `Request`, [`RequestId`] ) -> impl [`Future`]<Output=`Response`>
 /// - [`FnMut`] ( `Request`, [`ServiceInfo`] ) -> impl [`Future`]<Output=`Response`>
-pub trait IntoAsyncServiceCallback<T, Args>: Send + 'static
+pub trait IntoAsyncServiceCallback<T, Args>: Send + UnwindSafe + 'static
 where
     T: Service,
 {
@@ -23,7 +23,7 @@ where
 impl<T, F, Func> IntoAsyncServiceCallback<T, ()> for Func
 where
     T: Service,
-    Func: FnMut(T::Request) -> F + Send + 'static,
+    Func: FnMut(T::Request) -> F + Send + UnwindSafe + 'static,
     F: Future<Output = T::Response> + Send + 'static,
 {
     fn into_async_service_callback(mut self) -> AnyServiceCallback<T, ()> {
@@ -34,7 +34,7 @@ where
 impl<T, F, Func> IntoAsyncServiceCallback<T, RequestId> for Func
 where
     T: Service,
-    Func: FnMut(T::Request, RequestId) -> F + Send + 'static,
+    Func: FnMut(T::Request, RequestId) -> F + Send + UnwindSafe + 'static,
     F: Future<Output = T::Response> + Send + 'static,
 {
     fn into_async_service_callback(mut self) -> AnyServiceCallback<T, ()> {
@@ -48,7 +48,7 @@ where
 impl<T, F, Func> IntoAsyncServiceCallback<T, ServiceInfo> for Func
 where
     T: Service,
-    Func: FnMut(T::Request, ServiceInfo) -> F + Send + 'static,
+    Func: FnMut(T::Request, ServiceInfo) -> F + Send + UnwindSafe + 'static,
     F: Future<Output = T::Response> + Send + 'static,
 {
     fn into_async_service_callback(mut self) -> AnyServiceCallback<T, ()> {

--- a/rclrs/src/service/into_node_service_callback.rs
+++ b/rclrs/src/service/into_node_service_callback.rs
@@ -2,7 +2,10 @@ use rosidl_runtime_rs::Service;
 
 use crate::{AnyServiceCallback, NodeServiceCallback, RequestId, ServiceInfo};
 
-use std::sync::Arc;
+use std::{
+    panic::{RefUnwindSafe, UnwindSafe},
+    sync::Arc,
+};
 
 /// A trait to deduce regular callbacks of services.
 ///
@@ -12,7 +15,7 @@ use std::sync::Arc;
 /// - [`Fn`] ( `Request` ) -> `Response`
 /// - [`Fn`] ( `Request`, [`RequestId`] ) -> `Response`
 /// - [`Fn`] ( `Request`, [`ServiceInfo`] ) -> `Response`
-pub trait IntoNodeServiceCallback<T, Args>: Send + 'static
+pub trait IntoNodeServiceCallback<T, Args>: Send + UnwindSafe + 'static
 where
     T: Service,
 {
@@ -25,7 +28,7 @@ where
 impl<T, Func> IntoNodeServiceCallback<T, ()> for Func
 where
     T: Service,
-    Func: Fn(T::Request) -> T::Response + Send + Sync + 'static,
+    Func: Fn(T::Request) -> T::Response + Send + Sync + UnwindSafe + RefUnwindSafe + 'static,
 {
     fn into_node_service_callback(self) -> AnyServiceCallback<T, ()> {
         let func = Arc::new(self);
@@ -40,7 +43,12 @@ where
 impl<T, Func> IntoNodeServiceCallback<T, RequestId> for Func
 where
     T: Service,
-    Func: Fn(T::Request, RequestId) -> T::Response + Send + Sync + 'static,
+    Func: Fn(T::Request, RequestId) -> T::Response
+        + Send
+        + Sync
+        + UnwindSafe
+        + RefUnwindSafe
+        + 'static,
 {
     fn into_node_service_callback(self) -> AnyServiceCallback<T, ()> {
         let func = Arc::new(self);
@@ -55,7 +63,12 @@ where
 impl<T, Func> IntoNodeServiceCallback<T, ServiceInfo> for Func
 where
     T: Service,
-    Func: Fn(T::Request, ServiceInfo) -> T::Response + Send + Sync + 'static,
+    Func: Fn(T::Request, ServiceInfo) -> T::Response
+        + Send
+        + Sync
+        + UnwindSafe
+        + RefUnwindSafe
+        + 'static,
 {
     fn into_node_service_callback(self) -> AnyServiceCallback<T, ()> {
         let func = Arc::new(self);

--- a/rclrs/src/service/into_worker_service_callback.rs
+++ b/rclrs/src/service/into_worker_service_callback.rs
@@ -1,4 +1,5 @@
 use rosidl_runtime_rs::Service;
+use std::panic::UnwindSafe;
 
 use crate::{AnyServiceCallback, RequestId, ServiceInfo, Worker, WorkerServiceCallback};
 
@@ -13,7 +14,7 @@ use crate::{AnyServiceCallback, RequestId, ServiceInfo, Worker, WorkerServiceCal
 /// - [`FnMut`] ( `&mut Payload`, `Request` ) -> `Response`
 /// - [`FnMut`] ( `&mut Payload`, `Request`,  [`RequestId`] ) -> `Response`
 /// - [`FnMut`] ( `&mut Payload`, `Request`, [`ServiceInfo`] ) -> `Response`
-pub trait IntoWorkerServiceCallback<T, Payload, Args>: Send + 'static
+pub trait IntoWorkerServiceCallback<T, Payload, Args>: Send + UnwindSafe + 'static
 where
     T: Service,
     Payload: 'static + Send,
@@ -28,7 +29,7 @@ impl<T, Payload, Func> IntoWorkerServiceCallback<T, Payload, ()> for Func
 where
     T: Service,
     Payload: 'static + Send,
-    Func: FnMut(T::Request) -> T::Response + Send + 'static,
+    Func: FnMut(T::Request) -> T::Response + Send + UnwindSafe + 'static,
 {
     fn into_worker_service_callback(mut self) -> AnyServiceCallback<T, Payload> {
         let f = Box::new(move |_: &mut Payload, request| self(request));
@@ -40,7 +41,7 @@ impl<T, Payload, Func> IntoWorkerServiceCallback<T, Payload, Worker<Payload>> fo
 where
     T: Service,
     Payload: 'static + Send,
-    Func: FnMut(&mut Payload, T::Request) -> T::Response + Send + 'static,
+    Func: FnMut(&mut Payload, T::Request) -> T::Response + Send + UnwindSafe + 'static,
 {
     fn into_worker_service_callback(self) -> AnyServiceCallback<T, Payload> {
         WorkerServiceCallback::OnlyRequest(Box::new(self)).into()
@@ -51,7 +52,7 @@ impl<T, Payload, Func> IntoWorkerServiceCallback<T, Payload, RequestId> for Func
 where
     T: Service,
     Payload: 'static + Send,
-    Func: FnMut(T::Request, RequestId) -> T::Response + Send + 'static,
+    Func: FnMut(T::Request, RequestId) -> T::Response + Send + UnwindSafe + 'static,
 {
     fn into_worker_service_callback(mut self) -> AnyServiceCallback<T, Payload> {
         let f = Box::new(move |_: &mut Payload, request, request_id| self(request, request_id));
@@ -63,7 +64,7 @@ impl<T, Payload, Func> IntoWorkerServiceCallback<T, Payload, (Worker<Payload>, R
 where
     T: Service,
     Payload: 'static + Send,
-    Func: FnMut(&mut Payload, T::Request, RequestId) -> T::Response + Send + 'static,
+    Func: FnMut(&mut Payload, T::Request, RequestId) -> T::Response + Send + UnwindSafe + 'static,
 {
     fn into_worker_service_callback(self) -> AnyServiceCallback<T, Payload> {
         WorkerServiceCallback::WithId(Box::new(self)).into()
@@ -74,7 +75,7 @@ impl<T, Payload, Func> IntoWorkerServiceCallback<T, Payload, ServiceInfo> for Fu
 where
     T: Service,
     Payload: 'static + Send,
-    Func: FnMut(T::Request, ServiceInfo) -> T::Response + Send + 'static,
+    Func: FnMut(T::Request, ServiceInfo) -> T::Response + Send + UnwindSafe + 'static,
 {
     fn into_worker_service_callback(mut self) -> AnyServiceCallback<T, Payload> {
         let f = Box::new(move |_: &mut Payload, request, info| self(request, info));
@@ -86,7 +87,7 @@ impl<T, Payload, Func> IntoWorkerServiceCallback<T, Payload, (Worker<T>, Service
 where
     T: Service,
     Payload: 'static + Send,
-    Func: FnMut(&mut Payload, T::Request, ServiceInfo) -> T::Response + Send + 'static,
+    Func: FnMut(&mut Payload, T::Request, ServiceInfo) -> T::Response + Send + UnwindSafe + 'static,
 {
     fn into_worker_service_callback(self) -> AnyServiceCallback<T, Payload> {
         WorkerServiceCallback::WithInfo(Box::new(self)).into()

--- a/rclrs/src/service/node_service_callback.rs
+++ b/rclrs/src/service/node_service_callback.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use futures::future::BoxFuture;
 
-use std::sync::Arc;
+use std::{panic::UnwindSafe, sync::Arc};
 
 /// An enum capturing the various possible function signatures for service callbacks.
 pub enum NodeServiceCallback<T>
@@ -15,11 +15,21 @@ where
     T: Service,
 {
     /// A callback that only takes in the request value
-    OnlyRequest(Box<dyn FnMut(T::Request) -> BoxFuture<'static, T::Response> + Send>),
+    OnlyRequest(Box<dyn FnMut(T::Request) -> BoxFuture<'static, T::Response> + Send + UnwindSafe>),
     /// A callback that takes in the request value and the ID of the request
-    WithId(Box<dyn FnMut(T::Request, RequestId) -> BoxFuture<'static, T::Response> + Send>),
+    WithId(
+        Box<
+            dyn FnMut(T::Request, RequestId) -> BoxFuture<'static, T::Response> + Send + UnwindSafe,
+        >,
+    ),
     /// A callback that takes in the request value and all available
-    WithInfo(Box<dyn FnMut(T::Request, ServiceInfo) -> BoxFuture<'static, T::Response> + Send>),
+    WithInfo(
+        Box<
+            dyn FnMut(T::Request, ServiceInfo) -> BoxFuture<'static, T::Response>
+                + Send
+                + UnwindSafe,
+        >,
+    ),
 }
 
 impl<T: Service> NodeServiceCallback<T> {

--- a/rclrs/src/service/worker_service_callback.rs
+++ b/rclrs/src/service/worker_service_callback.rs
@@ -2,7 +2,7 @@ use rosidl_runtime_rs::Service;
 
 use crate::{RclrsError, RclrsErrorFilter, RequestId, ServiceHandle, ServiceInfo};
 
-use std::{any::Any, sync::Arc};
+use std::{any::Any, panic::UnwindSafe, sync::Arc};
 
 /// An enum capturing the various possible function signatures for service
 /// callbacks that can be used by a [`Worker`][crate::Worker].
@@ -16,11 +16,13 @@ where
     Payload: 'static + Send,
 {
     /// A callback that only takes in the request value
-    OnlyRequest(Box<dyn FnMut(&mut Payload, T::Request) -> T::Response + Send>),
+    OnlyRequest(Box<dyn FnMut(&mut Payload, T::Request) -> T::Response + Send + UnwindSafe>),
     /// A callback that takes in the request value and the ID of the request
-    WithId(Box<dyn FnMut(&mut Payload, T::Request, RequestId) -> T::Response + Send>),
+    WithId(Box<dyn FnMut(&mut Payload, T::Request, RequestId) -> T::Response + Send + UnwindSafe>),
     /// A callback that takes in the request value and all available
-    WithInfo(Box<dyn FnMut(&mut Payload, T::Request, ServiceInfo) -> T::Response + Send>),
+    WithInfo(
+        Box<dyn FnMut(&mut Payload, T::Request, ServiceInfo) -> T::Response + Send + UnwindSafe>,
+    ),
 }
 
 impl<T, Payload> WorkerServiceCallback<T, Payload>

--- a/rclrs/src/subscription.rs
+++ b/rclrs/src/subscription.rs
@@ -587,6 +587,7 @@ mod tests {
 
             let _ = commands.run(async move {
                 let (sender, mut receiver) = mpsc::unbounded();
+                let sender = std::panic::AssertUnwindSafe(sender);
                 let _subscription = node
                     .create_subscription("test_delayed_subscription", move |_: Empty| {
                         let _ = sender.unbounded_send(());

--- a/rclrs/src/subscription/into_async_subscription_callback.rs
+++ b/rclrs/src/subscription/into_async_subscription_callback.rs
@@ -3,7 +3,7 @@ use rosidl_runtime_rs::Message;
 use super::{AnySubscriptionCallback, MessageInfo, NodeSubscriptionCallback};
 use crate::ReadOnlyLoanedMessage;
 
-use std::future::Future;
+use std::{future::Future, panic::UnwindSafe};
 
 /// A trait for async callbacks of subscriptions.
 ///
@@ -14,7 +14,7 @@ use std::future::Future;
 /// - [`FnMut`] ( [`Box`]<`Message`>, [`MessageInfo`] ) -> impl [`Future`]<Output=()>
 /// - [`FnMut`] ( [`ReadOnlyLoanedMessage`]<`Message`> ) -> impl [`Future`]<Output=()>
 /// - [`FnMut`] ( [`ReadOnlyLoanedMessage`]<`Message`>, [`MessageInfo`] ) -> impl [`Future`]<Output=()>
-pub trait IntoAsyncSubscriptionCallback<T, Args>: Send + 'static
+pub trait IntoAsyncSubscriptionCallback<T, Args>: Send + UnwindSafe + 'static
 where
     T: Message,
 {
@@ -27,7 +27,7 @@ where
 impl<T, Out, Func> IntoAsyncSubscriptionCallback<T, (T,)> for Func
 where
     T: Message,
-    Func: FnMut(T) -> Out + Send + 'static,
+    Func: FnMut(T) -> Out + Send + UnwindSafe + 'static,
     Out: Future<Output = ()> + Send + 'static,
 {
     fn into_async_subscription_callback(mut self) -> AnySubscriptionCallback<T, ()> {
@@ -38,7 +38,7 @@ where
 impl<T, Out, Func> IntoAsyncSubscriptionCallback<T, (T, MessageInfo)> for Func
 where
     T: Message,
-    Func: FnMut(T, MessageInfo) -> Out + Send + 'static,
+    Func: FnMut(T, MessageInfo) -> Out + Send + UnwindSafe + 'static,
     Out: Future<Output = ()> + Send + 'static,
 {
     fn into_async_subscription_callback(mut self) -> AnySubscriptionCallback<T, ()> {
@@ -52,7 +52,7 @@ where
 impl<T, Out, Func> IntoAsyncSubscriptionCallback<T, (Box<T>,)> for Func
 where
     T: Message,
-    Func: FnMut(Box<T>) -> Out + Send + 'static,
+    Func: FnMut(Box<T>) -> Out + Send + UnwindSafe + 'static,
     Out: Future<Output = ()> + Send + 'static,
 {
     fn into_async_subscription_callback(mut self) -> AnySubscriptionCallback<T, ()> {
@@ -63,7 +63,7 @@ where
 impl<T, F, Func> IntoAsyncSubscriptionCallback<T, (Box<T>, MessageInfo)> for Func
 where
     T: Message,
-    Func: FnMut(Box<T>, MessageInfo) -> F + Send + 'static,
+    Func: FnMut(Box<T>, MessageInfo) -> F + Send + UnwindSafe + 'static,
     F: Future<Output = ()> + Send + 'static,
 {
     fn into_async_subscription_callback(mut self) -> AnySubscriptionCallback<T, ()> {
@@ -77,7 +77,7 @@ where
 impl<T, F, Func> IntoAsyncSubscriptionCallback<T, (ReadOnlyLoanedMessage<T>,)> for Func
 where
     T: Message,
-    Func: FnMut(ReadOnlyLoanedMessage<T>) -> F + Send + 'static,
+    Func: FnMut(ReadOnlyLoanedMessage<T>) -> F + Send + UnwindSafe + 'static,
     F: Future<Output = ()> + Send + 'static,
 {
     fn into_async_subscription_callback(mut self) -> AnySubscriptionCallback<T, ()> {
@@ -88,7 +88,7 @@ where
 impl<T, F, Func> IntoAsyncSubscriptionCallback<T, (ReadOnlyLoanedMessage<T>, MessageInfo)> for Func
 where
     T: Message,
-    Func: FnMut(ReadOnlyLoanedMessage<T>, MessageInfo) -> F + Send + 'static,
+    Func: FnMut(ReadOnlyLoanedMessage<T>, MessageInfo) -> F + Send + UnwindSafe + 'static,
     F: Future<Output = ()> + Send + 'static,
 {
     fn into_async_subscription_callback(mut self) -> AnySubscriptionCallback<T, ()> {

--- a/rclrs/src/subscription/into_node_subscription_callback.rs
+++ b/rclrs/src/subscription/into_node_subscription_callback.rs
@@ -4,7 +4,10 @@ use crate::{
     AnySubscriptionCallback, MessageInfo, NodeSubscriptionCallback, ReadOnlyLoanedMessage,
 };
 
-use std::sync::Arc;
+use std::{
+    panic::{RefUnwindSafe, UnwindSafe},
+    sync::Arc,
+};
 
 /// A trait for regular callbacks of subscriptions.
 ///
@@ -15,7 +18,7 @@ use std::sync::Arc;
 /// - [`Fn`] ( [`Box`]<`Message`>, [`MessageInfo`] )
 /// - [`Fn`] ( [`ReadOnlyLoanedMessage`]<`Message`> )
 /// - [`Fn`] ( [`ReadOnlyLoanedMessage`]<`Message`>, [`MessageInfo`] )
-pub trait IntoNodeSubscriptionCallback<T, Args>: Send + 'static
+pub trait IntoNodeSubscriptionCallback<T, Args>: Send + UnwindSafe + 'static
 where
     T: Message,
 {
@@ -28,7 +31,7 @@ where
 impl<T, Func> IntoNodeSubscriptionCallback<T, (T,)> for Func
 where
     T: Message,
-    Func: Fn(T) + Send + Sync + 'static,
+    Func: Fn(T) + Send + Sync + UnwindSafe + RefUnwindSafe + 'static,
 {
     fn into_node_subscription_callback(self) -> AnySubscriptionCallback<T, ()> {
         let func = Arc::new(self);
@@ -45,7 +48,7 @@ where
 impl<T, Func> IntoNodeSubscriptionCallback<T, (T, MessageInfo)> for Func
 where
     T: Message,
-    Func: Fn(T, MessageInfo) + Send + Sync + 'static,
+    Func: Fn(T, MessageInfo) + Send + Sync + UnwindSafe + RefUnwindSafe + 'static,
 {
     fn into_node_subscription_callback(self) -> AnySubscriptionCallback<T, ()> {
         let func = Arc::new(self);
@@ -62,7 +65,7 @@ where
 impl<T, Func> IntoNodeSubscriptionCallback<T, (Box<T>,)> for Func
 where
     T: Message,
-    Func: Fn(Box<T>) + Send + Sync + 'static,
+    Func: Fn(Box<T>) + Send + Sync + UnwindSafe + RefUnwindSafe + 'static,
 {
     fn into_node_subscription_callback(self) -> AnySubscriptionCallback<T, ()> {
         let func = Arc::new(self);
@@ -79,7 +82,7 @@ where
 impl<T, Func> IntoNodeSubscriptionCallback<T, (Box<T>, MessageInfo)> for Func
 where
     T: Message,
-    Func: Fn(Box<T>, MessageInfo) + Send + Sync + 'static,
+    Func: Fn(Box<T>, MessageInfo) + Send + Sync + UnwindSafe + RefUnwindSafe + 'static,
 {
     fn into_node_subscription_callback(self) -> AnySubscriptionCallback<T, ()> {
         let func = Arc::new(self);
@@ -96,7 +99,7 @@ where
 impl<T, Func> IntoNodeSubscriptionCallback<T, (ReadOnlyLoanedMessage<T>,)> for Func
 where
     T: Message,
-    Func: Fn(ReadOnlyLoanedMessage<T>) + Send + Sync + 'static,
+    Func: Fn(ReadOnlyLoanedMessage<T>) + Send + Sync + UnwindSafe + RefUnwindSafe + 'static,
 {
     fn into_node_subscription_callback(self) -> AnySubscriptionCallback<T, ()> {
         let func = Arc::new(self);
@@ -113,7 +116,12 @@ where
 impl<T, Func> IntoNodeSubscriptionCallback<T, (ReadOnlyLoanedMessage<T>, MessageInfo)> for Func
 where
     T: Message,
-    Func: Fn(ReadOnlyLoanedMessage<T>, MessageInfo) + Send + Sync + 'static,
+    Func: Fn(ReadOnlyLoanedMessage<T>, MessageInfo)
+        + Send
+        + Sync
+        + UnwindSafe
+        + RefUnwindSafe
+        + 'static,
 {
     fn into_node_subscription_callback(self) -> AnySubscriptionCallback<T, ()> {
         let func = Arc::new(self);

--- a/rclrs/src/subscription/into_worker_subscription_callback.rs
+++ b/rclrs/src/subscription/into_worker_subscription_callback.rs
@@ -1,8 +1,8 @@
-use rosidl_runtime_rs::Message;
-
 use crate::{
     AnySubscriptionCallback, MessageInfo, ReadOnlyLoanedMessage, WorkerSubscriptionCallback,
 };
+use rosidl_runtime_rs::Message;
+use std::panic::UnwindSafe;
 
 /// A trait for callbacks of subscriptions that run on a worker.
 ///
@@ -19,7 +19,7 @@ use crate::{
 /// - [`FnMut`] ( [`ReadOnlyLoanedMessage`]<`Message`>, [`MessageInfo`] )
 /// - [`FnMut`] ( `&mut Payload`, [`ReadOnlyLoanedMessage`]<`Message`> )
 /// - [`FnMut`] ( `&mut Payload`, [`ReadOnlyLoanedMessage`]<`Message`>, [`MessageInfo`] )
-pub trait IntoWorkerSubscriptionCallback<T, Payload, Args>: Send + 'static
+pub trait IntoWorkerSubscriptionCallback<T, Payload, Args>: Send + UnwindSafe + 'static
 where
     T: Message,
     Payload: 'static,
@@ -34,7 +34,7 @@ impl<T, Payload, Func> IntoWorkerSubscriptionCallback<T, Payload, (T,)> for Func
 where
     T: Message,
     Payload: 'static,
-    Func: FnMut(T) + Send + 'static,
+    Func: FnMut(T) + Send + UnwindSafe + 'static,
 {
     fn into_worker_subscription_callback(mut self) -> AnySubscriptionCallback<T, Payload> {
         let f = Box::new(move |_: &mut Payload, message| self(message));
@@ -46,7 +46,7 @@ impl<T, Payload, Func> IntoWorkerSubscriptionCallback<T, Payload, (Payload, T)> 
 where
     T: Message,
     Payload: 'static,
-    Func: FnMut(&mut Payload, T) + Send + 'static,
+    Func: FnMut(&mut Payload, T) + Send + UnwindSafe + 'static,
 {
     fn into_worker_subscription_callback(self) -> AnySubscriptionCallback<T, Payload> {
         WorkerSubscriptionCallback::Regular(Box::new(self)).into()
@@ -57,7 +57,7 @@ impl<T, Payload, Func> IntoWorkerSubscriptionCallback<T, Payload, (T, MessageInf
 where
     T: Message,
     Payload: 'static,
-    Func: FnMut(T, MessageInfo) + Send + 'static,
+    Func: FnMut(T, MessageInfo) + Send + UnwindSafe + 'static,
 {
     fn into_worker_subscription_callback(mut self) -> AnySubscriptionCallback<T, Payload> {
         let f = Box::new(move |_: &mut Payload, message, info| self(message, info));
@@ -70,7 +70,7 @@ impl<T, Payload, Func> IntoWorkerSubscriptionCallback<T, Payload, (Payload, T, M
 where
     T: Message,
     Payload: 'static,
-    Func: FnMut(&mut Payload, T, MessageInfo) + Send + 'static,
+    Func: FnMut(&mut Payload, T, MessageInfo) + Send + UnwindSafe + 'static,
 {
     fn into_worker_subscription_callback(self) -> AnySubscriptionCallback<T, Payload> {
         WorkerSubscriptionCallback::RegularWithMessageInfo(Box::new(self)).into()
@@ -81,7 +81,7 @@ impl<T, Payload, Func> IntoWorkerSubscriptionCallback<T, Payload, (Box<T>,)> for
 where
     T: Message,
     Payload: 'static,
-    Func: FnMut(Box<T>) + Send + 'static,
+    Func: FnMut(Box<T>) + Send + UnwindSafe + 'static,
 {
     fn into_worker_subscription_callback(mut self) -> AnySubscriptionCallback<T, Payload> {
         let f = Box::new(move |_: &mut Payload, message| self(message));
@@ -93,7 +93,7 @@ impl<T, Payload, Func> IntoWorkerSubscriptionCallback<T, Payload, (Payload, Box<
 where
     T: Message,
     Payload: 'static,
-    Func: FnMut(&mut Payload, Box<T>) + Send + 'static,
+    Func: FnMut(&mut Payload, Box<T>) + Send + UnwindSafe + 'static,
 {
     fn into_worker_subscription_callback(self) -> AnySubscriptionCallback<T, Payload> {
         WorkerSubscriptionCallback::Boxed(Box::new(self)).into()
@@ -104,7 +104,7 @@ impl<T, Payload, Func> IntoWorkerSubscriptionCallback<T, Payload, (Box<T>, Messa
 where
     T: Message,
     Payload: 'static,
-    Func: FnMut(Box<T>, MessageInfo) + Send + 'static,
+    Func: FnMut(Box<T>, MessageInfo) + Send + UnwindSafe + 'static,
 {
     fn into_worker_subscription_callback(mut self) -> AnySubscriptionCallback<T, Payload> {
         let f = Box::new(move |_: &mut Payload, message, info| self(message, info));
@@ -117,7 +117,7 @@ impl<T, Payload, Func> IntoWorkerSubscriptionCallback<T, Payload, (Payload, Box<
 where
     T: Message,
     Payload: 'static,
-    Func: FnMut(&mut Payload, Box<T>, MessageInfo) + Send + 'static,
+    Func: FnMut(&mut Payload, Box<T>, MessageInfo) + Send + UnwindSafe + 'static,
 {
     fn into_worker_subscription_callback(self) -> AnySubscriptionCallback<T, Payload> {
         WorkerSubscriptionCallback::BoxedWithMessageInfo(Box::new(self)).into()
@@ -129,7 +129,7 @@ impl<T, Payload, Func> IntoWorkerSubscriptionCallback<T, Payload, (ReadOnlyLoane
 where
     T: Message,
     Payload: 'static,
-    Func: FnMut(ReadOnlyLoanedMessage<T>) + Send + 'static,
+    Func: FnMut(ReadOnlyLoanedMessage<T>) + Send + UnwindSafe + 'static,
 {
     fn into_worker_subscription_callback(mut self) -> AnySubscriptionCallback<T, Payload> {
         let f = Box::new(move |_: &mut Payload, message| self(message));
@@ -142,7 +142,7 @@ impl<T, Payload, Func>
 where
     T: Message,
     Payload: 'static,
-    Func: FnMut(&mut Payload, ReadOnlyLoanedMessage<T>) + Send + 'static,
+    Func: FnMut(&mut Payload, ReadOnlyLoanedMessage<T>) + Send + UnwindSafe + 'static,
 {
     fn into_worker_subscription_callback(self) -> AnySubscriptionCallback<T, Payload> {
         WorkerSubscriptionCallback::Loaned(Box::new(self)).into()
@@ -154,7 +154,7 @@ impl<T, Payload, Func>
 where
     T: Message,
     Payload: 'static,
-    Func: FnMut(ReadOnlyLoanedMessage<T>, MessageInfo) + Send + 'static,
+    Func: FnMut(ReadOnlyLoanedMessage<T>, MessageInfo) + Send + UnwindSafe + 'static,
 {
     fn into_worker_subscription_callback(mut self) -> AnySubscriptionCallback<T, Payload> {
         let f = Box::new(move |_: &mut Payload, message, info| self(message, info));
@@ -168,7 +168,7 @@ impl<T, Payload, Func>
 where
     T: Message,
     Payload: 'static,
-    Func: FnMut(&mut Payload, ReadOnlyLoanedMessage<T>, MessageInfo) + Send + 'static,
+    Func: FnMut(&mut Payload, ReadOnlyLoanedMessage<T>, MessageInfo) + Send + UnwindSafe + 'static,
 {
     fn into_worker_subscription_callback(self) -> AnySubscriptionCallback<T, Payload> {
         WorkerSubscriptionCallback::LoanedWithMessageInfo(Box::new(self)).into()

--- a/rclrs/src/subscription/node_subscription_callback.rs
+++ b/rclrs/src/subscription/node_subscription_callback.rs
@@ -5,7 +5,7 @@ use crate::{RclrsError, RclrsErrorFilter, ReadOnlyLoanedMessage, WorkerCommands}
 
 use futures::future::BoxFuture;
 
-use std::sync::Arc;
+use std::{panic::UnwindSafe, sync::Arc};
 
 /// An enum capturing the various possible function signatures for subscription callbacks
 /// that can be used with the async worker.
@@ -17,20 +17,28 @@ use std::sync::Arc;
 /// [2]: crate::IntoAsyncSubscriptionCallback
 pub enum NodeSubscriptionCallback<T: Message> {
     /// A callback with only the message as an argument.
-    Regular(Box<dyn FnMut(T) -> BoxFuture<'static, ()> + Send>),
+    Regular(Box<dyn FnMut(T) -> BoxFuture<'static, ()> + Send + UnwindSafe>),
     /// A callback with the message and the message info as arguments.
-    RegularWithMessageInfo(Box<dyn FnMut(T, MessageInfo) -> BoxFuture<'static, ()> + Send>),
+    RegularWithMessageInfo(
+        Box<dyn FnMut(T, MessageInfo) -> BoxFuture<'static, ()> + Send + UnwindSafe>,
+    ),
     /// A callback with only the boxed message as an argument.
-    Boxed(Box<dyn FnMut(Box<T>) -> BoxFuture<'static, ()> + Send>),
+    Boxed(Box<dyn FnMut(Box<T>) -> BoxFuture<'static, ()> + Send + UnwindSafe>),
     /// A callback with the boxed message and the message info as arguments.
-    BoxedWithMessageInfo(Box<dyn FnMut(Box<T>, MessageInfo) -> BoxFuture<'static, ()> + Send>),
+    BoxedWithMessageInfo(
+        Box<dyn FnMut(Box<T>, MessageInfo) -> BoxFuture<'static, ()> + Send + UnwindSafe>,
+    ),
     /// A callback with only the loaned message as an argument.
     #[allow(clippy::type_complexity)]
-    Loaned(Box<dyn FnMut(ReadOnlyLoanedMessage<T>) -> BoxFuture<'static, ()> + Send>),
+    Loaned(Box<dyn FnMut(ReadOnlyLoanedMessage<T>) -> BoxFuture<'static, ()> + Send + UnwindSafe>),
     /// A callback with the loaned message and the message info as arguments.
     #[allow(clippy::type_complexity)]
     LoanedWithMessageInfo(
-        Box<dyn FnMut(ReadOnlyLoanedMessage<T>, MessageInfo) -> BoxFuture<'static, ()> + Send>,
+        Box<
+            dyn FnMut(ReadOnlyLoanedMessage<T>, MessageInfo) -> BoxFuture<'static, ()>
+                + Send
+                + UnwindSafe,
+        >,
     ),
 }
 

--- a/rclrs/src/subscription/worker_subscription_callback.rs
+++ b/rclrs/src/subscription/worker_subscription_callback.rs
@@ -5,7 +5,7 @@ use crate::{
     ReadOnlyLoanedMessage,
 };
 
-use std::{any::Any, sync::Arc};
+use std::{any::Any, panic::UnwindSafe, sync::Arc};
 
 /// An enum capturing the various possible function signatures for subscription
 /// callbacks that can be used by a [`Worker`][crate::Worker].
@@ -15,18 +15,18 @@ use std::{any::Any, sync::Arc};
 /// [1]: crate::IntoWorkerSubscriptionCallback
 pub enum WorkerSubscriptionCallback<T: Message, Payload> {
     /// A callback that only takes the payload and the message as arguments.
-    Regular(Box<dyn FnMut(&mut Payload, T) + Send>),
+    Regular(Box<dyn FnMut(&mut Payload, T) + Send + UnwindSafe>),
     /// A callback with the payload, message, and the message info as arguments.
-    RegularWithMessageInfo(Box<dyn FnMut(&mut Payload, T, MessageInfo) + Send>),
+    RegularWithMessageInfo(Box<dyn FnMut(&mut Payload, T, MessageInfo) + Send + UnwindSafe>),
     /// A callback with only the payload and boxed message as arguments.
-    Boxed(Box<dyn FnMut(&mut Payload, Box<T>) + Send>),
+    Boxed(Box<dyn FnMut(&mut Payload, Box<T>) + Send + UnwindSafe>),
     /// A callback with the payload, boxed message, and the message info as arguments.
-    BoxedWithMessageInfo(Box<dyn FnMut(&mut Payload, Box<T>, MessageInfo) + Send>),
+    BoxedWithMessageInfo(Box<dyn FnMut(&mut Payload, Box<T>, MessageInfo) + Send + UnwindSafe>),
     /// A callback with only the payload and loaned message as arguments.
-    Loaned(Box<dyn FnMut(&mut Payload, ReadOnlyLoanedMessage<T>) + Send>),
+    Loaned(Box<dyn FnMut(&mut Payload, ReadOnlyLoanedMessage<T>) + Send + UnwindSafe>),
     /// A callback with the payload, loaned message, and the message info as arguments.
     LoanedWithMessageInfo(
-        Box<dyn FnMut(&mut Payload, ReadOnlyLoanedMessage<T>, MessageInfo) + Send>,
+        Box<dyn FnMut(&mut Payload, ReadOnlyLoanedMessage<T>, MessageInfo) + Send + UnwindSafe>,
     ),
 }
 

--- a/rclrs/src/timer/any_timer_callback.rs
+++ b/rclrs/src/timer/any_timer_callback.rs
@@ -1,14 +1,14 @@
 use crate::{TimerState, WorkScope};
-use std::sync::Arc;
+use std::{panic::UnwindSafe, sync::Arc};
 
 /// A callback that can be triggered when a timer elapses.
 pub enum AnyTimerCallback<Scope: WorkScope> {
     /// This callback will be triggered repeatedly, each time the period of the
     /// timer elapses.
-    Repeating(Box<dyn FnMut(&mut Scope::Payload, &Arc<TimerState<Scope>>) + Send>),
+    Repeating(Box<dyn FnMut(&mut Scope::Payload, &Arc<TimerState<Scope>>) + Send + UnwindSafe>),
     /// This callback will be triggered exactly once, the first time the period
     /// of the timer elapses.
-    OneShot(Box<dyn FnOnce(&mut Scope::Payload, &Arc<TimerState<Scope>>) + Send>),
+    OneShot(Box<dyn FnOnce(&mut Scope::Payload, &Arc<TimerState<Scope>>) + Send + UnwindSafe>),
     /// Do nothing when the timer elapses. This can be replaced later so that
     /// the timer does something.
     Inert,

--- a/rclrs/src/timer/into_node_timer_callback.rs
+++ b/rclrs/src/timer/into_node_timer_callback.rs
@@ -1,14 +1,15 @@
 use crate::{AnyTimerCallback, Node, Time, Timer};
+use std::panic::UnwindSafe;
 
 /// This trait is used to create timer callbacks for repeating timers in a Node.
-pub trait IntoNodeTimerRepeatingCallback<Args>: 'static + Send {
+pub trait IntoNodeTimerRepeatingCallback<Args>: 'static + Send + UnwindSafe {
     /// Convert a suitable object into a repeating timer callback for the node scope
     fn into_node_timer_repeating_callback(self) -> AnyTimerCallback<Node>;
 }
 
 impl<Func> IntoNodeTimerRepeatingCallback<()> for Func
 where
-    Func: FnMut() + 'static + Send,
+    Func: FnMut() + 'static + Send + UnwindSafe,
 {
     fn into_node_timer_repeating_callback(mut self) -> AnyTimerCallback<Node> {
         AnyTimerCallback::Repeating(Box::new(move |_, _| self())).into()
@@ -17,7 +18,7 @@ where
 
 impl<Func> IntoNodeTimerRepeatingCallback<Timer> for Func
 where
-    Func: FnMut(&Timer) + 'static + Send,
+    Func: FnMut(&Timer) + 'static + Send + UnwindSafe,
 {
     fn into_node_timer_repeating_callback(mut self) -> AnyTimerCallback<Node> {
         AnyTimerCallback::Repeating(Box::new(move |_, t| self(t))).into()
@@ -26,7 +27,7 @@ where
 
 impl<Func> IntoNodeTimerRepeatingCallback<Time> for Func
 where
-    Func: FnMut(Time) + 'static + Send,
+    Func: FnMut(Time) + 'static + Send + UnwindSafe,
 {
     fn into_node_timer_repeating_callback(mut self) -> AnyTimerCallback<Node> {
         AnyTimerCallback::Repeating(Box::new(move |_, t| self(t.handle.clock.now()))).into()
@@ -34,14 +35,14 @@ where
 }
 
 /// This trait is used to create timer callbacks for one-shot timers in a Node.
-pub trait IntoNodeTimerOneshotCallback<Args>: 'static + Send {
+pub trait IntoNodeTimerOneshotCallback<Args>: 'static + Send + UnwindSafe {
     /// Convert a suitable object into a one-shot timer callback for a node scope
     fn into_node_timer_oneshot_callback(self) -> AnyTimerCallback<Node>;
 }
 
 impl<Func> IntoNodeTimerOneshotCallback<()> for Func
 where
-    Func: FnOnce() + 'static + Send,
+    Func: FnOnce() + 'static + Send + UnwindSafe,
 {
     fn into_node_timer_oneshot_callback(self) -> AnyTimerCallback<Node> {
         AnyTimerCallback::OneShot(Box::new(move |_, _| self())).into()
@@ -50,7 +51,7 @@ where
 
 impl<Func> IntoNodeTimerOneshotCallback<Timer> for Func
 where
-    Func: FnOnce(&Timer) + 'static + Send,
+    Func: FnOnce(&Timer) + 'static + Send + UnwindSafe,
 {
     fn into_node_timer_oneshot_callback(self) -> AnyTimerCallback<Node> {
         AnyTimerCallback::OneShot(Box::new(move |_, t| self(t))).into()
@@ -59,7 +60,7 @@ where
 
 impl<Func> IntoNodeTimerOneshotCallback<Time> for Func
 where
-    Func: FnOnce(Time) + 'static + Send,
+    Func: FnOnce(Time) + 'static + Send + UnwindSafe,
 {
     fn into_node_timer_oneshot_callback(self) -> AnyTimerCallback<Node> {
         AnyTimerCallback::OneShot(Box::new(move |_, t| self(t.handle.clock.now()))).into()

--- a/rclrs/src/timer/into_worker_timer_callback.rs
+++ b/rclrs/src/timer/into_worker_timer_callback.rs
@@ -1,15 +1,17 @@
 use crate::{AnyTimerCallback, Time, TimerState, WorkScope};
-use std::sync::Arc;
+use std::{panic::UnwindSafe, sync::Arc};
 
 /// This trait is used to create timer callbacks for repeating timers in a Worker.
-pub trait IntoWorkerTimerRepeatingCallback<Scope: WorkScope, Args>: 'static + Send {
+pub trait IntoWorkerTimerRepeatingCallback<Scope: WorkScope, Args>:
+    'static + Send + UnwindSafe
+{
     /// Convert a suitable object into a repeating timer callback for a worker scope
     fn into_worker_timer_repeating_callback(self) -> AnyTimerCallback<Scope>;
 }
 
 impl<Scope: WorkScope, Func> IntoWorkerTimerRepeatingCallback<Scope, ()> for Func
 where
-    Func: FnMut() + 'static + Send,
+    Func: FnMut() + 'static + Send + UnwindSafe,
 {
     fn into_worker_timer_repeating_callback(mut self) -> AnyTimerCallback<Scope> {
         AnyTimerCallback::Repeating(Box::new(move |_, _| self())).into()
@@ -18,7 +20,7 @@ where
 
 impl<Scope: WorkScope, Func> IntoWorkerTimerRepeatingCallback<Scope, (Scope::Payload,)> for Func
 where
-    Func: FnMut(&mut Scope::Payload) + 'static + Send,
+    Func: FnMut(&mut Scope::Payload) + 'static + Send + UnwindSafe,
 {
     fn into_worker_timer_repeating_callback(mut self) -> AnyTimerCallback<Scope> {
         AnyTimerCallback::Repeating(Box::new(move |payload, _| self(payload))).into()
@@ -28,7 +30,7 @@ where
 impl<Scope: WorkScope, Func>
     IntoWorkerTimerRepeatingCallback<Scope, (Scope::Payload, Arc<TimerState<Scope>>)> for Func
 where
-    Func: FnMut(&mut Scope::Payload, &Arc<TimerState<Scope>>) + 'static + Send,
+    Func: FnMut(&mut Scope::Payload, &Arc<TimerState<Scope>>) + 'static + Send + UnwindSafe,
 {
     fn into_worker_timer_repeating_callback(self) -> AnyTimerCallback<Scope> {
         AnyTimerCallback::Repeating(Box::new(self)).into()
@@ -38,7 +40,7 @@ where
 impl<Scope: WorkScope, Func> IntoWorkerTimerRepeatingCallback<Scope, (Scope::Payload, Time)>
     for Func
 where
-    Func: FnMut(&mut Scope::Payload, Time) + 'static + Send,
+    Func: FnMut(&mut Scope::Payload, Time) + 'static + Send + UnwindSafe,
 {
     fn into_worker_timer_repeating_callback(mut self) -> AnyTimerCallback<Scope> {
         AnyTimerCallback::Repeating(Box::new(move |payload, t| {
@@ -49,14 +51,16 @@ where
 }
 
 /// This trait is used to create timer callbacks for one-shot timers in a Worker.
-pub trait IntoWorkerTimerOneshotCallback<Scope: WorkScope, Args>: 'static + Send {
+pub trait IntoWorkerTimerOneshotCallback<Scope: WorkScope, Args>:
+    'static + Send + UnwindSafe
+{
     /// Convert a suitable object into a one-shot timer callback for a worker scope
     fn into_worker_timer_oneshot_callback(self) -> AnyTimerCallback<Scope>;
 }
 
 impl<Scope: WorkScope, Func> IntoWorkerTimerOneshotCallback<Scope, ()> for Func
 where
-    Func: FnOnce() + 'static + Send,
+    Func: FnOnce() + 'static + Send + UnwindSafe,
 {
     fn into_worker_timer_oneshot_callback(self) -> AnyTimerCallback<Scope> {
         AnyTimerCallback::OneShot(Box::new(move |_, _| self())).into()
@@ -65,7 +69,7 @@ where
 
 impl<Scope: WorkScope, Func> IntoWorkerTimerOneshotCallback<Scope, (Scope::Payload,)> for Func
 where
-    Func: FnOnce(&mut Scope::Payload) + 'static + Send,
+    Func: FnOnce(&mut Scope::Payload) + 'static + Send + UnwindSafe,
 {
     fn into_worker_timer_oneshot_callback(self) -> AnyTimerCallback<Scope> {
         AnyTimerCallback::OneShot(Box::new(move |payload, _| self(payload))).into()
@@ -75,7 +79,7 @@ where
 impl<Scope: WorkScope, Func>
     IntoWorkerTimerOneshotCallback<Scope, (Scope::Payload, Arc<TimerState<Scope>>)> for Func
 where
-    Func: FnOnce(&mut Scope::Payload, &Arc<TimerState<Scope>>) + 'static + Send,
+    Func: FnOnce(&mut Scope::Payload, &Arc<TimerState<Scope>>) + 'static + Send + UnwindSafe,
 {
     fn into_worker_timer_oneshot_callback(self) -> AnyTimerCallback<Scope> {
         AnyTimerCallback::OneShot(Box::new(self)).into()
@@ -84,7 +88,7 @@ where
 
 impl<Scope: WorkScope, Func> IntoWorkerTimerOneshotCallback<Scope, (Scope::Payload, Time)> for Func
 where
-    Func: FnMut(&mut Scope::Payload, Time) + 'static + Send,
+    Func: FnMut(&mut Scope::Payload, Time) + 'static + Send + UnwindSafe,
 {
     fn into_worker_timer_oneshot_callback(mut self) -> AnyTimerCallback<Scope> {
         AnyTimerCallback::OneShot(Box::new(move |payload, t| {

--- a/rclrs/src/wait_set/guard_condition.rs
+++ b/rclrs/src/wait_set/guard_condition.rs
@@ -1,5 +1,6 @@
 use std::{
     any::Any,
+    panic::UnwindSafe,
     sync::{Arc, Mutex},
 };
 
@@ -55,7 +56,7 @@ impl GuardCondition {
     /// users of rclrs do not need to access guard conditions.
     pub(crate) fn new(
         context: &Arc<ContextHandle>,
-        callback: Option<Box<dyn FnMut() + Send + Sync>>,
+        callback: Option<Box<dyn FnMut() + Send + Sync + UnwindSafe>>,
     ) -> (Arc<Self>, Waitable) {
         let rcl_guard_condition = {
             // SAFETY: Getting a zero initialized value is always safe
@@ -96,7 +97,7 @@ impl GuardCondition {
         context: &Arc<ContextHandle>,
         rcl_guard_condition: *const rcl_guard_condition_t,
         owner: Box<dyn Any>,
-        callback: Option<Box<dyn FnMut() + Send + Sync>>,
+        callback: Option<Box<dyn FnMut() + Send + Sync + UnwindSafe>>,
     ) -> (Self, Waitable) {
         let rcl_guard_condition = Mutex::new(InnerGuardConditionHandle::Unowned {
             handle: rcl_guard_condition,
@@ -202,7 +203,7 @@ struct GuardConditionExecutable {
     /// The callback that will be triggered when execute is called. Not all
     /// guard conditions need to have a callback associated, so this could be
     /// [`None`].
-    callback: Option<Box<dyn FnMut() + Send + Sync>>,
+    callback: Option<Box<dyn FnMut() + Send + Sync + UnwindSafe>>,
 }
 
 impl RclPrimitive for GuardConditionExecutable {

--- a/rclrs/src/wait_set/wait_set_runner.rs
+++ b/rclrs/src/wait_set/wait_set_runner.rs
@@ -5,6 +5,7 @@ use futures::channel::{
 
 use std::{
     any::Any,
+    panic::{self, AssertUnwindSafe},
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc, Mutex,
@@ -28,6 +29,14 @@ pub struct WaitSetRunner {
     activity_listeners: Arc<Mutex<Vec<WeakActivityListener>>>,
     guard_condition: Arc<GuardCondition>,
     payload: Box<dyn Any + Send>,
+}
+
+/// The outcome produced when a [`WaitSetRunner`] finishes running on its thread.
+pub enum WaitSetRunnerOutcome {
+    /// The runner completed, possibly with an [`RclrsError`].
+    Completed(Result<(), RclrsError>),
+    /// A callback panicked while the runner was executing.
+    Panicked(Box<dyn Any + Send + 'static>),
 }
 
 /// These are the conditions used by the [`WaitSetRunner`] to determine when it
@@ -107,11 +116,17 @@ impl WaitSetRunner {
     pub fn run(
         mut self,
         conditions: WaitSetRunConditions,
-    ) -> Promise<(Self, Result<(), RclrsError>)> {
+    ) -> Promise<(Self, WaitSetRunnerOutcome)> {
         let (sender, promise) = channel();
         std::thread::spawn(move || {
-            let result = self.run_blocking(conditions);
-            if let Err(_) = sender.send((self, result)) {
+            let result = panic::catch_unwind(AssertUnwindSafe(|| self.run_blocking(conditions)));
+
+            let outcome = match result {
+                Ok(run_result) => WaitSetRunnerOutcome::Completed(run_result),
+                Err(panic_payload) => WaitSetRunnerOutcome::Panicked(panic_payload),
+            };
+
+            if let Err(_) = sender.send((self, outcome)) {
                 // This is a debug log because this is a normal thing to occur
                 // when an executor is winding down.
                 log_debug!(

--- a/rclrs/src/worker.rs
+++ b/rclrs/src/worker.rs
@@ -13,6 +13,7 @@ use futures::channel::oneshot;
 use rosidl_runtime_rs::{Message, Service as ServiceIDL};
 use std::{
     any::Any,
+    panic::{AssertUnwindSafe, UnwindSafe},
     sync::{Arc, Mutex, Weak},
 };
 
@@ -31,6 +32,10 @@ use std::{
 ///
 /// The API for the worker is provided through [`WorkerState`].
 pub type Worker<Payload> = Arc<WorkerState<Payload>>;
+
+fn send_unwind_safe<T>(sender: AssertUnwindSafe<oneshot::Sender<T>>, value: T) {
+    sender.0.send(value).ok();
+}
 
 /// The inner state of a [`Worker`].
 ///
@@ -56,10 +61,11 @@ impl<Payload: 'static + Send + Sync> WorkerState<Payload> {
     /// what happened inside the callback.
     pub fn run<Out, F>(&self, f: F) -> Promise<Out>
     where
-        F: FnOnce(&mut Payload) -> Out + 'static + Send,
+        F: FnOnce(&mut Payload) -> Out + 'static + Send + UnwindSafe,
         Out: 'static + Send,
     {
         let (sender, receiver) = oneshot::channel();
+        let sender = AssertUnwindSafe(sender);
         self.commands.run_on_payload(Box::new(move |any_payload| {
             let Some(payload) = any_payload.downcast_mut::<Payload>() else {
                 log_fatal!(
@@ -71,7 +77,7 @@ impl<Payload: 'static + Send + Sync> WorkerState<Payload> {
             };
 
             let out = f(payload);
-            sender.send(out).ok();
+            send_unwind_safe(sender, out);
         }));
         receiver
     }
@@ -83,11 +89,13 @@ impl<Payload: 'static + Send + Sync> WorkerState<Payload> {
     /// [1]: crate::SpinOptions::until_promise_resolved
     pub fn run_with_notice<Out, F>(&self, f: F) -> (Promise<Out>, Promise<()>)
     where
-        F: FnOnce(&mut Payload) -> Out + 'static + Send,
+        F: FnOnce(&mut Payload) -> Out + 'static + Send + UnwindSafe,
         Out: 'static + Send,
     {
         let (notice_sender, notice_receiver) = oneshot::channel();
+        let notice_sender = AssertUnwindSafe(notice_sender);
         let (sender, receiver) = oneshot::channel();
+        let sender = AssertUnwindSafe(sender);
         self.commands.run_on_payload(Box::new(move |any_payload| {
             let Some(payload) = any_payload.downcast_mut::<Payload>() else {
                 log_fatal!(
@@ -99,8 +107,8 @@ impl<Payload: 'static + Send + Sync> WorkerState<Payload> {
             };
 
             let out = f(payload);
-            sender.send(out).ok();
-            notice_sender.send(()).ok();
+            send_unwind_safe(sender, out);
+            send_unwind_safe(notice_sender, ());
         }));
         (receiver, notice_receiver)
     }
@@ -109,7 +117,7 @@ impl<Payload: 'static + Send + Sync> WorkerState<Payload> {
     /// listening will continue until the [`ActivityListener`] is dropped.
     pub fn listen<F>(&self, mut f: F) -> ActivityListener<Payload>
     where
-        F: FnMut(&mut Payload) + 'static + Send + Sync,
+        F: FnMut(&mut Payload) + 'static + Send + UnwindSafe + Sync,
         Payload: Sync,
     {
         let f = Box::new(move |any_payload: &mut dyn Any| {
@@ -139,32 +147,32 @@ impl<Payload: 'static + Send + Sync> WorkerState<Payload> {
     /// the listener will keep running.
     pub fn listen_until<Out, F>(&self, mut f: F) -> Promise<Out>
     where
-        F: FnMut(&mut Payload) -> Option<Out> + 'static + Send + Sync,
+        F: FnMut(&mut Payload) -> Option<Out> + 'static + Send + UnwindSafe + Sync,
         Out: 'static + Send + Sync,
         Payload: Sync,
     {
         let (sender, receiver) = oneshot::channel();
-        let mut captured_sender = Some(sender);
+        let mut captured_sender = Some(AssertUnwindSafe(sender));
         let listener = ActivityListener::new(ActivityListenerCallback::Inert);
 
         // We capture the listener so that its lifecycle is tied to the success
         // of the callback.
-        let mut _captured_listener = Some(listener.clone());
+        let mut _captured_listener = AssertUnwindSafe(Some(listener.clone()));
         listener.set_callback(move |payload| {
             if let Some(sender) = captured_sender.take() {
                 if sender.is_canceled() {
-                    _captured_listener = None;
+                    *_captured_listener = None;
                     return;
                 }
 
                 if let Some(out) = f(payload) {
-                    sender.send(out).ok();
-                    _captured_listener = None;
+                    send_unwind_safe(sender, out);
+                    *_captured_listener = None;
                 } else {
                     captured_sender = Some(sender);
                 }
             } else {
-                _captured_listener = None;
+                *_captured_listener = None;
             }
         });
 
@@ -317,7 +325,7 @@ impl<Payload: 'static + Send + Sync> WorkerState<Payload> {
         callback: F,
     ) -> Result<WorkerDynamicSubscription<Payload>, RclrsError>
     where
-        F: FnMut(&mut Payload, DynamicMessage, MessageInfo) + Send + Sync + 'static,
+        F: FnMut(&mut Payload, DynamicMessage, MessageInfo) + Send + Sync + UnwindSafe + 'static,
     {
         DynamicSubscriptionState::<Worker<Payload>>::create(
             topic_type,
@@ -700,7 +708,7 @@ impl<Payload: 'static + Send + Sync> ActivityListener<Payload> {
     /// Change the callback for this listener.
     pub fn set_callback<F>(&self, mut f: F)
     where
-        F: FnMut(&mut Payload) + 'static + Send + Sync,
+        F: FnMut(&mut Payload) + 'static + Send + UnwindSafe + Sync,
     {
         let f = Box::new(move |any_payload: &mut dyn Any| {
             let Some(payload) = any_payload.downcast_mut::<Payload>() else {
@@ -735,7 +743,7 @@ pub type WeakActivityListener = Weak<Mutex<Option<ActivityListenerCallback>>>;
 /// Enum for the different types of callbacks that a listener may have
 pub enum ActivityListenerCallback {
     /// The listener is listening
-    Listen(Box<dyn FnMut(&mut dyn Any) + 'static + Send>),
+    Listen(Box<dyn FnMut(&mut dyn Any) + 'static + Send + UnwindSafe>),
     /// The listener is inert
     Inert,
 }


### PR DESCRIPTION
  Fixes #613.

  A panic inside a callback was caught by its `WaitSetRunner`, but the basic
  executor immediately resumed unwinding when it received the panic. This
  allowed executor and ROS entities to be destroyed while other runner threads
  were still active, causing RMW cleanup errors and potentially a segmentation
  fault.

  This change:

  - Returns callback panics from `WaitSetRunner` as a distinct outcome.
  - Saves the first panic payload and the runner that encountered it.
  - Signals all remaining runners to stop and wakes runners blocked in the wait set.
  - Waits for the runners to finish.
  - Restores executor-owned state before resuming the original panic.

  The panic still propagates to the caller, but worker shutdown and ROS resource
  cleanup now happen first.

  ### Validation


  - Ran `cargo check -p rclrs --lib`.
  - Reproduced the issue using example 613 with an intentional callback panic.
  - Confirmed that the panic is propagated without the previous RMW cleanup
    errors or segmentation fault.
  - Confirmed the panic can be caught by the caller with `catch_unwind`.
  
  ```
  use rclrs::*;
use ros_env::std_msgs;
use std::time::Duration;

fn main() -> Result<(), RclrsError> {
    let mut executor = Context::default_from_env()?.create_basic_executor();
    let node = executor.create_node("worker_demo")?;

    let publisher = node.create_publisher("output_topic")?;

    // Keep a separate runner blocked in rcl_wait when the subscription callback
    // panics. The executor must stop and reclaim this runner before propagating
    // the panic.
    let idle_worker = node.create_worker(());
    let _idle_timer = idle_worker.create_timer_inert(Duration::from_secs(60))?;

    let worker = node.create_worker(String::new());
    let _subscription = worker.create_subscription(
        "input_topic",
        move |data: &mut String, msg: std_msgs::msg::String| {
            *data = msg.data;
            panic!();
        },
    )?;

    // Use this timer-based implementation when timers are available instead
    // of using std::thread::spawn.
    let _timer =
        worker.create_timer_repeating(Duration::from_secs(1), move |data: &mut String| {
            let msg = std_msgs::msg::String { data: data.clone() };

            publisher.publish(msg).ok();
        })?;

    println!(
        "Beginning repeater... \n >> \
        Publish a std_msg::msg::String to \"input_topic\" and we will periodically republish it to \"output_topic\".\n\n\
        To see this in action run the following commands in two different terminals:\n \
        $ ros2 topic echo output_topic\n \
        $ ros2 topic pub input_topic std_msgs/msg/String \"{{data: Hello}}\""
    );
    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
        executor.spin(SpinOptions::default());
    }));

    assert!(result.is_err(), "callback panic was not propagated");

    Ok(())
}
  ```
<img width="3587" height="1950" alt="image" src="https://github.com/user-attachments/assets/90a4a51d-d845-4fba-9d41-b560c8a80f2c" />
<img width="719" height="222" alt="image" src="https://github.com/user-attachments/assets/134ac339-5c1e-40c5-987d-09893879c0f6" />
