### PR TITLE
docs: say what actually guards the dynamic_message publish/take casts

### DIFF
--- a/rclrs/src/dynamic_message/dynamic_publisher.rs
+++ b/rclrs/src/dynamic_message/dynamic_publisher.rs
@@ -125,9 +125,19 @@ impl DynamicPublisherState {
         }
         let rcl_publisher = &mut *self.handle.rcl_publisher.lock().unwrap();
         unsafe {
-            // SAFETY: The message type is guaranteed to match the publisher type by the type system.
+            // SAFETY: Unlike `Publisher<T>`, nothing here is enforced by the type system --
+            // a `DynamicMessage`'s type is a runtime value. What guarantees the match is the
+            // `message_type` comparison at the top of this function.
+            //
+            // That comparison is by name (`MessageTypeName`), so it stands on the two type
+            // support libraries for a given package describing the same layout: the
+            // introspection one laid out `message.storage` (via `DynamicMessageMetadata`),
+            // while `rcl_publish` serialises those bytes through the `rosidl_typesupport_c`
+            // one. `DynamicPublisher::create` resolves both from the same package name, so
+            // they come from one install prefix.
+            //
             // The message does not need to be valid beyond the duration of this function call.
-            // The third argument is explictly allowed to be NULL.
+            // The third argument is explicitly allowed to be NULL.
             rcl_publish(
                 rcl_publisher,
                 message.storage.as_mut_ptr() as *mut _,

--- a/rclrs/src/dynamic_message/dynamic_subscription.rs
+++ b/rclrs/src/dynamic_message/dynamic_subscription.rs
@@ -201,6 +201,12 @@ impl<Payload> DynamicSubscriptionExecutable<Payload> {
             // SAFETY: The first two pointers are valid/initialized, and do not need to be valid
             // beyond the function call.
             // The latter two pointers are explicitly allowed to be NULL.
+            //
+            // `rmw_message` points at storage laid out by the *introspection* type support
+            // (`self.metadata.create()`), while `rcl_take` writes it through the
+            // `rosidl_typesupport_c` one. Those must describe the same layout;
+            // `DynamicSubscription::create` resolves both from the same package name, so they
+            // come from one install prefix.
             rcl_take(
                 rcl_subscription,
                 rmw_message as *mut _,


### PR DESCRIPTION
Comments only. No code changes — every changed line starts with `//`, and stripping comments
from both files before and after gives byte-identical text.

### What it fixes

`DynamicPublisher::publish` carries this:

```rust
// SAFETY: The message type is guaranteed to match the publisher type by the type system.
```

It is a verbatim copy of the comment on `Publisher::publish`, misspelling of "explictly"
included. On `Publisher<T>` the sentence is true — the generic parameter ties the message to
`<T as Message>::RmwMsg`. On `DynamicPublisher`, whose whole point is that the type is a runtime
value, the compiler cannot see anything of the sort. What actually guards the cast is the
`message_type` comparison two lines above, and that comparison is by **name**
(`MessageTypeName { package_name, type_name }`).

### The obligation neither comment mentions

Two type support libraries are involved:

| | library | role |
|---|---|---|
| `DynamicMessageMetadata` | `rosidl_typesupport_introspection_c` | lays out `message.storage` |
| the publisher / subscription | `rosidl_typesupport_c` | what `rcl_publish` / `rcl_take` serialise with |

So the name comparison rests on those two describing the same layout. Both constructors already
say the two libraries exist, in prose a few lines up — *"This loads the introspection type
support library … However, we also need the regular type support library"* — so this is known,
just missing from the place where the `unsafe` block is justified.

`DynamicSubscription`'s `take()` is the mirror: `metadata.create()` lays out the storage by
introspection, `rcl_take` writes it through the C type support, and the comment discusses
pointer validity only.

### Both are sound as written

Each constructor resolves the metadata and the C type support from the same package name in the
same function, through one `ament.find_package`, so they come from one install prefix and agree
by construction. This PR records that, rather than changing it. The point is that a reader
auditing these blocks is currently told the compiler is checking something it never sees.

Happy to reword or drop either hunk.


---

### Generative AI disclosure

This PR was opened on 2026-08-08, before this repository adopted the OSRF AI policy in #672 on
2026-09-01. Adding the disclosure now so the record is complete:

```text
Assisted-by: Codex:gpt-5.6-sol
```

`AGENTS.md` also asks for the trailer in the commit message body. I have left the commit as it
is rather than rewriting it, since amending would invalidate the existing CI results and any
references to the current SHA. Happy to amend and force-push if you would prefer the trailer on
the commit itself.
