### PR TITLE
ci: update rolling docker image

### DIFF
--- a/.github/workflows/generate-bindings.yml
+++ b/.github/workflows/generate-bindings.yml
@@ -34,7 +34,7 @@ jobs:
             ros_distribution: kilted
             ros_version: 2
           # Rolling Ridley  (June 2020 - Present)
-          - docker_image: rostooling/setup-ros-docker:ubuntu-noble-ros-rolling-ros-base-latest
+          - docker_image: rostooling/setup-ros-docker:ubuntu-resolute-ros-rolling-ros-base-latest
             ros_distribution: rolling
             ros_version: 2
     runs-on: ubuntu-latest

--- a/.github/workflows/rust-minimal.yml
+++ b/.github/workflows/rust-minimal.yml
@@ -37,7 +37,7 @@ jobs:
             ros_distribution: kilted
             ros_version: 2
           # Rolling Ridley  (June 2020 - Present)
-          - docker_image: rostooling/setup-ros-docker:ubuntu-noble-ros-rolling-ros-base-latest
+          - docker_image: rostooling/setup-ros-docker:ubuntu-resolute-ros-rolling-ros-base-latest
             ros_distribution: rolling
             ros_version: 2
     runs-on: ubuntu-latest
@@ -62,16 +62,23 @@ jobs:
         required-ros-distributions: ${{ matrix.ros_distribution }}
         use-ros2-testing: ${{ matrix.ros_distribution == 'rolling' }}
 
+    # Installing the ros metapackage (in setup-ros) leaves the packages already baked into the image
+    # untouched. This forces an upgrade of all packages to test against the latest available versions.
+    - name: Update environment and force upgrade new packages
+      run: |
+        sudo apt-get update
+        sudo apt-get dist-upgrade -y
+
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@1.85
       with:
         components: clippy, rustfmt
 
-    # Colcon can not be run in a venv which is required in Ubuntu Noble
+    # Colcon can not be run in a venv which is required from Ubuntu Noble on
     # Removing the externally managed file
     - name: Install colcon-cargo and colcon-ros-cargo
       run: |
-        sudo rm -f /usr/lib/python3.12/EXTERNALLY-MANAGED
+        sudo rm -f /usr/lib/python3.*/EXTERNALLY-MANAGED
         sudo pip3 install git+https://github.com/colcon/colcon-cargo.git
         sudo pip3 install git+https://github.com/colcon/colcon-ros-cargo.git
 

--- a/.github/workflows/rust-stable.yml
+++ b/.github/workflows/rust-stable.yml
@@ -37,7 +37,7 @@ jobs:
             ros_distribution: kilted
             ros_version: 2
           # Rolling Ridley  (June 2020 - Present)
-          - docker_image: rostooling/setup-ros-docker:ubuntu-noble-ros-rolling-ros-base-latest
+          - docker_image: rostooling/setup-ros-docker:ubuntu-resolute-ros-rolling-ros-base-latest
             ros_distribution: rolling
             ros_version: 2
     runs-on: ubuntu-latest
@@ -62,16 +62,23 @@ jobs:
         required-ros-distributions: ${{ matrix.ros_distribution }}
         use-ros2-testing: ${{ matrix.ros_distribution == 'rolling' }}
 
+    # Installing the ros metapackage (in setup-ros) leaves the packages already baked into the image
+    # untouched. This forces an upgrade of all packages to test against the latest available versions.
+    - name: Update environment and force upgrade new packages
+      run: |
+        sudo apt-get update
+        sudo apt-get dist-upgrade -y
+
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@stable
       with:
         components: clippy, rustfmt
 
-    # Colcon can not be run in a venv which is required in Ubuntu Noble
+    # Colcon can not be run in a venv which is required from Ubuntu Noble on
     # Removing the externally managed file
     - name: Install colcon-cargo and colcon-ros-cargo
       run: |
-        sudo rm -f /usr/lib/python3.12/EXTERNALLY-MANAGED
+        sudo rm -f /usr/lib/python3.*/EXTERNALLY-MANAGED
         sudo pip3 install git+https://github.com/colcon/colcon-cargo.git
         sudo pip3 install git+https://github.com/colcon/colcon-ros-cargo.git
 


### PR DESCRIPTION
In #658 it was noted that there is a segfault occurring in Lyrical. Rolling is actually similarly broken. It wasn't caught because the CI is using a very old version of some of the rolling packages. Because the docker image already contains some of the rolling packages and because we don't do an apt dist-upgrade those packages are actually never updated to the latest. So we are testing against packages from 2025-07-30 on rolling. 

This forces an update of the packages in the CI images and prevents testing on stale packages. At the same time we are updating to ubuntu resolute instead of noble for rolling as packages are not being built for noble anymore since April.

**Expected:** This PR should start making rolling failing