### PR TITLE
Remove sync requirement for action server task

### DIFF
--- a/rclrs/src/action/action_server.rs
+++ b/rclrs/src/action/action_server.rs
@@ -245,7 +245,7 @@ impl<A: Action> ActionServerState<A> {
         mut callback: impl FnMut(RequestedGoal<A>) -> Task + Send + Sync + 'static,
     ) -> Result<ActionServer<A>, RclrsError>
     where
-        Task: Future<Output = TerminatedGoal> + Send + Sync + 'static,
+        Task: Future<Output = TerminatedGoal> + Send + 'static,
     {
         let callback = Box::new(
             move |requested_goal| -> BoxFuture<'static, TerminatedGoal> {

--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -404,7 +404,7 @@ impl NodeState {
         callback: impl FnMut(RequestedGoal<A>) -> Task + Send + Sync + 'static,
     ) -> Result<ActionServer<A>, RclrsError>
     where
-        Task: Future<Output = TerminatedGoal> + Send + Sync + 'static,
+        Task: Future<Output = TerminatedGoal> + Send + 'static,
     {
         ActionServerState::create(self, options, callback)
     }


### PR DESCRIPTION
This is a teeny tiny PR that removes an unnecessary restriction on action servers.

When I initially implemented the action server API, I naively put both `Send + Sync` requirements everywhere to ensure that objects can be used safely across threads. This is more restrictive than necessary for the async task that needs to be produced by an action server. Async tasks really only need to be `Send`, not `Sync`. It's worth noting that [`BoxFuture`](https://docs.rs/futures/latest/futures/future/type.BoxFuture.html), which gets used to encapsulate many async tasks across many different Rust async execution engines, only requires `Send` and not `Sync`.

This change is backwards compatible for all existing uses of this API, because we are only removing a constraint.