### PR TITLE
ci: guard the Windows libclang rename against an existing target

### DIFF
--- a/.github/workflows/rust-win.yml
+++ b/.github/workflows/rust-win.yml
@@ -39,13 +39,16 @@ jobs:
 
       - name: Install ros2_rust prerequisites 
         # prerequisites and fixes for windows build ros2_rust:
-        #     * Libclang has to be added (from the ros2_rust instructions) and the dll has to be renamed
+        #     * Libclang has to be added (from the ros2_rust instructions). Older builds of the
+        #       conda package only shipped a versioned libclang-13.dll, which bindgen does not
+        #       find, so it gets renamed. Newer builds ship libclang.dll themselves, in which
+        #       case there is nothing to rename.
         #     * colcon-ros-cargo and colcon-cargo have to be added as PyPI packages
         run: |
           pixi add libclang --manifest-path C:\pixi_ws\pixi.toml
           $src = "C:\pixi_ws\.pixi\envs\default\Library\bin\libclang-13.dll"
           $dst = "C:\pixi_ws\.pixi\envs\default\Library\bin\libclang.dll"
-          if (Test-Path $src) { Rename-Item -Path $src -NewName "libclang.dll" }
+          if ((Test-Path $src) -and -not (Test-Path $dst)) { Rename-Item -Path $src -NewName "libclang.dll" }
           pixi add --pypi "colcon-ros-cargo@git+https://github.com/colcon/colcon-ros-cargo.git" --manifest-path C:\pixi_ws\pixi.toml
           pixi add --pypi "colcon-cargo@git+https://github.com/colcon/colcon-cargo.git" --manifest-path C:\pixi_ws\pixi.toml
           pixi upgrade colcon-core --manifest-path C:\pixi_ws\pixi.toml


### PR DESCRIPTION
The Windows job fails in "Install ros2_rust prerequisites" before any Rust is compiled:

    Added libclang >=21.1.0,<22
    Rename-Item: Cannot create a file when that file already exists.

The step renames libclang-13.dll to libclang.dll so that bindgen can find it. The conda libclang package now resolves to 21.1.0, and that build ships both libclang-13.dll and libclang.dll, so the rename collides with a file that is already there. GitHub runs pwsh with $ErrorActionPreference = 'Stop', which turns that non-terminating error into a failed step and aborts the job.

The guard only tested the source path. $dst was computed and never used, so the missing half of the check was already visible in the source. Test both paths and skip the rename when the target exists, which keeps the workaround in place for older package builds that ship only the versioned DLL.

Assisted-by: Claude:claude-opus-5 [Claude Code]