### PR TITLE
Update setup-pixi action version to v0.10.2

### DIFF
--- a/.github/workflows/rust-win.yml
+++ b/.github/workflows/rust-win.yml
@@ -33,7 +33,7 @@ jobs:
         run: irm https://raw.githubusercontent.com/ros2/ros2/refs/heads/rolling/pixi.toml -OutFile C:\pixi_ws\pixi.toml
 
       - name: Setup Pixi environment with ROS 2 toml file
-        uses: prefix-dev/setup-pixi@v0.8.1
+        uses: prefix-dev/setup-pixi@v0.10.2
         with:
           manifest-path: C:/pixi_ws/pixi.toml
 


### PR DESCRIPTION
Seems like the latest windows CI is broken, and that is probably due to that the pixi.toml file for rolling has been updated to only work with the latest pixi version. This should hopefully solve the issue