### PR TITLE
feat!: expose the QoS profile in TopicEndpointInfo

### DIFF
--- a/rclrs/src/dynamic_message/dynamic_publisher.rs
+++ b/rclrs/src/dynamic_message/dynamic_publisher.rs
@@ -154,7 +154,7 @@ mod tests {
 
     #[test]
     fn test_dynamic_publishers() -> Result<(), RclrsError> {
-        use crate::TopicEndpointInfo;
+        use crate::{QoSDurabilityPolicy, QoSReliabilityPolicy};
         use ros_env::test_msgs::msg;
 
         let namespace = "/test_dynamic_publishers_graph";
@@ -200,19 +200,17 @@ mod tests {
         assert!(types.contains(&"test_msgs/msg/Defaults".to_string()));
 
         // Test get_publishers_info_by_topic()
-        let expected_publishers_info = vec![TopicEndpointInfo {
-            node_name: String::from("graph_test_node_1"),
-            node_namespace: String::from(namespace),
-            topic_type: String::from("test_msgs/msg/Empty"),
-        }];
-        assert_eq!(
-            graph.node1.get_publishers_info_by_topic(&topic1)?,
-            expected_publishers_info
-        );
-        assert_eq!(
-            graph.node2.get_publishers_info_by_topic(&topic1)?,
-            expected_publishers_info
-        );
+        for node in [&graph.node1, &graph.node2] {
+            let publishers_info = node.get_publishers_info_by_topic(&topic1)?;
+            assert_eq!(publishers_info.len(), 1);
+
+            let info = &publishers_info[0];
+            assert_eq!(info.node_name, "graph_test_node_1");
+            assert_eq!(info.node_namespace, namespace);
+            assert_eq!(info.topic_type, "test_msgs/msg/Empty");
+            assert_eq!(info.qos_profile.reliability, QoSReliabilityPolicy::Reliable);
+            assert_eq!(info.qos_profile.durability, QoSDurabilityPolicy::Volatile);
+        }
 
         // Test get_subscription_count()
         assert_eq!(node_1_empty_publisher.get_subscription_count(), Ok(0));

--- a/rclrs/src/dynamic_message/dynamic_subscription.rs
+++ b/rclrs/src/dynamic_message/dynamic_subscription.rs
@@ -384,7 +384,7 @@ mod tests {
 
     #[test]
     fn test_dynamic_subscriptions() -> Result<(), RclrsError> {
-        use crate::TopicEndpointInfo;
+        use crate::{QoSDurabilityPolicy, QoSReliabilityPolicy};
 
         let namespace = "/test_dynamic_subscriptions_graph";
         let graph = construct_test_graph(namespace)?;
@@ -434,19 +434,17 @@ mod tests {
         assert!(types.contains(&"test_msgs/msg/BasicTypes".to_string()));
 
         // Test get_subscriptions_info_by_topic()
-        let expected_subscriptions_info = vec![TopicEndpointInfo {
-            node_name: String::from("graph_test_node_2"),
-            node_namespace: String::from(namespace),
-            topic_type: String::from("test_msgs/msg/Empty"),
-        }];
-        assert_eq!(
-            graph.node1.get_subscriptions_info_by_topic(&topic1)?,
-            expected_subscriptions_info
-        );
-        assert_eq!(
-            graph.node2.get_subscriptions_info_by_topic(&topic1)?,
-            expected_subscriptions_info
-        );
+        for node in [&graph.node1, &graph.node2] {
+            let subscriptions_info = node.get_subscriptions_info_by_topic(&topic1)?;
+            assert_eq!(subscriptions_info.len(), 1);
+
+            let info = &subscriptions_info[0];
+            assert_eq!(info.node_name, "graph_test_node_2");
+            assert_eq!(info.node_namespace, namespace);
+            assert_eq!(info.topic_type, "test_msgs/msg/Empty");
+            assert_eq!(info.qos_profile.reliability, QoSReliabilityPolicy::Reliable);
+            assert_eq!(info.qos_profile.durability, QoSDurabilityPolicy::Volatile);
+        }
         Ok(())
     }
 }

--- a/rclrs/src/node/graph.rs
+++ b/rclrs/src/node/graph.rs
@@ -3,7 +3,7 @@ use std::{
     ffi::{CStr, CString},
 };
 
-use crate::{rcl_bindings::*, NodeState, RclrsError, ToResult};
+use crate::{rcl_bindings::*, NodeState, QoSProfile, RclrsError, ToResult};
 
 impl Drop for rmw_names_and_types_t {
     fn drop(&mut self) {
@@ -55,6 +55,8 @@ pub struct TopicEndpointInfo {
     pub node_namespace: String,
     /// The type of the topic
     pub topic_type: String,
+    /// The QoS profile offered (publisher) or requested (subscription) by the endpoint
+    pub qos_profile: QoSProfile,
 }
 
 impl NodeState {
@@ -408,6 +410,7 @@ impl NodeState {
                     node_name,
                     node_namespace,
                     topic_type,
+                    qos_profile: QoSProfile::from(&info.qos_profile),
                 }
             })
             .collect();

--- a/rclrs/src/publisher.rs
+++ b/rclrs/src/publisher.rs
@@ -356,7 +356,7 @@ mod tests {
 
     #[test]
     fn test_publishers() -> Result<(), RclrsError> {
-        use crate::TopicEndpointInfo;
+        use crate::{QoSDurabilityPolicy, QoSReliabilityPolicy};
         use ros_env::test_msgs::msg;
 
         let namespace = "/test_publishers_graph";
@@ -401,19 +401,17 @@ mod tests {
         assert!(types.contains(&"test_msgs/msg/Defaults".to_string()));
 
         // Test get_publishers_info_by_topic()
-        let expected_publishers_info = vec![TopicEndpointInfo {
-            node_name: String::from("graph_test_node_1"),
-            node_namespace: String::from(namespace),
-            topic_type: String::from("test_msgs/msg/Empty"),
-        }];
-        assert_eq!(
-            graph.node1.get_publishers_info_by_topic(&topic1)?,
-            expected_publishers_info
-        );
-        assert_eq!(
-            graph.node2.get_publishers_info_by_topic(&topic1)?,
-            expected_publishers_info
-        );
+        for node in [&graph.node1, &graph.node2] {
+            let publishers_info = node.get_publishers_info_by_topic(&topic1)?;
+            assert_eq!(publishers_info.len(), 1);
+
+            let info = &publishers_info[0];
+            assert_eq!(info.node_name, "graph_test_node_1");
+            assert_eq!(info.node_namespace, namespace);
+            assert_eq!(info.topic_type, "test_msgs/msg/Empty");
+            assert_eq!(info.qos_profile.reliability, QoSReliabilityPolicy::Reliable);
+            assert_eq!(info.qos_profile.durability, QoSDurabilityPolicy::Volatile);
+        }
 
         // Test get_subscription_count()
         assert_eq!(node_1_empty_publisher.get_subscription_count(), Ok(0));

--- a/rclrs/src/subscription.rs
+++ b/rclrs/src/subscription.rs
@@ -452,7 +452,7 @@ mod tests {
 
     #[test]
     fn test_subscriptions() -> Result<(), RclrsError> {
-        use crate::TopicEndpointInfo;
+        use crate::{QoSDurabilityPolicy, QoSReliabilityPolicy};
 
         let namespace = "/test_subscriptions_graph";
         let graph = construct_test_graph(namespace)?;
@@ -498,19 +498,17 @@ mod tests {
         assert!(types.contains(&"test_msgs/msg/BasicTypes".to_string()));
 
         // Test get_subscriptions_info_by_topic()
-        let expected_subscriptions_info = vec![TopicEndpointInfo {
-            node_name: String::from("graph_test_node_2"),
-            node_namespace: String::from(namespace),
-            topic_type: String::from("test_msgs/msg/Empty"),
-        }];
-        assert_eq!(
-            graph.node1.get_subscriptions_info_by_topic(&topic1)?,
-            expected_subscriptions_info
-        );
-        assert_eq!(
-            graph.node2.get_subscriptions_info_by_topic(&topic1)?,
-            expected_subscriptions_info
-        );
+        for node in [&graph.node1, &graph.node2] {
+            let subscriptions_info = node.get_subscriptions_info_by_topic(&topic1)?;
+            assert_eq!(subscriptions_info.len(), 1);
+
+            let info = &subscriptions_info[0];
+            assert_eq!(info.node_name, "graph_test_node_2");
+            assert_eq!(info.node_namespace, namespace);
+            assert_eq!(info.topic_type, "test_msgs/msg/Empty");
+            assert_eq!(info.qos_profile.reliability, QoSReliabilityPolicy::Reliable);
+            assert_eq!(info.qos_profile.durability, QoSDurabilityPolicy::Volatile);
+        }
         Ok(())
     }
 


### PR DESCRIPTION
rmw_topic_endpoint_info_t contains the endpoint's QoS profile. rclrs drops it during conversion. This PR adds it to TopicEndpointInfo as a qos_profile field, using the existing From<&rmw_qos_profile_t> impl.

rclcpp and rclpy already expose this field. It lets a subscriber match a discovered publisher's QoS

Marked feat! because the new field breaks literal construction of the struct.