### PR TITLE
fix: Same version of ament_rs for the build script and crate

### DIFF
--- a/rclrs/Cargo.toml
+++ b/rclrs/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/lib.rs"
 # and also state why each dependency is needed.
 [dependencies]
 # Needed for dynamically finding type support libraries
-ament_rs = "0.2"
+ament_rs = "0.3"
 
 # Needed to create the GoalClientStream
 async-stream = "0.3.6"


### PR DESCRIPTION
We were using 0.2 and 0.3. Just a simple mistake, updated to be on the same version